### PR TITLE
Enable core productivity modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 ### Added
 - Stripped Emacs configuration with core modules and UI defaults.
+- Core productivity modules for completion, navigation, development,
+  and Git integration. Phase 2 now enabled in `init.el`.
 ### Changed
 - Updated module comments to reflect Phase 1 is active.
 ### Removed

--- a/emacs/init.el
+++ b/emacs/init.el
@@ -162,14 +162,14 @@
 (bv-require bv-defaults)
 (bv-require bv-ui)
 
-;; Phase 2: Core Productivity (Critical) - DISABLED
-;; (with-eval-after-load 'bv-core
-;;   (run-with-idle-timer 0.1 nil
-;;     (lambda ()
-;;       (bv-require bv-completion)
-;;       (bv-require bv-navigation)
-;;       (bv-require bv-development)
-;;       (bv-require bv-git))))
+;; Phase 2: Core Productivity (Critical)
+(with-eval-after-load 'bv-core
+  (run-with-idle-timer 0.1 nil
+    (lambda ()
+      (bv-require bv-completion)
+      (bv-require bv-navigation)
+      (bv-require bv-development)
+      (bv-require bv-git))))
 
 ;; Phase 3: Language Support (High) - DISABLED
 ;; (with-eval-after-load 'bv-development

--- a/emacs/lisp/bv-completion.el
+++ b/emacs/lisp/bv-completion.el
@@ -1,0 +1,505 @@
+;;; bv-completion.el --- Modern completion system -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; State-of-the-art completion system
+;; Features: orderless fuzzy matching, marginalia annotations,
+;; embark actions, vertico UI, corfu in-buffer completion
+
+;;; Code:
+
+(require 'bv-core)
+
+;;;; Custom Variables
+
+(defgroup bv-completion nil
+  "Modern completion configuration."
+  :group 'bv)
+
+(bv-defcustom bv-completion-style 'orderless
+  "Completion style to use."
+  :type '(choice (const orderless) (const flex) (const substring))
+  :group 'bv-completion)
+
+(bv-defcustom bv-completion-cycle t
+  "Enable cycling through completion candidates."
+  :type 'boolean
+  :group 'bv-completion)
+
+(bv-defcustom bv-completion-auto t
+  "Enable automatic completion in buffers."
+  :type 'boolean
+  :group 'bv-completion)
+
+(bv-defcustom bv-completion-auto-delay 0.1
+  "Delay before automatic completion starts."
+  :type 'number
+  :group 'bv-completion)
+
+(bv-defcustom bv-completion-auto-prefix 2
+  "Minimum prefix length for automatic completion."
+  :type 'integer
+  :group 'bv-completion)
+
+(bv-defcustom bv-completion-annotations 'left
+  "Position of completion annotations."
+  :type '(choice (const left) (const right))
+  :group 'bv-completion)
+
+;;;; Core Completion Infrastructure
+
+(use-package emacs
+  :ensure nil
+  :init
+  ;; Enable recursive minibuffers
+  (setq enable-recursive-minibuffers t)
+
+  ;; Performance
+  (setq read-process-output-max (* 1024 1024))
+  (setq gc-cons-threshold (* 100 1024 1024))
+
+  ;; Better defaults
+  (setq completion-cycle-threshold 3)
+  (setq tab-always-indent 'complete)
+  (setq completions-detailed t)
+
+  ;; Ignore case
+  (setq read-file-name-completion-ignore-case t
+        read-buffer-completion-ignore-case t
+        completion-ignore-case t)
+
+  (setq completion-show-help nil)
+
+  :config
+  ;; Minibuffer improvements
+  (setq minibuffer-prompt-properties
+        '(read-only t cursor-intangible t face minibuffer-prompt))
+  (add-hook 'minibuffer-setup-hook #'cursor-intangible-mode)
+
+  ;; Better default UI
+  (setq completions-format 'one-column)
+  (setq completions-header-format nil)
+
+  ;; Keybindings
+  (define-key minibuffer-mode-map (kbd "C-n") 'minibuffer-next-completion)
+  (define-key minibuffer-mode-map (kbd "C-p") 'minibuffer-previous-completion)
+  (define-key minibuffer-mode-map (kbd "M-RET") 'minibuffer-force-complete-and-exit))
+
+;;;; Orderless - Fuzzy Matching
+
+(use-package orderless
+  :demand t
+  :config
+  ;; Matching styles
+  (setq orderless-matching-styles
+        '(orderless-prefixes
+          orderless-regexp
+          orderless-initialism
+          orderless-flex))
+
+  ;; Allow SPC in minibuffer
+  (setq orderless-component-separator 'orderless-escapable-split-on-space)
+
+  ;; Style dispatchers
+  (defun bv-orderless-literal-dispatcher (pattern _index _total)
+    "Literal style dispatcher using = suffix."
+    (cond
+     ((equal "=" pattern) '(orderless-literal . "="))
+     ((string-suffix-p "=" pattern)
+      (cons 'orderless-literal (substring pattern 0 -1)))))
+
+  (defun bv-orderless-flex-dispatcher (pattern _index _total)
+    "Flex style dispatcher using ~ suffix."
+    (cond
+     ((equal "~" pattern) '(orderless-literal . "~"))
+     ((string-suffix-p "~" pattern)
+      (cons 'orderless-flex (substring pattern 0 -1)))))
+
+  (defun bv-orderless-initialism-dispatcher (pattern _index _total)
+    "Initialism style dispatcher using , suffix."
+    (cond
+     ((equal "," pattern) '(orderless-literal . ","))
+     ((string-suffix-p "," pattern)
+      (cons 'orderless-initialism (substring pattern 0 -1)))))
+
+  (defun bv-orderless-without-literal-dispatcher (pattern _index _total)
+    "Exclude matches using ! suffix."
+    (cond
+     ((equal "!" pattern) '(orderless-literal . "!"))
+     ((string-suffix-p "!" pattern)
+      (cons 'orderless-without-literal (substring pattern 0 -1)))))
+
+  (setq orderless-style-dispatchers
+        '(bv-orderless-literal-dispatcher
+          bv-orderless-flex-dispatcher
+          bv-orderless-initialism-dispatcher
+          bv-orderless-without-literal-dispatcher))
+
+  ;; Set as default
+  (setq completion-styles '(orderless basic))
+  (setq completion-category-defaults nil)
+  (setq completion-category-overrides
+        '((file (styles . (orderless partial-completion)))
+          (buffer (styles . (orderless flex)))
+          (project-file (styles . (orderless partial-completion))))))
+
+;;;; Marginalia - Rich Annotations
+
+(use-package marginalia
+  :demand t
+  :config
+  (setq marginalia-align bv-completion-annotations)
+  (setq marginalia-max-relative-age 0)
+  (setq marginalia-align-offset 1)
+
+  ;; Custom annotators
+  (add-to-list 'marginalia-prompt-categories '\("\\<buffer\\>" . buffer))
+  (add-to-list 'marginalia-prompt-categories '\("\\<file\\>" . file))
+
+  (marginalia-mode 1))
+
+;;;; Consult - Advanced Commands
+
+(use-package consult
+  :bind (;; C-c bindings
+         ("C-c M-x" . consult-mode-command)
+         ("C-c h" . consult-history)
+         ("C-c k" . consult-kmacro)
+         ("C-c m" . consult-man)
+         ("C-c i" . consult-info)
+         ([remap Info-search] . consult-info)
+         ;; C-x bindings
+         ("C-x M-:" . consult-complex-command)
+         ("C-x b" . consult-buffer)
+         ("C-x 4 b" . consult-buffer-other-window)
+         ("C-x 5 b" . consult-buffer-other-frame)
+         ("C-x r b" . consult-bookmark)
+         ("C-x p b" . consult-project-buffer)
+         ("C-x C-r" . consult-recent-file)
+         ;; Register access
+         ("M-#" . consult-register-load)
+         ("M-'" . consult-register-store)
+         ("C-M-#" . consult-register)
+         ;; Other bindings
+         ("M-y" . consult-yank-pop)
+         ;; M-g bindings
+         ("M-g e" . consult-compile-error)
+         ("M-g f" . consult-flymake)
+         ("M-g g" . consult-goto-line)
+         ("M-g M-g" . consult-goto-line)
+         ("M-g o" . consult-outline)
+         ("M-g m" . consult-mark)
+         ("M-g k" . consult-global-mark)
+         ("M-g i" . consult-imenu)
+         ("M-g I" . consult-imenu-multi)
+         ;; M-s bindings
+         ("M-s d" . consult-find)
+         ("M-s D" . consult-locate)
+         ("M-s g" . consult-grep)
+         ("M-s G" . consult-git-grep)
+         ("M-s r" . consult-ripgrep)
+         ("M-s l" . consult-line)
+         ("M-s L" . consult-line-multi)
+         ("M-s k" . consult-keep-lines)
+         ("M-s u" . consult-focus-lines)
+         ;; Isearch integration
+         ("M-s e" . consult-isearch-history)
+         :map isearch-mode-map
+         ("M-e" . consult-isearch-history)
+         ("M-s e" . consult-isearch-history)
+         ("M-s l" . consult-line)
+         ("M-s L" . consult-line-multi)
+         :map minibuffer-local-map
+         ("M-s" . consult-history)
+         ("M-r" . consult-history))
+
+  :init
+  (setq register-preview-delay 0.5
+        register-preview-function #'consult-register-format)
+
+  (setq xref-show-xrefs-function #'consult-xref
+        xref-show-definitions-function #'consult-xref)
+
+  :config
+  ;; Preview configuration
+  (setq consult-preview-key '(:debounce 0.2 any))
+  (setq consult-narrow-key "<")
+
+  (define-key consult-narrow-map (vconcat consult-narrow-key "?") #'consult-narrow-help)
+
+  (setq completion-in-region-function #'consult-completion-in-region)
+
+  ;; Buffer sources
+  (setq consult-buffer-sources
+        '(consult--source-hidden-buffer
+          consult--source-modified-buffer
+          consult--source-buffer
+          consult--source-recent-file
+          consult--source-file-register
+          consult--source-bookmark
+          consult--source-project-buffer-hidden
+          consult--source-project-recent-file)))
+
+;;;; Embark - Contextual Actions
+
+(use-package embark
+  :bind (("C-." . embark-act)
+         ("C-;" . embark-dwim)
+         ("C-h B" . embark-bindings)
+         :map minibuffer-local-map
+         ("C-c C-o" . embark-export)
+         ("C-c C-c" . embark-collect))
+
+  :init
+  ;; Which-key integration
+  (setq embark-indicators
+        '(embark-which-key-indicator
+          embark-highlight-indicator
+          embark-isearch-highlight-indicator))
+
+  :config
+  ;; Hide mode line in Embark buffers
+  (add-to-list 'display-buffer-alist
+               '("\\`\\*Embark Collect \\(?:Live\\|Completions\\)\\*\\'"
+                 nil
+                 (window-parameters (mode-line-format . none))))
+
+  ;; Which-key indicator
+  (defun embark-which-key-indicator ()
+    "An embark indicator that displays keymaps using which-key."
+    (lambda (&optional keymap targets prefix)
+      (if (null keymap)
+          (which-key--hide-popup-ignore-command)
+        (which-key--show-keymap
+         (if (eq (plist-get (car targets) :type) 'embark-become)
+             "Become"
+           (format "Act on %s '%s'%s"
+                   (plist-get (car targets) :type)
+                   (embark--truncate-target (plist-get (car targets) :target))
+                   (if prefix (format " (prefix: %s)" prefix) "")))
+         (lookup-key keymap prefix 'accept-default)))))
+
+  (setq embark-mixed-indicator-delay 0.5)
+  (setq embark-verbose-indicator-display-action nil))
+
+(use-package embark-consult
+  :after (embark consult)
+  :demand t
+  :hook
+  (embark-collect-mode . consult-preview-at-point-mode))
+
+;;;; Vertico - Vertical Minibuffer UI
+
+(use-package vertico
+  :demand t
+  :bind (:map vertico-map
+         ("RET" . vertico-directory-enter)
+         ("DEL" . vertico-directory-delete-char)
+         ("M-DEL" . vertico-directory-delete-word)
+         ("C-w" . vertico-directory-delete-word)
+         ("C-l" . vertico-directory-up)
+         ("M-q" . vertico-quick-insert)
+         ("C-M-n" . vertico-next-group)
+         ("C-M-p" . vertico-previous-group)
+         ("TAB" . vertico-insert)
+         ("C-g" . vertico-exit))
+
+  :init
+  (setq vertico-cycle bv-completion-cycle)
+  (setq vertico-resize nil)
+  (setq vertico-count 12)
+  (setq vertico-grid-separator "       ")
+  (setq vertico-grid-lookahead 50)
+
+  :config
+  (vertico-mode 1)
+
+  (setq vertico-scroll-margin 0)
+  (setq vertico-count 15)
+  (setq vertico-resize t)
+  (setq vertico-cycle t)
+
+  ;; CRM indicator
+  (defun crm-indicator (args)
+    (cons (format "[CRM%s] %s"
+                  (replace-regexp-in-string
+                   "\\`\\[.*?]\\*\\|\\[.*?]\\*\\'" "" 
+                   crm-separator)
+                  (car args))
+          (cdr args)))
+  (advice-add #'completing-read-multiple :filter-args #'crm-indicator)
+
+  (setq minibuffer-prompt-properties
+        '(read-only t cursor-intangible t face minibuffer-prompt))
+  (add-hook 'minibuffer-setup-hook #'cursor-intangible-mode))
+
+;; Vertico extensions
+(use-package vertico-directory
+  :ensure nil
+  :after vertico
+  :bind (:map vertico-map
+         ("RET" . vertico-directory-enter)
+         ("DEL" . vertico-directory-delete-char)
+         ("M-DEL" . vertico-directory-delete-word))
+  :hook (rfn-eshadow-update-overlay . vertico-directory-tidy))
+
+(use-package vertico-repeat
+  :ensure nil
+  :after vertico
+  :bind ("M-R" . vertico-repeat)
+  :hook (minibuffer-setup . vertico-repeat-save))
+
+(use-package vertico-multiform
+  :ensure nil
+  :after vertico
+  :config
+  (vertico-multiform-mode 1)
+  (setq vertico-multiform-commands
+        '((consult-line buffer)
+          (consult-imenu buffer)
+          (consult-buffer flat)
+          (consult-project-buffer flat)
+          (consult-yank-pop buffer)))
+  (setq vertico-multiform-categories
+        '((file grid)
+          (buffer flat)
+          (consult-grep buffer))))
+
+;;;; Corfu - In-buffer Completion
+
+(use-package corfu
+  :custom
+  (corfu-cycle bv-completion-cycle)
+  (corfu-auto bv-completion-auto)
+  (corfu-auto-delay bv-completion-auto-delay)
+  (corfu-auto-prefix bv-completion-auto-prefix)
+  (corfu-separator ?\s)
+  (corfu-quit-no-match t)
+  (corfu-preview-current nil)
+  (corfu-preselect 'prompt)
+  (corfu-on-exact-match nil)
+  (corfu-scroll-margin 4)
+  (corfu-count 12)
+  (corfu-max-width 100)
+  (corfu-min-width 40)
+  :bind (:map corfu-map
+         ("TAB" . corfu-next)
+         ([tab] . corfu-next)
+         ("S-TAB" . corfu-previous)
+         ([backtab] . corfu-previous)
+         ("M-d" . corfu-doc-toggle)
+         ("M-l" . corfu-show-location)
+         ("M-q" . corfu-quick-complete)
+         ("C-q" . corfu-quick-insert))
+
+  :init
+  (global-corfu-mode)
+
+  :config
+  ;; Terminal support
+  (unless (display-graphic-p)
+    (corfu-terminal-mode +1))
+
+  ;; Minibuffer support
+  (defun corfu-enable-in-minibuffer ()
+    "Enable Corfu in the minibuffer if `completion-at-point' is bound."
+    (when (where-is-internal #'completion-at-point (list (current-local-map)))
+      (setq-local corfu-echo-delay nil
+                  corfu-popupinfo-delay nil)
+      (corfu-mode 1)))
+  (add-hook 'minibuffer-setup-hook #'corfu-enable-in-minibuffer)
+
+  ;; Move to minibuffer
+  (defun corfu-move-to-minibuffer ()
+    (interactive)
+    (let ((completion-extra-properties corfu--extra)
+          completion-cycle-threshold completion-cycling)
+      (apply #'consult-completion-in-region completion-in-region--data)))
+  (define-key corfu-map "\M-m" #'corfu-move-to-minibuffer))
+
+;; Corfu extensions
+(use-package corfu-popupinfo
+  :ensure nil
+  :after corfu
+  :hook (corfu-mode . corfu-popupinfo-mode)
+  :custom
+  (corfu-popupinfo-delay '(0.5 . 0.2))
+  (corfu-popupinfo-hide nil)
+  :config
+  (corfu-popupinfo-mode))
+
+(use-package corfu-history
+  :ensure nil
+  :after corfu
+  :config
+  (with-eval-after-load 'savehist
+    (add-to-list 'savehist-additional-variables 'corfu-history))
+  (corfu-history-mode))
+
+(use-package corfu-quick
+  :ensure nil
+  :after corfu
+  :bind (:map corfu-map
+         ("M-q" . corfu-quick-complete)
+         ("C-q" . corfu-quick-insert)))
+
+;;;; Cape - Completion At Point Extensions
+
+(use-package cape
+  :init
+  ;; Add completion functions
+  (add-to-list 'completion-at-point-functions #'cape-dabbrev)
+  (add-to-list 'completion-at-point-functions #'cape-file)
+  (add-to-list 'completion-at-point-functions #'cape-keyword)
+
+  :config
+  ;; Silence pcomplete
+  (advice-add 'pcomplete-completions-at-point :around #'cape-wrap-silent)
+  (advice-add 'pcomplete-completions-at-point :around #'cape-wrap-purify)
+
+  :bind (("C-c p p" . completion-at-point)
+         ("C-c p d" . cape-dabbrev)
+         ("C-c p h" . cape-history)
+         ("C-c p f" . cape-file)
+         ("C-c p k" . cape-keyword)
+         ("C-c p s" . cape-symbol)
+         ("C-c p a" . cape-abbrev)
+         ("C-c p i" . cape-ispell)
+         ("C-c p l" . cape-line)
+         ("C-c p w" . cape-dict)))
+
+;;;; Kind Icon - Icons in Completion
+
+(when (bv-value-exists-p 'bv-ui-enable-icons)
+  (use-package kind-icon
+    :after corfu
+    :custom
+    (kind-icon-default-face 'corfu-default)
+    (kind-icon-blend-background nil)
+    (kind-icon-blend-frac 0.08)
+    :config
+    (add-to-list 'corfu-margin-formatters #'kind-icon-margin-formatter)))
+
+;;;; Additional Optimizations
+
+(use-package emacs
+  :ensure nil
+  :config
+  ;; Fast path expansion
+  (setq file-name-shadow-properties '(invisible t intangible t))
+  (file-name-shadow-mode +1)
+
+  (setq insert-default-directory nil)
+  (setq completion-auto-help 'lazy)
+  (setq completions-detailed t))
+
+;; Performance tuning
+(setq-default cache-long-scans t)
+(setq-default bidi-paragraph-direction 'left-to-right)
+(setq bidi-inhibit-bpa t)
+
+;; Register feature
+(bv-register-feature 'bv-completion)
+(bv-set-value 'completion-system 'vertico-corfu)
+
+(provide 'bv-completion)
+;;; bv-completion.el ends here

--- a/emacs/lisp/bv-development.el
+++ b/emacs/lisp/bv-development.el
@@ -1,0 +1,415 @@
+;;; bv-development.el --- Language-agnostic development tools -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Core development tools
+;; Features: smartparens, eglot (LSP), flymake, xref, treesitter
+
+;;; Code:
+
+(require 'bv-core)
+
+;;;; Custom Variables
+
+(defgroup bv-development nil
+  "Core development configuration."
+  :group 'bv)
+
+;; Smartparens settings
+(bv-defcustom bv-dev-smartparens-strict t
+  "Enable strict smartparens mode by default."
+  :type 'boolean
+  :group 'bv-development)
+
+(bv-defcustom bv-dev-smartparens-show-pairs nil
+  "Show matching pairs (alternative to show-paren-mode)."
+  :type 'boolean
+  :group 'bv-development)
+
+(bv-defcustom bv-dev-paredit-bindings nil
+  "Use paredit-style bindings instead of smartparens defaults."
+  :type 'boolean
+  :group 'bv-development)
+
+;; Eglot settings
+(bv-defcustom bv-dev-format-on-save t
+  "Format buffer on save using LSP."
+  :type 'boolean
+  :group 'bv-development)
+
+(bv-defcustom bv-dev-eldoc-documentation-strategy 'eldoc-documentation-compose
+  "How to display eldoc documentation."
+  :type 'symbol
+  :group 'bv-development)
+
+;; Flymake settings
+(bv-defcustom bv-dev-flymake-no-changes-timeout 0.5
+  "Time to wait after last change before running flymake."
+  :type 'number
+  :group 'bv-development)
+
+;; Re-builder settings
+(bv-defcustom bv-dev-re-builder-syntax 'rx
+  "Syntax to use in re-builder."
+  :type '(choice (const :tag "Read syntax" read)
+                 (const :tag "String syntax" string)
+                 (const :tag "Rx syntax" rx))
+  :group 'bv-development)
+
+;;;; Treesitter Support (Emacs 30)
+
+(when (fboundp 'treesit-available-p)
+  (use-package treesit
+    :ensure nil
+    :config
+    ;; Grammar installation directory
+    (setq treesit-extra-load-path
+          (list (expand-file-name "tree-sitter" bv-var-dir)))
+
+    ;; Auto-install grammars
+    (defun bv-dev-ensure-grammar (lang url &optional branch)
+      "Ensure tree-sitter grammar for LANG is installed from URL."
+      (unless (treesit-language-available-p lang)
+        (treesit-install-language-grammar lang url nil branch)))
+
+    ;; Remap modes to use tree-sitter
+    (setq major-mode-remap-alist
+          '((python-mode . python-ts-mode)
+            (javascript-mode . js-ts-mode)
+            (typescript-mode . typescript-ts-mode)
+            (json-mode . json-ts-mode)
+            (css-mode . css-ts-mode)
+            (yaml-mode . yaml-ts-mode)
+            (toml-mode . toml-ts-mode)
+            (rust-mode . rust-ts-mode)
+            (c-mode . c-ts-mode)
+            (c++-mode . c++-ts-mode)
+            (java-mode . java-ts-mode)
+            (go-mode . go-ts-mode)))
+
+    ;; Font-lock levels
+    (setq treesit-font-lock-level 4)))
+
+;;;; Smartparens - Structural Editing
+
+(use-package smartparens
+  :hook ((prog-mode text-mode) . smartparens-mode)
+  :bind (:map smartparens-mode-map
+         ;; Navigation
+         ("C-M-f" . sp-forward-sexp)
+         ("C-M-b" . sp-backward-sexp)
+         ("C-M-d" . sp-down-sexp)
+         ("C-M-a" . sp-backward-down-sexp)
+         ("C-S-a" . sp-beginning-of-sexp)
+         ("C-S-d" . sp-end-of-sexp)
+         ("C-M-e" . sp-up-sexp)
+         ("C-M-u" . sp-backward-up-sexp)
+         ("C-M-t" . sp-transpose-sexp)
+         ;; Selection
+         ("C-M-k" . sp-kill-sexp)
+         ("C-M-w" . sp-copy-sexp)
+         ("M-<delete>" . sp-unwrap-sexp)
+         ("M-<backspace>" . sp-backward-unwrap-sexp)
+         ;; Manipulation
+         ("C-<right>" . sp-forward-slurp-sexp)
+         ("C-<left>" . sp-forward-barf-sexp)
+         ("C-M-<left>" . sp-backward-slurp-sexp)
+         ("C-M-<right>" . sp-backward-barf-sexp)
+         ("M-D" . sp-splice-sexp)
+         ("C-M-<delete>" . sp-splice-sexp-killing-forward)
+         ("C-M-<backspace>" . sp-splice-sexp-killing-backward)
+         ("C-S-<backspace>" . sp-splice-sexp-killing-around)
+         ;; Wrapping
+         ("C-(" . sp-wrap-round)
+         ("C-[" . sp-wrap-square)
+         ("C-{" . sp-wrap-curly))
+  :init
+  ;; Strict mode setup
+  (when bv-dev-smartparens-strict
+    (dolist (hook '(prog-mode-hook text-mode-hook))
+      (add-hook hook #'smartparens-strict-mode)))
+
+  :config
+  ;; Load default configuration
+  (require 'smartparens-config)
+
+  ;; Use paredit bindings if requested
+  (when bv-dev-paredit-bindings
+    (sp-use-paredit-bindings))
+
+  ;; Remove conflicting binding
+  (define-key smartparens-mode-map (kbd "M-s") nil)
+
+  ;; Show smartparens mode
+  (if bv-dev-smartparens-show-pairs
+      (progn
+        (show-smartparens-global-mode 1)
+        (show-paren-mode -1))
+    (show-paren-mode 1))
+
+  ;; Better pair highlighting
+  (setq sp-show-pair-delay 0.1
+        sp-show-pair-from-inside t
+        sp-highlight-pair-overlay nil
+        sp-highlight-wrap-overlay nil
+        sp-highlight-wrap-tag-overlay nil)
+
+  ;; Don't insert pairs when in string/comment
+  (setq sp-autoskip-closing-pair 'always
+        sp-autoskip-opening-pair t
+        sp-navigate-skip-match t)
+
+  ;; Additional pairs
+  (sp-local-pair 'org-mode "=" "=")
+  (sp-local-pair 'org-mode "*" "*")
+  (sp-local-pair 'org-mode "/" "/")
+  (sp-local-pair 'org-mode "_" "_")
+  (sp-local-pair 'org-mode "+" "+")
+  (sp-local-pair 'markdown-mode "`" "`"))
+
+;;;; Eglot - Built-in LSP Client
+
+(use-package eglot
+  :ensure nil
+  :commands (eglot eglot-ensure)
+  :bind (:map eglot-mode-map
+         ("C-c l r" . eglot-rename)
+         ("C-c l a" . eglot-code-actions)
+         ("C-c l o" . eglot-code-action-organize-imports)
+         ("C-c l f" . eglot-format)
+         ("C-c l F" . eglot-format-buffer)
+         ("C-c l d" . eldoc)
+         ("C-c l s" . consult-eglot-symbols))
+  :init
+  ;; Performance tuning
+  (setq read-process-output-max (* 1024 1024))
+  (setq gc-cons-threshold 100000000)
+
+  :config
+  ;; Configure servers
+  (setq eglot-server-programs
+        '((python-mode python-ts-mode . ("pylsp"))
+          (rust-mode rust-ts-mode . ("rust-analyzer"))
+          ((js-mode js-ts-mode typescript-mode typescript-ts-mode) . ("typescript-language-server" "--stdio"))
+          ((c-mode c-ts-mode c++-mode c++-ts-mode) . ("clangd"))
+          (go-mode go-ts-mode . ("gopls"))
+          (java-mode java-ts-mode . ("jdtls"))
+          ((ruby-mode ruby-ts-mode) . ("solargraph" "stdio"))
+          (haskell-mode . ("haskell-language-server-wrapper" "--lsp"))
+          (nix-mode . ("nil"))))
+
+  ;; Performance
+  (setq eglot-events-buffer-size 0)
+
+  ;; Stay out of the way
+  (setq eglot-autoshutdown t
+        eglot-confirm-server-initiated-edits nil
+        eglot-extend-to-xref t)
+
+  ;; Eldoc
+  (setq eldoc-echo-area-use-multiline-p nil
+        eldoc-echo-area-display-truncation-message nil
+        eldoc-documentation-strategy bv-dev-eldoc-documentation-strategy)
+
+  ;; Format on save
+  (when bv-dev-format-on-save
+    (defun bv-dev-eglot-format-on-save ()
+      "Format buffer on save if eglot is active."
+      (when (and (bound-and-true-p eglot--managed-mode)
+                 (eglot--server-capable :documentFormattingProvider))
+        (eglot-format-buffer)))
+
+    (add-hook 'before-save-hook #'bv-dev-eglot-format-on-save))
+
+  ;; Clear imenu cache
+  (defun bv-dev-eglot-clear-imenu-cache ()
+    "Clear imenu cache when eglot is active."
+    (when (bound-and-true-p eglot--managed-mode)
+      (setq imenu--index-alist nil)))
+
+  (add-hook 'eglot-managed-mode-hook
+            (lambda ()
+              (add-hook 'after-save-hook #'bv-dev-eglot-clear-imenu-cache nil t)))
+
+  ;; Completion integration
+  (setq completion-category-overrides
+        '((eglot (styles orderless))
+          (eglot-capf (styles orderless)))))
+
+;; Consult integration
+(bv-when-feature bv-completion
+  (use-package consult-eglot
+    :after (eglot consult)
+    :bind (:map eglot-mode-map
+           ("M-g s" . consult-eglot-symbols))))
+
+;;;; Flymake - Syntax Checking
+
+(use-package flymake
+  :ensure nil
+  :hook ((prog-mode text-mode) . flymake-mode)
+  :bind (:map flymake-mode-map
+         ("M-n" . flymake-goto-next-error)
+         ("M-p" . flymake-goto-prev-error)
+         ("C-c ! l" . flymake-show-buffer-diagnostics)
+         ("C-c ! L" . flymake-show-project-diagnostics)
+         ("C-c ! n" . flymake-goto-next-error)
+         ("C-c ! p" . flymake-goto-prev-error))
+  :config
+  (setq flymake-no-changes-timeout bv-dev-flymake-no-changes-timeout
+        flymake-start-on-save-buffer t
+        flymake-proc-compilation-prevents-syntax-check t
+        flymake-wraparound t)
+
+  ;; Better fringe indicators
+  (define-fringe-bitmap 'bv-flymake-fringe-indicator
+    (vector #b00000000
+            #b00000000
+            #b00000000
+            #b00000000
+            #b00000000
+            #b00111000
+            #b01111100
+            #b01111100
+            #b01111100
+            #b00111000
+            #b00000000
+            #b00000000
+            #b00000000
+            #b00000000
+            #b00000000))
+
+  (setq flymake-error-bitmap '(bv-flymake-fringe-indicator compilation-error)
+        flymake-warning-bitmap '(bv-flymake-fringe-indicator compilation-warning)
+        flymake-note-bitmap '(bv-flymake-fringe-indicator compilation-info))
+
+  ;; Don't popup automatically
+  (remove-hook 'flymake-diagnostic-functions #'flymake-proc-legacy-flymake))
+
+;; Flymake indicators
+(use-package flymake-indicator
+  :after flymake
+  :hook (flymake-mode . flymake-indicator-mode))
+
+;;;; Xref - Cross References
+
+(use-package xref
+  :ensure nil
+  :bind (("M-." . xref-find-definitions)
+         ("M-," . xref-go-back)
+         ("M-?" . xref-find-references)
+         ("C-M-." . xref-find-apropos))
+  :config
+  ;; Better behavior
+  (setq xref-auto-jump-to-first-definition 'move
+        xref-auto-jump-to-first-xref 'move
+        xref-search-program 'ripgrep)
+
+  ;; Don't prompt for identifier at point
+  (setq xref-prompt-for-identifier
+        '(not xref-find-definitions
+              xref-find-definitions-other-window
+              xref-find-definitions-other-frame))
+
+  ;; Use completion system
+  (bv-when-feature bv-completion
+    (setq xref-show-xrefs-function #'consult-xref
+          xref-show-definitions-function #'consult-xref)))
+
+;;;; Re-builder - Regular Expression Development
+
+(use-package re-builder
+  :ensure nil
+  :bind (("C-c r" . re-builder))
+  :config
+  (setq reb-re-syntax bv-dev-re-builder-syntax)
+  (setq reb-auto-match-limit 200)
+  (setq reb-blink-delay 0.5))
+
+;;;; Compilation
+
+(use-package compile
+  :ensure nil
+  :bind (("C-c c" . compile)
+         ("C-c C" . recompile))
+  :config
+  ;; Auto-scroll compilation output
+  (setq compilation-scroll-output 'first-error)
+
+  ;; Kill compilation process before starting new one
+  (setq compilation-always-kill t)
+
+  ;; Don't ask about saving buffers
+  (setq compilation-ask-about-save nil)
+
+  ;; Colorize compilation buffer
+  (add-hook 'compilation-filter-hook #'ansi-color-compilation-filter))
+
+;;;; Electric Pairs
+
+(use-package elec-pair
+  :ensure nil
+  :hook (prog-mode . electric-pair-local-mode)
+  :config
+  (setq electric-pair-preserve-balance t
+        electric-pair-delete-adjacent-pairs t
+        electric-pair-skip-self 'electric-pair-default-skip-self))
+
+;;;; Code Folding
+
+(use-package hideshow
+  :ensure nil
+  :hook (prog-mode . hs-minor-mode)
+  :bind (:map hs-minor-mode-map
+         ("C-c @" . hs-toggle-hiding)
+         ("C-c h" . hs-hide-all)
+         ("C-c s" . hs-show-all)))
+
+;;;; Additional Development Utilities
+
+;; Highlight TODO keywords
+(use-package hl-todo
+  :hook (prog-mode . hl-todo-mode)
+  :config
+  (setq hl-todo-keyword-faces
+        '(("TODO" . "#FF0000")
+          ("FIXME" . "#FF0000")
+          ("HACK" . "#7C7C75")
+          ("REVIEW" . "#FF6C00")
+          ("NOTE" . "#0000FF")
+          ("DEPRECATED" . "#7C7C75"))))
+
+;; Rainbow delimiters
+(use-package rainbow-delimiters
+  :hook ((prog-mode conf-mode) . rainbow-delimiters-mode))
+
+;; Indentation guides
+(use-package highlight-indent-guides
+  :hook (prog-mode . highlight-indent-guides-mode)
+  :config
+  (setq highlight-indent-guides-method 'character
+        highlight-indent-guides-character ?\│
+        highlight-indent-guides-responsive 'top
+        highlight-indent-guides-delay 0.1))
+
+;;;; Eldoc Configuration
+
+(use-package eldoc
+  :ensure nil
+  :config
+  (setq eldoc-idle-delay 0.3
+        eldoc-echo-area-display-truncation-message nil)
+
+  ;; Use buffer for long documentation
+  (setq eldoc-echo-area-prefer-doc-buffer t))
+
+;;;; Feature Registration
+
+(bv-register-feature 'bv-development)
+
+;; Register capabilities
+(bv-set-value 'lsp-client 'eglot)
+(bv-set-value 'structural-editing 'smartparens)
+(bv-set-value 'syntax-checker 'flymake)
+
+(provide 'bv-development)
+;;; bv-development.el ends here

--- a/emacs/lisp/bv-git.el
+++ b/emacs/lisp/bv-git.el
@@ -1,0 +1,207 @@
+;;; bv-git.el --- Version control with Git -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Comprehensive Git support with Magit, git-gutter, and related tools.
+
+;;; Code:
+
+;;;; Dependencies
+(require 'bv-core)
+
+;;;; Custom Variables
+(defgroup bv-git nil
+  "Git and version control configuration."
+  :group 'bv)
+
+(defcustom bv-git-project-directory nil
+  "Directory where project repositories are stored."
+  :type '(choice (const nil) directory)
+  :group 'bv-git)
+
+(defcustom bv-git-enable-todos t
+  "Enable magit-todos integration."
+  :type 'boolean
+  :group 'bv-git)
+
+(defcustom bv-git-enable-gutter t
+  "Enable git-gutter mode."
+  :type 'boolean
+  :group 'bv-git)
+
+(defcustom bv-git-gutter-update-on-focus t
+  "Update git-gutter when window gains focus."
+  :type 'boolean
+  :group 'bv-git)
+
+;;;; Git Link
+(use-package git-link
+  :defer t
+  :config
+  ;; Add advice to support specific remote for commit links
+  (advice-add
+   'git-link :around
+   (lambda (f remote start end)
+     "`git-link--last-commit' advice with specific remote."
+     (let ((git-link--last-commit-from-remote
+            (lambda ()
+              (car (git-link--exec
+                    "--no-pager" "log" "-n1" "--pretty=format:%h"
+                    (concat remote "/" (git-link--branch)))))))
+       (advice-add 'git-link--last-commit :override
+                   git-link--last-commit-from-remote)
+       (funcall f remote start end)
+       (advice-remove 'git-link--last-commit
+                      git-link--last-commit-from-remote))))
+  
+  ;; Custom command that always includes commit hash
+  (defun bv-git-link ()
+    "Same as `git-link', but with commit hash specified."
+    (interactive)
+    (let ((git-link-use-commit t))
+      (if (git-link--relative-filename)
+          (call-interactively 'git-link)
+        (call-interactively 'git-link-commit)))))
+
+;;;; Git Timemachine
+(use-package git-timemachine
+  :defer t)
+
+;;;; Git Gutter
+(use-package git-gutter
+  :defer t
+  :diminish git-gutter-mode
+  :init
+  (when bv-git-enable-gutter
+    (add-hook 'prog-mode-hook 'git-gutter-mode)
+    (add-hook 'text-mode-hook 'git-gutter-mode))
+  :custom
+  (git-gutter:lighter " GG")
+  :config
+  ;; Update hooks
+  (when bv-git-gutter-update-on-focus
+    (add-to-list 'git-gutter:update-hooks 'focus-in-hook))
+  (add-to-list 'git-gutter:update-commands 'other-window)
+  
+  ;; Update after magit operations
+  (with-eval-after-load 'magit
+    (add-hook 'magit-post-stage-hook 'git-gutter:update-all-windows)
+    (add-hook 'magit-post-unstage-hook 'git-gutter:update-all-windows))
+  
+  ;; Use y-or-n-p for revert-hunk
+  (defun bv-git-gutter-y-or-n-p (orig-fun &rest r)
+    "Use y-or-n-p instead of yes-or-no-p."
+    (cl-letf (((symbol-function 'yes-or-no-p) 'y-or-n-p))
+      (apply orig-fun r)))
+  
+  (advice-add 'git-gutter:revert-hunk :around #'bv-git-gutter-y-or-n-p)
+  
+  ;; Auto-confirm staging (no prompts)
+  (defun bv-git-gutter-auto-stage (orig-fun &rest args)
+    "Auto-confirm git-gutter:stage-hunk."
+    (cl-letf (((symbol-function 'yes-or-no-p) (lambda (&rest _) t)))
+      (apply orig-fun args)))
+  
+  (advice-add 'git-gutter:stage-hunk :around #'bv-git-gutter-auto-stage))
+
+;;;; Git Gutter Fringe
+(use-package git-gutter-fringe
+  :after git-gutter
+  :config
+  ;; Custom fringe bitmaps
+  (dolist (fringe '(git-gutter-fr:added
+                    git-gutter-fr:modified))
+    (define-fringe-bitmap fringe (vector 8) nil nil '(top repeat)))
+  (define-fringe-bitmap 'git-gutter-fr:deleted
+    (vector 8 12 14 15)
+    nil nil 'bottom))
+
+;;;; Magit
+(use-package magit
+  :bind (("C-x g" . magit-status)
+         ("C-x M-g" . magit-dispatch)
+         ("C-c g" . magit-file-dispatch))
+  :custom
+  ;; Performance optimizations
+  (magit-refresh-status-buffer nil)
+  (magit-diff-refine-hunk t)
+  (magit-save-repository-buffers 'dontask)
+  ;; Show local branches after stashes
+  (magit-status-sections-hook
+   '(magit-insert-status-headers
+     magit-insert-merge-log
+     magit-insert-rebase-sequence
+     magit-insert-am-sequence
+     magit-insert-sequencer-sequence
+     magit-insert-bisect-output
+     magit-insert-bisect-rest
+     magit-insert-bisect-log
+     magit-insert-untracked-files
+     magit-insert-unstaged-changes
+     magit-insert-staged-changes
+     magit-insert-stashes
+     magit-insert-local-branches
+     magit-insert-unpushed-to-pushremote
+     magit-insert-unpushed-to-upstream-or-recent
+     magit-insert-unpulled-from-pushremote
+     magit-insert-unpulled-from-upstream))
+  :config
+  ;; Clone directory logic
+  (defun bv-get-local-repo-path-from-url (url)
+    "Get directory from repository URL."
+    (require 'git-link)
+    (let* ((path (cadr (git-link--parse-remote url)))
+           (dir (file-name-directory (directory-file-name path))))
+      (if bv-git-project-directory
+          (expand-file-name dir bv-git-project-directory)
+        dir)))
+  
+  (setq magit-clone-default-directory 'bv-get-local-repo-path-from-url)
+  
+  ;; Performance for large repos
+  (setq magit-revision-insert-related-refs nil))
+
+;;;; Magit Todos
+(use-package magit-todos
+  :after magit
+  :when bv-git-enable-todos
+  :config
+  (magit-todos-mode 1))
+
+;;;; Transient History
+(use-package transient
+  :ensure nil
+  :custom
+  (transient-history-file
+   (expand-file-name "transient/history.el" bv-cache-dir)))
+
+;;;; Keybindings
+(with-eval-after-load 'bv-core
+  ;; Toggle git-gutter
+  (define-key bv-toggle-map "g" 'git-gutter-mode)
+  (define-key bv-toggle-map "G" 'global-git-gutter-mode))
+
+;;;; Feature Definition
+(defun bv-git-load ()
+  "Load Git configuration."
+  (add-to-list 'bv-enabled-features 'git)
+  
+  ;; Git aliases for eshell
+  (with-eval-after-load 'em-alias
+    (eshell/alias "gd" "magit-diff-unstaged")
+    (eshell/alias "gs" "magit-status")
+    (eshell/alias "gl" "magit-log-current")
+    (eshell/alias "gp" "magit-push-current")
+    (eshell/alias "gf" "magit-fetch")))
+
+;;;; Integration with Other Features
+(bv-with-feature project
+  (with-eval-after-load 'project
+    ;; Add magit-project-status to project commands
+    (define-key project-prefix-map "m" 'magit-project-status)))
+
+(bv-with-feature embark
+  (with-eval-after-load 'embark
+    (define-key embark-file-map "g" 'magit-file-dispatch)))
+
+(provide 'bv-git)
+;;; bv-git.el ends here

--- a/emacs/lisp/bv-navigation.el
+++ b/emacs/lisp/bv-navigation.el
@@ -1,0 +1,398 @@
+;;; bv-navigation.el --- Navigation and window management -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Navigation and window management features
+;; Project.el, dired, ace-window, focus mode, perspectives
+
+;;; Code:
+
+(require 'bv-core)
+
+;;;; Custom Variables
+
+(defgroup bv-navigation nil
+  "Navigation and window management configuration."
+  :group 'bv)
+
+;; Project settings
+(bv-defcustom bv-project-root-files
+  '(".project" ".projectile" ".dir-locals.el" ".envrc" "Makefile" "package.json")
+  "Files that indicate a project root."
+  :type '(repeat string)
+  :group 'bv-navigation)
+
+(bv-defcustom bv-project-switch-commands 'project-dired
+  "Default action when switching projects."
+  :type '(choice (const :tag "Dired" project-dired)
+                 (const :tag "Find file" project-find-file)
+                 (const :tag "Magit" magit-project-status)
+                 (const :tag "Eshell" project-eshell))
+  :group 'bv-navigation)
+
+;; Dired settings
+(bv-defcustom bv-dired-listing-switches "-alh --group-directories-first"
+  "Switches passed to ls for dired listings."
+  :type 'string
+  :group 'bv-navigation)
+
+(bv-defcustom bv-dired-kill-when-opening-new-buffer nil
+  "Kill dired buffer when opening a new dired buffer."
+  :type 'boolean
+  :group 'bv-navigation)
+
+;; Window management
+(bv-defcustom bv-ace-window-keys '(?a ?s ?d ?f ?g ?h ?j ?k ?l)
+  "Keys used for ace-window selection."
+  :type '(repeat character)
+  :group 'bv-navigation)
+
+;; Focus mode settings
+(bv-defcustom bv-focus-mode-width 85
+  "Width of text body in focus mode."
+  :type 'integer
+  :group 'bv-navigation)
+
+;; Perspective settings
+(bv-defcustom bv-enable-perspectives nil
+  "Enable perspective-based workspace management."
+  :type 'boolean
+  :group 'bv-navigation)
+
+;;;; Project.el Configuration
+
+(use-package project
+  :ensure nil
+  :bind (("s-p" . project-prefix-map)
+         :map project-prefix-map
+         ("P" . bv-project-switch-project-in-perspective)
+         ("F" . consult-find)
+         ("R" . consult-ripgrep)
+         ("b" . consult-project-buffer)
+         ("d" . project-dired)
+         ("c" . project-compile)
+         ("t" . bv-project-todo))
+  :init
+  ;; Custom project root detection
+  (defun bv-project-try-local (dir)
+    "Find project root in DIR by looking for specific files."
+    (let ((root (cl-find-if
+                 (lambda (file)
+                   (locate-dominating-file dir file))
+                 bv-project-root-files)))
+      (when root
+        (cons 'transient (locate-dominating-file dir root)))))
+
+  :config
+  ;; Add custom project finder
+  (add-hook 'project-find-functions #'bv-project-try-local 90)
+
+  ;; Better project switching
+  (setq project-switch-commands bv-project-switch-commands)
+  (setq project-switch-use-entire-map t)
+
+  ;; XDG-compliant project list
+  (setq project-list-file
+        (expand-file-name "emacs/projects"
+                          (or (getenv "XDG_CACHE_HOME") "~/.cache")))
+
+  ;; Compilation buffer naming
+  (defun bv-project-compilation-buffer-name (mode)
+    "Generate a project-specific compilation buffer name."
+    (if (project-current)
+        (project-prefixed-buffer-name mode)
+      (compilation--default-buffer-name mode)))
+
+  (setq project-compilation-buffer-name-function
+        #'bv-project-compilation-buffer-name)
+
+  ;; Project-specific compile command
+  (defun bv-project-compile (&optional comint)
+    "Run project compilation with optional COMINT mode."
+    (interactive "P")
+    (let ((default-directory (project-root (project-current t)))
+          (compilation-buffer-name-function
+           (or project-compilation-buffer-name-function
+               compilation-buffer-name-function)))
+      (compile (compilation-read-command compile-command) comint)))
+
+  (advice-add 'project-compile :override #'bv-project-compile)
+
+  ;; Project TODO finder
+  (defun bv-project-todo ()
+    "Find TODO items in current project."
+    (interactive)
+    (consult-ripgrep (project-root (project-current t))
+                     "\b(TODO|FIXME|HACK|NOTE)\b"))
+
+  ;; Integration with completion system
+  (with-eval-after-load 'consult
+    (setq consult-project-function #'project-current)))
+
+;;;; Dired Configuration
+
+(use-package dired
+  :ensure nil
+  :commands (dired dired-jump)
+  :bind (("s-d" . dired-jump)
+         :map dired-mode-map
+         ("q" . kill-current-buffer)
+         ("V" . bv-dired-open-externally)
+         ("C-c C-r" . dired-rsync)
+         ("M-n" . dired-next-subdir)
+         ("M-p" . dired-prev-subdir)
+         ("M-u" . dired-up-directory))
+  :config
+  ;; Better defaults
+  (setq dired-dwim-target t
+        dired-listing-switches bv-dired-listing-switches
+        dired-recursive-copies 'always
+        dired-recursive-deletes 'always
+        dired-kill-when-opening-new-dired-buffer bv-dired-kill-when-opening-new-buffer
+        delete-by-moving-to-trash nil
+        dired-clean-confirm-killing-deleted-buffers nil)
+
+  ;; Auto-refresh
+  (setq dired-auto-revert-buffer t)
+
+  ;; Hide details by default
+  (add-hook 'dired-mode-hook #'dired-hide-details-mode)
+
+  ;; Line truncation
+  (add-hook 'dired-mode-hook #'toggle-truncate-lines)
+
+  ;; Open files externally
+  (defun bv-dired-open-externally ()
+    "Open marked files in external application."
+    (interactive)
+    (let ((files (dired-get-marked-files)))
+      (dolist (file files)
+        (call-process "xdg-open" nil 0 nil file))))
+
+  ;; Use ls-lisp on non-Linux platforms
+  (when (or (eq system-type 'windows-nt)
+            (eq system-type 'darwin))
+    (setq ls-lisp-use-insert-directory-program nil)
+    (require 'ls-lisp)))
+
+;; Dired enhancements
+(use-package dired-x
+  :ensure nil
+  :after dired
+  :config
+  (setq dired-x-hands-off-my-keys t)
+  (setq dired-clean-up-buffers-too t))
+
+;; Icons in dired (if enabled)
+(bv-when-feature bv-ui
+  (when (bv-get-value 'ui-enable-icons)
+    (use-package all-the-icons-dired
+      :hook (dired-mode . all-the-icons-dired-mode)
+      :config
+      (setq all-the-icons-dired-monochrome nil))))
+
+;; Dired rsync
+(use-package dired-rsync
+  :after dired
+  :config
+  (setq dired-rsync-options
+        "--archive --verbose --compress --human-readable --progress --delete"))
+
+;;;; Ace Window - Quick Window Switching
+
+(use-package ace-window
+  :bind (("M-o" . ace-window)
+         ("s-o" . ace-window))
+  :config
+  (setq aw-keys bv-ace-window-keys
+        aw-scope 'frame
+        aw-background nil
+        aw-display-mode-overlay t
+        aw-ignore-current nil)
+
+  ;; Custom actions
+  (setq aw-dispatch-alist
+        '((?x aw-delete-window "Delete Window")
+          (?m aw-swap-window "Swap Windows")
+          (?M aw-move-window "Move Window")
+          (?c aw-copy-window "Copy Window")
+          (?j aw-switch-buffer-in-window "Select Buffer")
+          (?n aw-flip-window)
+          (?u aw-switch-buffer-other-window "Switch Buffer Other Window")
+          (?e aw-execute-command-other-window "Execute Command")
+          (?F aw-split-window-fair "Split Fair Window")
+          (?v aw-split-window-vert "Split Vert Window")
+          (?b aw-split-window-horz "Split Horz Window")
+          (?o delete-other-windows "Delete Other Windows")
+          (?? aw-show-dispatch-help)))
+
+  ;; Face customization
+  (custom-set-faces
+   '(aw-leading-char-face
+     ((t (:inherit ace-jump-face-foreground :height 2.0))))))
+
+;;;; Focus Mode (Monocle)
+
+(use-package olivetti
+  :commands (olivetti-mode bv-toggle-focus-mode)
+  :bind ("s-f" . bv-toggle-focus-mode)
+  :config
+  (setq olivetti-body-width bv-focus-mode-width
+        olivetti-margin-width 0
+        olivetti-minimum-body-width 40
+        olivetti-recall-visual-line-mode-entry-state t))
+
+;; Hide mode line
+(use-package hide-mode-line
+  :commands (hide-mode-line-mode))
+
+;; Focus mode toggle
+(defvar-local bv--focus-mode-previous-config nil
+  "Store previous window configuration for focus mode.")
+
+(defun bv-toggle-focus-mode (&optional arg)
+  "Toggle focus mode for distraction-free editing."
+  (interactive "P")
+  (if arg
+      ;; Global toggle
+      (progn
+        (if (and (bound-and-true-p global-olivetti-mode)
+                 (bound-and-true-p global-hide-mode-line-mode))
+            (progn
+              (global-hide-mode-line-mode -1)
+              (global-olivetti-mode -1))
+          (progn
+            (global-hide-mode-line-mode 1)
+            (global-olivetti-mode 1))))
+    ;; Local toggle with window configuration
+    (if (one-window-p)
+        (when bv--focus-mode-previous-config
+          (set-window-configuration bv--focus-mode-previous-config)
+          (setq bv--focus-mode-previous-config nil))
+      (setq bv--focus-mode-previous-config (current-window-configuration))
+      (delete-other-windows))))
+
+;; Define focus mode minor mode
+(define-minor-mode bv-focus-mode
+  "Minor mode for focused editing."
+  :init-value nil
+  :lighter " Focus"
+  (if bv-focus-mode
+      (progn
+        (olivetti-mode 1)
+        (hide-mode-line-mode 1))
+    (olivetti-mode -1)
+    (hide-mode-line-mode -1)))
+
+;;;; Window Management Utilities
+
+;; Better window splitting
+(defun bv-split-window-below-and-switch ()
+  "Split window below and switch to it."
+  (interactive)
+  (split-window-below)
+  (other-window 1))
+
+(defun bv-split-window-right-and-switch ()
+  "Split window right and switch to it."
+  (interactive)
+  (split-window-right)
+  (other-window 1))
+
+(global-set-key (kbd "C-x 2") #'bv-split-window-below-and-switch)
+(global-set-key (kbd "C-x 3") #'bv-split-window-right-and-switch)
+
+;; Window resizing
+(defun bv-window-resize (key)
+  "Interactively resize windows with KEY."
+  (interactive "cPress {/} to shrink/enlarge horizontally, [/] vertically")
+  (let ((horizontal (memq key '(?{ ?})))
+        (shrink (memq key '(?{ ?\[))))
+    (enlarge-window (if shrink -3 3) horizontal)))
+
+(global-set-key (kbd "C-x }") #'bv-window-resize)
+(global-set-key (kbd "C-x {") #'bv-window-resize)
+
+;;;; Perspective (Optional Workspace Management)
+
+(when bv-enable-perspectives
+  (use-package perspective
+    :bind (("C-x x s" . persp-switch)
+           ("C-x x k" . persp-kill)
+           ("C-x x r" . persp-rename)
+           ("C-x x a" . persp-add-buffer)
+           ("C-x x A" . persp-set-buffer)
+           ("C-x x i" . persp-import)
+           ("C-x x n" . persp-next)
+           ("C-x x p" . persp-prev)
+           ("C-x x c" . persp-kill-buffer))
+    :custom
+    (persp-mode-prefix-key (kbd "C-x x"))
+    :init
+    (setq persp-state-default-file
+          (expand-file-name "perspective-state" bv-var-dir))
+    :config
+    (setq persp-show-modestring t
+          persp-modestring-dividers '("[" "]" "|"))
+
+    ;; Integration with project.el
+    (defun bv-project-switch-project-in-perspective (dir)
+      "Switch to project DIR in its own perspective."
+      (interactive (list (project-prompt-project-dir)))
+      (let ((name (file-name-nondirectory
+                   (directory-file-name
+                    (file-name-directory dir)))))
+        (persp-switch name)
+        (project-switch-project dir)))
+
+    (persp-mode)))
+
+;;;; Better Buffer Management
+
+(defun bv-kill-current-buffer ()
+  "Kill current buffer without confirmation."
+  (interactive)
+  (kill-buffer (current-buffer)))
+
+(defun bv-kill-buffer-and-window ()
+  "Kill current buffer and delete window."
+  (interactive)
+  (kill-current-buffer)
+  (when (not (one-window-p))
+    (delete-window)))
+
+;; Key bindings
+(global-set-key (kbd "s-w") #'bv-kill-current-buffer)
+(global-set-key (kbd "s-W") #'bv-kill-buffer-and-window)
+
+;;;; Integration with Completion System
+
+;; Consult buffer source for project buffers
+(with-eval-after-load 'consult
+  (defvar bv-consult-source-project-buffer
+    `(:name "Project Buffer"
+            :narrow ?p
+            :category buffer
+            :face consult-buffer
+            :history buffer-name-history
+            :state ,#'consult--buffer-state
+            :default t
+            :items
+            ,(lambda ()
+               (when-let (project (project-current))
+                 (mapcar #'buffer-name
+                         (seq-filter
+                          (lambda (b)
+                            (when-let (file (buffer-file-name b))
+                              (file-in-directory-p file (project-root project))))
+                          (buffer-list))))))
+    "Project buffer candidate source for `consult-buffer'.")
+
+  ;; Add to consult sources
+  (add-to-list 'consult-buffer-sources 'bv-consult-source-project-buffer 'append))
+
+;;;; Feature Registration
+
+(bv-register-feature 'bv-navigation)
+
+(provide 'bv-navigation)
+;;; bv-navigation.el ends here


### PR DESCRIPTION
## Summary
- add modern completion stack
- add navigation utilities and project tweaks
- add development tooling including smartparens, eglot and flymake
- add Git integration via Magit and git-gutter
- activate phase 2 module loading in `init.el`
- document new modules in the changelog

## Testing
- `emacs --batch -Q --eval (batch-byte-compile) ...` *(fails: emacs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684a6c605490832bb9f58f36b5fe78d2