### PR TITLE
Enable Emacs language modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Stripped Emacs configuration with core modules and UI defaults.
 - Core productivity modules for completion, navigation, development,
   and Git integration. Phase 2 now enabled in `init.el`.
+- Language support modules for Python, Rust, Lisp and C/C++.
 ### Changed
-- Updated module comments to reflect Phase 1 is active.
+- Phase 3 modules are now enabled in `init.el`.
+- Updated comments to reflect active module loading.
 ### Removed
 - Old Emacs configuration to prepare for a new setup.

--- a/emacs/init.el
+++ b/emacs/init.el
@@ -155,7 +155,7 @@
                        (lambda (a b) (> (cdr a) (cdr b)))))
     (message "  %-20s %.3fs" (car entry) (cdr entry))))
 
-;;;; MODULES STRIPPED - NO LOADING
+;;;; Module loading
 
 ;; Phase 1: Foundation (Critical)
 (bv-require bv-core)
@@ -171,15 +171,15 @@
       (bv-require bv-development)
       (bv-require bv-git))))
 
-;; Phase 3: Language Support (High) - DISABLED
-;; (with-eval-after-load 'bv-development
-;;   (run-with-idle-timer 0.5 nil
-;;     (lambda ()
-;;       (bv-require bv-lang-python noerror)
-;;       (bv-require bv-lang-rust noerror)
-;;       (bv-require bv-lang-lisp)
-;;       (bv-require bv-lang-systems noerror)
-;;       (bv-require bv-lang-haskell noerror))))
+;; Phase 3: Language Support (High)
+(with-eval-after-load 'bv-development
+  (run-with-idle-timer 0.5 nil
+    (lambda ()
+      (bv-require bv-lang-python noerror)
+      (bv-require bv-lang-rust noerror)
+      (bv-require bv-lang-lisp)
+      (bv-require bv-lang-systems noerror)
+      (bv-require bv-lang-haskell noerror))))
 
 ;; Phase 4: Research Infrastructure (High) - DISABLED but functions kept
 (defun bv-load-research-features ()

--- a/emacs/lisp/bv-lang-lisp.el
+++ b/emacs/lisp/bv-lang-lisp.el
@@ -1,0 +1,356 @@
+;;; bv-lang-lisp.el --- Lisp languages support -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Support for Lisp dialects: Emacs Lisp, Scheme/Guile, and Common Lisp.
+
+;;; Code:
+
+;;;; Dependencies
+(require 'bv-core)
+(require 'bv-development)
+
+;;;; Custom Variables
+(defgroup bv-lisp nil
+  "Lisp languages configuration."
+  :group 'bv-languages)
+
+(defcustom bv-lisp-structural-editing-mode 'smartparens
+  "Structural editing mode to use for Lisp."
+  :type '(choice (const :tag "Smartparens" smartparens)
+                 (const :tag "Paredit" paredit)
+                 (const :tag "Lispy" lispy)
+                 (const :tag "None" nil))
+  :group 'bv-lisp)
+
+(defcustom bv-lisp-repl-pop-to-buffer t
+  "Pop to REPL buffer after evaluation."
+  :type 'boolean
+  :group 'bv-lisp)
+
+(defcustom bv-lisp-pretty-print-results t
+  "Pretty print evaluation results."
+  :type 'boolean
+  :group 'bv-lisp)
+
+(defcustom bv-lisp-common-lisp-implementation 'sbcl
+  "Common Lisp implementation to use."
+  :type '(choice (const :tag "SBCL" sbcl)
+                 (const :tag "CCL" ccl)
+                 (const :tag "ECL" ecl)
+                 (const :tag "CLISP" clisp))
+  :group 'bv-lisp)
+
+;;;; Common Lisp Functions
+(defun bv-lisp-indent-setup ()
+  "Common indentation setup for all Lisps."
+  (setq-local indent-tabs-mode nil)
+  (setq-local tab-width 2))
+
+(defun bv-lisp-enable-structural-editing ()
+  "Enable configured structural editing mode."
+  (pcase bv-lisp-structural-editing-mode
+    ('smartparens (smartparens-strict-mode 1))
+    ('paredit (enable-paredit-mode))
+    ('lispy (lispy-mode 1))))
+
+;;;; Emacs Lisp
+(use-package elisp-mode
+  :ensure nil
+  :mode ("\\.el\\'" . emacs-lisp-mode)
+  :hook ((emacs-lisp-mode . bv-lisp-indent-setup)
+         (emacs-lisp-mode . bv-lisp-enable-structural-editing)
+         (emacs-lisp-mode . flymake-mode))
+  :bind (:map emacs-lisp-mode-map
+              ("C-x C-e" . pp-eval-last-sexp)
+              ("M-:" . pp-eval-expression)
+              ("C-c C-m" . pp-macroexpand-last-sexp)
+              ("C-c C-b" . eval-buffer)
+              ("C-c C-c" . bv-elisp-eval-defun)
+              ("C-c C-r" . eval-region)
+              ("C-c C-l" . load-file)
+              ("C-c C-z" . ielm)
+              ("C-c C-d" . describe-function-at-point)
+              ("C-c C-v" . describe-variable-at-point))
+  :config
+  ;; Enhanced eval-defun
+  (defun bv-elisp-eval-defun ()
+    "Evaluate defun at point and pretty-print result."
+    (interactive)
+    (let ((result (eval-defun nil)))
+      (when bv-lisp-pretty-print-results
+        (pp result))
+      result))
+  
+  ;; Better help integration
+  (defun describe-function-at-point ()
+    "Describe function at point."
+    (interactive)
+    (let ((fn (function-called-at-point)))
+      (if fn
+          (describe-function fn)
+        (call-interactively 'describe-function))))
+  
+  (defun describe-variable-at-point ()
+    "Describe variable at point."
+    (interactive)
+    (let ((var (variable-at-point)))
+      (if (and var (not (equal var 0)))
+          (describe-variable var)
+        (call-interactively 'describe-variable)))))
+
+;;;; IELM (Emacs Lisp REPL)
+(use-package ielm
+  :ensure nil
+  :defer t
+  :config
+  (setq ielm-header "")
+  (setq ielm-prompt "λ> ")
+  (setq ielm-dynamic-return nil)
+  (setq ielm-dynamic-multiline-inputs t)
+  
+  ;; Enhanced IELM
+  (defun bv-ielm-return ()
+    "Custom return for IELM with paredit compatibility."
+    (interactive)
+    (if (and (bound-and-true-p paredit-mode)
+             (not (paredit--region-ok-p (ielm-pm) (point))))
+        (paredit-newline)
+      (ielm-return)))
+  
+  (define-key ielm-map (kbd "RET") 'bv-ielm-return)
+  
+  ;; Clear IELM buffer
+  (defun bv-ielm-clear ()
+    "Clear IELM buffer."
+    (interactive)
+    (let ((inhibit-read-only t))
+      (erase-buffer)
+      (ielm-return)))
+  
+  (define-key ielm-map (kbd "C-c M-o") 'bv-ielm-clear))
+
+;;;; Scheme/Guile Support
+(use-package geiser
+  :defer t
+  :custom
+  (geiser-default-implementation 'guile)
+  (geiser-active-implementations '(guile))
+  (geiser-repl-query-on-kill-p nil)
+  (geiser-repl-query-on-exit-p nil)
+  :config
+  (setq geiser-repl-history-filename
+        (expand-file-name "geiser-history" bv-cache-dir))
+  (setq geiser-repl-add-project-paths nil))
+
+(use-package geiser-guile
+  :after geiser
+  :config
+  (setq geiser-guile-binary (executable-find "guile")))
+
+;; Enhanced Geiser features
+(use-package geiser-eros
+  :hook (geiser-mode . geiser-eros-mode))
+
+(use-package gider
+  :hook (geiser-mode . gider-mode))
+
+;; Scheme mode configuration
+(use-package scheme
+  :ensure nil
+  :mode ("\\.scm\\'" . scheme-mode)
+  :hook ((scheme-mode . bv-lisp-indent-setup)
+         (scheme-mode . bv-lisp-enable-structural-editing))
+  :bind (:map scheme-mode-map
+              ("C-c C-z" . geiser-repl)
+              ("C-c C-c" . geiser-eval-definition)
+              ("C-c C-r" . geiser-eval-region)
+              ("C-c C-b" . geiser-eval-buffer)
+              ("C-c C-l" . geiser-load-file)))
+
+;;;; Common Lisp Support (SLY)
+(use-package sly
+  :defer t
+  :commands sly
+  :custom
+  (inferior-lisp-program (pcase bv-lisp-common-lisp-implementation
+                          ('sbcl "sbcl")
+                          ('ccl "ccl")
+                          ('ecl "ecl")
+                          ('clisp "clisp")))
+  :config
+  ;; Better defaults
+  (setq sly-net-coding-system 'utf-8-unix)
+  (setq sly-complete-symbol-function 'sly-flex-completions)
+  
+  ;; History file
+  (setq sly-mrepl-history-file-name
+        (expand-file-name "sly-mrepl-history" bv-cache-dir))
+  
+  ;; Enhanced REPL
+  (defun bv-sly-eval-dwim ()
+    "Eval last sexp or region in SLY."
+    (interactive)
+    (if (use-region-p)
+        (sly-eval-region (region-beginning) (region-end))
+      (sly-eval-last-expression)))
+  
+  ;; Debugger improvements
+  (setq sly-db-initial-restart-limit 10))
+
+;; SLY contrib modules
+(use-package sly-asdf
+  :after sly)
+
+(use-package sly-quicklisp
+  :after sly)
+
+(use-package sly-repl-ansi-color
+  :after sly
+  :config
+  (add-to-list 'sly-contribs 'sly-repl-ansi-color))
+
+;; Common Lisp mode configuration
+(use-package lisp-mode
+  :ensure nil
+  :mode ("\\.lisp\\'" "\\.cl\\'" "\\.asd\\'")
+  :hook ((lisp-mode . bv-lisp-indent-setup)
+         (lisp-mode . bv-lisp-enable-structural-editing)
+         (lisp-mode . sly-mode))
+  :bind (:map lisp-mode-map
+              ("C-c C-z" . sly)
+              ("C-c C-c" . sly-compile-defun)
+              ("C-c C-r" . sly-eval-region)
+              ("C-c C-b" . sly-eval-buffer)
+              ("C-c C-l" . sly-compile-and-load-file)
+              ("C-c C-d" . sly-documentation-lookup)))
+
+;;;; Structural Editing
+;; Lisp-specific config for smartparens
+(with-eval-after-load 'smartparens
+  ;; Lisp-specific pairs
+  (sp-with-modes sp-lisp-modes
+    (sp-local-pair "'" nil :actions nil)
+    (sp-local-pair "`" nil :actions nil))
+  
+  ;; Additional keybindings for Lisp
+  (define-key smartparens-mode-map (kbd "C-M-f") 'sp-forward-sexp)
+  (define-key smartparens-mode-map (kbd "C-M-b") 'sp-backward-sexp)
+  (define-key smartparens-mode-map (kbd "C-M-u") 'sp-backward-up-sexp)
+  (define-key smartparens-mode-map (kbd "C-M-d") 'sp-down-sexp)
+  (define-key smartparens-mode-map (kbd "C-M-k") 'sp-kill-sexp)
+  (define-key smartparens-mode-map (kbd "C-M-w") 'sp-copy-sexp))
+
+;;;; Lispy Alternative
+(use-package lispy
+  :when (eq bv-lisp-structural-editing-mode 'lispy)
+  :hook ((emacs-lisp-mode scheme-mode lisp-mode) . lispy-mode)
+  :config
+  (setq lispy-compat '(edebug cider)))
+
+;;;; Common REPL Commands
+(defun bv-lisp-switch-to-repl ()
+  "Switch to appropriate REPL for current mode."
+  (interactive)
+  (pcase major-mode
+    ('emacs-lisp-mode (ielm))
+    ('scheme-mode (geiser-repl-switch))
+    ('lisp-mode (sly-mrepl))))
+
+(defun bv-lisp-eval-and-switch ()
+  "Evaluate and switch to REPL."
+  (interactive)
+  (pcase major-mode
+    ('emacs-lisp-mode
+     (call-interactively 'pp-eval-last-sexp)
+     (when bv-lisp-repl-pop-to-buffer (ielm)))
+    ('scheme-mode
+     (call-interactively 'geiser-eval-last-sexp)
+     (when bv-lisp-repl-pop-to-buffer (geiser-repl-switch)))
+    ('lisp-mode
+     (call-interactively 'sly-eval-last-expression)
+     (when bv-lisp-repl-pop-to-buffer (sly-mrepl)))))
+
+;;;; Debugging Support
+;; Emacs Lisp debugging
+(use-package edebug
+  :ensure nil
+  :defer t
+  :config
+  (setq edebug-print-length 50)
+  (setq edebug-print-level 5)
+  (setq edebug-trace nil))
+
+;; Enhanced debugging commands
+(defun bv-elisp-debug-defun ()
+  "Instrument function for debugging."
+  (interactive)
+  (edebug-defun))
+
+(defun bv-elisp-remove-instrumentation ()
+  "Remove debugging instrumentation."
+  (interactive)
+  (eval-defun t))
+
+;;;; Lisp Documentation
+(defun bv-lisp-online-documentation ()
+  "Open online documentation for current Lisp."
+  (interactive)
+  (pcase major-mode
+    ('emacs-lisp-mode
+     (browse-url "https://www.gnu.org/software/emacs/manual/html_node/elisp/"))
+    ('scheme-mode
+     (browse-url "https://www.gnu.org/software/guile/manual/"))
+    ('lisp-mode
+     (browse-url "http://www.lispworks.com/documentation/HyperSpec/Front/"))))
+
+;;;; Org Babel Support
+(bv-with-feature org
+  (with-eval-after-load 'org
+    ;; Emacs Lisp
+    (add-to-list 'org-babel-load-languages '(emacs-lisp . t))
+    (setq org-babel-default-header-args:emacs-lisp
+          '((:lexical . "t")
+            (:results . "scalar")))
+    
+    ;; Scheme
+    (add-to-list 'org-babel-load-languages '(scheme . t))
+    (setq org-babel-default-header-args:scheme
+          '((:results . "scalar")))
+    
+    ;; Common Lisp
+    (add-to-list 'org-babel-load-languages '(lisp . t))))
+
+;;;; Global Keybindings
+(with-eval-after-load 'bv-core
+  ;; Common keybinding for all Lisp modes
+  (dolist (mode '(emacs-lisp-mode-map
+                  scheme-mode-map
+                  lisp-mode-map))
+    (when (boundp mode)
+      (define-key (symbol-value mode) (kbd "C-c C-s") 'bv-lisp-switch-to-repl)
+      (define-key (symbol-value mode) (kbd "C-x C-S-e") 'bv-lisp-eval-and-switch)
+      (define-key (symbol-value mode) (kbd "C-c C-D") 'bv-lisp-online-documentation))))
+
+;;;; Feature Definition
+(defun bv-lisp-load ()
+  "Load Lisp languages configuration."
+  (add-to-list 'bv-enabled-features 'lisp)
+  
+  ;; Add IELM to app map
+  (with-eval-after-load 'bv-core
+    (define-key bv-app-map "I" 'ielm))
+  
+  ;; Check for Lisp implementations
+  (unless (executable-find "guile")
+    (message "Warning: Guile not found. Scheme support limited."))
+  
+  (let ((cl-impl (pcase bv-lisp-common-lisp-implementation
+                   ('sbcl "sbcl")
+                   ('ccl "ccl")
+                   ('ecl "ecl")
+                   ('clisp "clisp"))))
+    (unless (executable-find cl-impl)
+      (message "Warning: %s not found. Common Lisp support unavailable." cl-impl))))
+
+(provide 'bv-lang-lisp)
+;;; bv-lang-lisp.el ends here

--- a/emacs/lisp/bv-lang-python.el
+++ b/emacs/lisp/bv-lang-python.el
@@ -1,0 +1,353 @@
+;;; bv-lang-python.el --- Python development environment -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Modern Python development with eglot, pyright, and virtual environment support.
+
+;;; Code:
+
+;;;; Dependencies
+(require 'bv-core)
+(require 'bv-development)
+
+;;;; Custom Variables
+(defgroup bv-python nil
+  "Python development configuration."
+  :group 'bv-languages)
+
+(defcustom bv-python-formatter 'black
+  "Python code formatter to use."
+  :type '(choice (const :tag "Black" black)
+                 (const :tag "Ruff" ruff)
+                 (const :tag "None" nil))
+  :group 'bv-python)
+
+(defcustom bv-python-format-on-save t
+  "Format Python buffers on save."
+  :type 'boolean
+  :group 'bv-python)
+
+(defcustom bv-python-shell-interpreter "python"
+  "Default Python interpreter."
+  :type 'string
+  :group 'bv-python)
+
+(defcustom bv-python-venv-auto-activate t
+  "Automatically activate virtual environments."
+  :type 'boolean
+  :group 'bv-python)
+
+(defcustom bv-python-pyenv-mode 'project
+  "How to manage Python versions with pyenv."
+  :type '(choice (const :tag "Global" global)
+                 (const :tag "Project" project)
+                 (const :tag "Manual" nil))
+  :group 'bv-python)
+
+;;;; Virtual Environment Detection
+(defvar bv-python-venv-names '(".venv" "venv" ".env" "env")
+  "Common virtual environment directory names.")
+
+(defvar bv-python-venv-indicators
+  '("pyvenv.cfg"           ; venv/virtualenv
+    "conda-meta"           ; conda
+    ".python-version"      ; pyenv
+    "poetry.lock"          ; poetry
+    "Pipfile.lock"         ; pipenv
+    "requirements.txt"     ; pip
+    "requirements.in"      ; pip-tools
+    "setup.py"            ; setuptools
+    "setup.cfg"           ; setuptools
+    "pyproject.toml")     ; modern python
+  "Files indicating a Python project root.")
+
+(defun bv-python-find-project-root ()
+  "Find Python project root by looking for indicator files."
+  (let ((indicators (append bv-python-venv-indicators
+                           bv-python-venv-names)))
+    (locate-dominating-file
+     default-directory
+     (lambda (dir)
+       (cl-some (lambda (name)
+                  (file-exists-p (expand-file-name name dir)))
+                indicators)))))
+
+(defun bv-python-find-virtualenv ()
+  "Find virtual environment for current project."
+  (when-let ((root (bv-python-find-project-root)))
+    (cond
+     ;; Poetry environment
+     ((file-exists-p (expand-file-name "poetry.lock" root))
+      (bv-python-poetry-get-virtualenv root))
+     ;; Standard venv in project
+     ((cl-some (lambda (name)
+                 (let ((venv-dir (expand-file-name name root)))
+                   (when (file-directory-p venv-dir)
+                     venv-dir)))
+               bv-python-venv-names))
+     ;; Conda environment
+     ((getenv "CONDA_DEFAULT_ENV")
+      (expand-file-name (getenv "CONDA_DEFAULT_ENV")
+                        (or (getenv "CONDA_PREFIX")
+                            (expand-file-name "~/miniconda3/envs/"))))
+     ;; Pipenv
+     ((file-exists-p (expand-file-name "Pipfile.lock" root))
+      (bv-python-pipenv-get-virtualenv root)))))
+
+(defun bv-python-poetry-get-virtualenv (root)
+  "Get Poetry virtual environment path for ROOT."
+  (let ((default-directory root))
+    (condition-case nil
+        (string-trim
+         (shell-command-to-string "poetry env info --path"))
+      (error nil))))
+
+(defun bv-python-pipenv-get-virtualenv (root)
+  "Get Pipenv virtual environment path for ROOT."
+  (let ((default-directory root))
+    (condition-case nil
+        (string-trim
+         (shell-command-to-string "pipenv --venv"))
+      (error nil))))
+
+;;;; Python Mode
+(use-package python
+  :ensure nil
+  :mode (("\\.py\\'" . python-mode)
+         ("\\.pyi\\'" . python-mode))
+  :custom
+  (python-shell-interpreter bv-python-shell-interpreter)
+  (python-shell-completion-native-enable nil)
+  (python-indent-guess-indent-offset-verbose nil)
+  :config
+  ;; Auto-activate virtual environments
+  (when bv-python-venv-auto-activate
+    (add-hook 'python-mode-hook 'bv-python-auto-activate-venv))
+  
+  ;; Format on save
+  (when bv-python-format-on-save
+    (add-hook 'python-mode-hook 'bv-python-enable-format-on-save)))
+
+;;;; Pyenv
+(use-package pyenv-mode
+  :when (executable-find "pyenv")
+  :hook ((python-mode . (lambda ()
+                          (when (eq bv-python-pyenv-mode 'project)
+                            (pyenv-mode 1)))))
+  :custom
+  (pyenv-mode-set "3.11.0")
+  :config
+  (defun bv-python-set-project-version ()
+    "Set Python version for current project."
+    (interactive)
+    (when-let ((root (bv-python-find-project-root)))
+      (let ((default-directory root))
+        (call-interactively 'pyenv-mode-set))))
+  
+  ;; Auto-detect .python-version files
+  (defun bv-python-auto-pyenv ()
+    "Automatically activate pyenv version if .python-version exists."
+    (when-let ((root (bv-python-find-project-root))
+               (version-file (expand-file-name ".python-version" root)))
+      (when (file-exists-p version-file)
+        (pyenv-mode-set (string-trim
+                         (with-temp-buffer
+                           (insert-file-contents version-file)
+                           (buffer-string))))))))
+
+;;;; Virtual Environment Management
+(use-package pyvenv
+  :defer t
+  :config
+  (defun bv-python-auto-activate-venv ()
+    "Automatically activate virtual environment."
+    (when-let ((venv (bv-python-find-virtualenv)))
+      (pyvenv-activate venv)
+      (message "Activated venv: %s" venv)))
+  
+  (defun bv-python-workon ()
+    "Enhanced pyvenv-workon with project detection."
+    (interactive)
+    (if-let ((venv (bv-python-find-virtualenv)))
+        (pyvenv-activate venv)
+      (call-interactively 'pyvenv-workon))))
+
+;;;; Poetry
+(use-package poetry
+  :when (executable-find "poetry")
+  :hook (python-mode . (lambda ()
+                         (when (locate-dominating-file
+                                default-directory "poetry.lock")
+                           (poetry 1))))
+  :config
+  (defun bv-python-poetry-shell ()
+    "Start a poetry shell in the current project."
+    (interactive)
+    (let ((default-directory (bv-python-find-project-root)))
+      (compile "poetry shell"))))
+
+;;;; Pip-tools
+(defun bv-python-pip-compile ()
+  "Run pip-compile on requirements.in."
+  (interactive)
+  (when-let ((root (bv-python-find-project-root))
+             (req-in (expand-file-name "requirements.in" root)))
+    (when (file-exists-p req-in)
+      (let ((default-directory root))
+        (compile "pip-compile requirements.in")))))
+
+(defun bv-python-pip-sync ()
+  "Run pip-sync to install dependencies."
+  (interactive)
+  (when-let ((root (bv-python-find-project-root)))
+    (let ((default-directory root))
+      (compile "pip-sync"))))
+
+;;;; Black Formatter
+(use-package python-black
+  :when (eq bv-python-formatter 'black)
+  :defer t
+  :config
+  (defun bv-python-enable-black-on-save ()
+    "Enable black formatting on save."
+    (when (eq bv-python-formatter 'black)
+      (python-black-on-save-mode 1))))
+
+;;;; Ruff Formatter
+(defun bv-python-ruff-format-buffer ()
+  "Format current buffer with ruff."
+  (interactive)
+  (when (executable-find "ruff")
+    (let ((tmp-file (make-temp-file "ruff-format" nil ".py")))
+      (write-region nil nil tmp-file)
+      (call-process "ruff" nil nil nil "format" tmp-file)
+      (let ((formatted (with-temp-buffer
+                        (insert-file-contents tmp-file)
+                        (buffer-string))))
+        (delete-region (point-min) (point-max))
+        (insert formatted))
+      (delete-file tmp-file))))
+
+(defun bv-python-enable-ruff-on-save ()
+  "Enable ruff formatting on save."
+  (when (and (eq bv-python-formatter 'ruff)
+             (executable-find "ruff"))
+    (add-hook 'before-save-hook 'bv-python-ruff-format-buffer nil t)))
+
+;;;; Common Format Setup
+(defun bv-python-enable-format-on-save ()
+  "Enable appropriate formatter on save."
+  (cond
+   ((eq bv-python-formatter 'black)
+    (bv-python-enable-black-on-save))
+   ((eq bv-python-formatter 'ruff)
+    (bv-python-enable-ruff-on-save))))
+
+;;;; Pytest
+(use-package pytest
+  :defer t
+  :bind (:map python-mode-map
+              ("C-c t t" . pytest-one)
+              ("C-c t m" . pytest-module)
+              ("C-c t ." . pytest-last-failed)
+              ("C-c t x" . pytest-failed)
+              ("C-c t a" . pytest-all))
+  :custom
+  (pytest-project-root-test 'bv-python-find-project-root))
+
+;;;; Python Test (alternative)
+(use-package python-test
+  :defer t
+  :bind (:map python-mode-map
+              ("C-c t f" . python-test-function)
+              ("C-c t c" . python-test-class)
+              ("C-c t b" . python-test-buffer)
+              ("C-c t p" . python-test-project)))
+
+;;;; Eglot with Pyright
+(with-eval-after-load 'eglot
+  ;; Configure pyright as the Python LSP server
+  (add-to-list 'eglot-server-programs
+               '(python-mode . ("pyright-langserver" "--stdio")))
+  
+  ;; Custom eglot configuration for Python
+  (defun bv-python-eglot-config ()
+    "Configure eglot for Python."
+    (when (derived-mode-p 'python-mode)
+      ;; Set workspace configuration
+      (let ((venv (bv-python-find-virtualenv)))
+        (when venv
+          (setq-local eglot-workspace-configuration
+                      `(:python (:venvPath ,venv
+                                 :pythonPath ,(expand-file-name "bin/python" venv))
+                        :pyright (:useLibraryCodeForTypes t)))))))
+  
+  (add-hook 'eglot-managed-mode-hook 'bv-python-eglot-config))
+
+;;;; Enhanced Python REPL
+(use-package python-pytest
+  :defer t)
+
+(defun bv-python-send-buffer-or-region ()
+  "Send buffer or region to Python shell."
+  (interactive)
+  (if (use-region-p)
+      (python-shell-send-region (region-beginning) (region-end))
+    (python-shell-send-buffer)))
+
+(defun bv-python-restart-shell ()
+  "Restart Python shell."
+  (interactive)
+  (when (get-buffer "*Python*")
+    (kill-buffer "*Python*"))
+  (run-python))
+
+;;;; IPython/Jupyter
+(use-package jupyter
+  :defer t
+  :config
+  (defun bv-python-jupyter-notebook ()
+    "Start Jupyter notebook in project root."
+    (interactive)
+    (let ((default-directory (bv-python-find-project-root)))
+      (start-process "jupyter" "*jupyter*" "jupyter" "notebook"))))
+
+;;;; Dir-locals Support
+(defun bv-python-add-dir-locals ()
+  "Add Python-specific dir-locals to current project."
+  (interactive)
+  (when-let ((root (bv-python-find-project-root)))
+    (let ((dir-locals-file (expand-file-name ".dir-locals.el" root)))
+      (with-temp-file dir-locals-file
+        (insert "((python-mode . ((python-shell-interpreter . \"python\")\n")
+        (insert "                 (python-shell-virtualenv-root . ")
+        (insert (format \"\%s\" (bv-python-find-virtualenv)))
+        (insert "))))\n")))))
+
+;;;; Keybindings
+(with-eval-after-load 'python
+  (define-key python-mode-map (kbd "C-c C-z") 'run-python)
+  (define-key python-mode-map (kbd "C-c C-c") 'bv-python-send-buffer-or-region)
+  (define-key python-mode-map (kbd "C-c C-r") 'bv-python-restart-shell)
+  (define-key python-mode-map (kbd "C-c v a") 'pyvenv-activate)
+  (define-key python-mode-map (kbd "C-c v w") 'bv-python-workon)
+  (define-key python-mode-map (kbd "C-c v d") 'pyvenv-deactivate)
+  (define-key python-mode-map (kbd "C-c p v") 'bv-python-set-project-version)
+  (define-key python-mode-map (kbd "C-c p c") 'bv-python-pip-compile)
+  (define-key python-mode-map (kbd "C-c p s") 'bv-python-pip-sync))
+
+;;;; Feature Definition
+(defun bv-python-load ()
+  "Load Python configuration."
+  (add-to-list 'bv-enabled-features 'python)
+  
+  ;; Ensure pyright is available
+  (unless (executable-find "pyright-langserver")
+    (message "Warning: pyright-langserver not found. Install with: npm install -g pyright"))
+  
+  ;; Add python to org-babel
+  (bv-with-feature org
+    (with-eval-after-load 'org
+      (add-to-list 'org-babel-load-languages '(python . t)))))
+
+(provide 'bv-lang-python)
+;;; bv-lang-python.el ends here

--- a/emacs/lisp/bv-lang-rust.el
+++ b/emacs/lisp/bv-lang-rust.el
@@ -1,0 +1,354 @@
+;;; bv-lang-rust.el --- Rust development environment -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Modern Rust development with eglot, rust-analyzer, and cargo integration.
+
+;;; Code:
+
+;;;; Dependencies
+(require 'bv-core)
+(require 'bv-development)
+
+;;;; Custom Variables
+(defgroup bv-rust nil
+  "Rust development configuration."
+  :group 'bv-languages)
+
+(defcustom bv-rust-format-on-save t
+  "Run rustfmt on save."
+  :type 'boolean
+  :group 'bv-rust)
+
+(defcustom bv-rust-analyzer-check-command "clippy"
+  "Command to use for cargo check."
+  :type '(choice (const "check")
+                 (const "clippy"))
+  :group 'bv-rust)
+
+(defcustom bv-rust-analyzer-cargo-watch t
+  "Enable cargo watch for continuous checking."
+  :type 'boolean
+  :group 'bv-rust)
+
+(defcustom bv-rust-analyzer-proc-macro t
+  "Enable procedural macro support."
+  :type 'boolean
+  :group 'bv-rust)
+
+(defcustom bv-rust-analyzer-inlay-hints t
+  "Enable inlay hints for types and parameters."
+  :type 'boolean
+  :group 'bv-rust)
+
+(defcustom bv-rust-analyzer-display-chaining-hints t
+  "Display chaining hints."
+  :type 'boolean
+  :group 'bv-rust)
+
+(defcustom bv-rust-analyzer-display-parameter-hints t
+  "Display parameter hints."
+  :type 'boolean
+  :group 'bv-rust)
+
+;;;; Rust Mode
+(use-package rust-mode
+  :mode ("\\.rs\\'" . rust-mode)
+  :custom
+  (rust-format-on-save bv-rust-format-on-save)
+  (rust-format-show-buffer nil)
+  :config
+  ;; Better indentation settings
+  (setq rust-indent-method-chain t)
+  (setq rust-indent-where-clause t)
+  
+  ;; Compilation settings
+  (setq compilation-error-regexp-alist-alist
+        (cons '(cargo
+                "\\(?:error\\|\\(warning\\)\\|\\(note\\)\\)[^:]*:[[:space:]]+\\(.+\\):\\([0-9]+\\):\\([0-9]+\\)"
+                3 4 5 (1 . 2))
+              compilation-error-regexp-alist-alist))
+  
+  (add-to-list 'compilation-error-regexp-alist 'cargo))
+
+;;;; Cargo Integration
+(use-package cargo
+  :hook (rust-mode . cargo-minor-mode)
+  :bind (:map cargo-mode-map
+              ("C-c C-c C-b" . cargo-process-build)
+              ("C-c C-c C-r" . cargo-process-run)
+              ("C-c C-c C-t" . cargo-process-test)
+              ("C-c C-c C-l" . cargo-process-clippy)
+              ("C-c C-c C-d" . cargo-process-doc)
+              ("C-c C-c C-f" . cargo-process-fmt)
+              ("C-c C-c C-c" . cargo-process-check)
+              ("C-c C-c C-o" . cargo-process-doc-open))
+  :custom
+  (cargo-process--command-clippy "clippy --all-targets --all-features -- -D warnings")
+  (cargo-process--enable-rust-backtrace t))
+
+;;;; Rust Analyzer Configuration
+(with-eval-after-load 'eglot
+  ;; Add rust-analyzer to eglot
+  (add-to-list 'eglot-server-programs
+               '(rust-mode . ("rust-analyzer")))
+  
+  ;; Configure rust-analyzer
+  (defun bv-rust-eglot-config ()
+    "Configure eglot for Rust."
+    (when (derived-mode-p 'rust-mode)
+      (setq-local eglot-workspace-configuration
+                  `(:rust-analyzer
+                    (:procMacro (:enable ,bv-rust-analyzer-proc-macro)
+                     :cargo (:watch (:enable ,bv-rust-analyzer-cargo-watch))
+                     :checkOnSave (:command ,bv-rust-analyzer-check-command
+                                   :allTargets t
+                                   :allFeatures t
+                                   :extraArgs ["--" "-D" "warnings"])
+                     :inlayHints (:enable ,bv-rust-analyzer-inlay-hints
+                                  :chainingHints ,bv-rust-analyzer-display-chaining-hints
+                                  :parameterHints ,bv-rust-analyzer-display-parameter-hints
+                                  :typeHints t
+                                  :maxLength 25)
+                     :lens (:enable t
+                            :implementations t
+                            :run t
+                            :methodReferences t)
+                     :completion (:autoimport t
+                                  :autoself t
+                                  :postfix t)
+                     :diagnostics (:enable t
+                                   :experimental (:enable t))
+                     :hover (:documentation t
+                             :links t)
+                     :rustfmt (:enableRangeFormatting t))))))
+  
+  (add-hook 'eglot-managed-mode-hook 'bv-rust-eglot-config))
+
+;;;; Cargo Edit Commands
+(defun bv-rust-cargo-add (crate)
+  "Add CRATE dependency using cargo-edit."
+  (interactive "sCrate name: ")
+  (compile (format "cargo add %s" crate)))
+
+(defun bv-rust-cargo-rm (crate)
+  "Remove CRATE dependency using cargo-edit."
+  (interactive
+   (list (completing-read "Remove crate: "
+                         (bv-rust-get-dependencies))))
+  (compile (format "cargo rm %s" crate)))
+
+(defun bv-rust-cargo-upgrade ()
+  "Upgrade dependencies using cargo-edit."
+  (interactive)
+  (compile "cargo upgrade"))
+
+(defun bv-rust-cargo-update ()
+  "Update Cargo.lock."
+  (interactive)
+  (compile "cargo update"))
+
+(defun bv-rust-get-dependencies ()
+  "Get list of dependencies from Cargo.toml."
+  (let ((cargo-toml (expand-file-name "Cargo.toml"
+                                      (locate-dominating-file
+                                       default-directory "Cargo.toml"))))
+    (when (file-exists-p cargo-toml)
+      (with-temp-buffer
+        (insert-file-contents cargo-toml)
+        (let ((deps '()))
+          (while (re-search-forward "^\\([a-zA-Z0-9_-]+\\) =" nil t)
+            (push (match-string 1) deps))
+          deps)))))
+
+;;;; Enhanced Rust Commands
+(defun bv-rust-run-bin ()
+  "Run a binary target."
+  (interactive)
+  (let ((bins (bv-rust-get-bin-targets)))
+    (if bins
+        (let ((bin (if (= 1 (length bins))
+                       (car bins)
+                     (completing-read "Binary: " bins))))
+          (compile (format "cargo run --bin %s" bin)))
+      (compile "cargo run"))))
+
+(defun bv-rust-run-example ()
+  "Run an example."
+  (interactive)
+  (let ((examples (bv-rust-get-examples)))
+    (when examples
+      (let ((example (completing-read "Example: " examples)))
+        (compile (format "cargo run --example %s" example))))))
+
+(defun bv-rust-test-current ()
+  "Run test at point."
+  (interactive)
+  (let ((test-name (bv-rust-get-current-test)))
+    (if test-name
+        (compile (format "cargo test %s" test-name))
+      (message "No test found at point"))))
+
+(defun bv-rust-get-current-test ()
+  "Get the name of the test at point."
+  (save-excursion
+    (when (re-search-backward "^[[:space:]]*#[\\[]test\\]" nil t)
+      (forward-line 1)
+      (when (re-search-forward "fn[[:space:]]+\\([a-zA-Z0-9_]+\\)" nil t)
+        (match-string 1)))))
+
+(defun bv-rust-get-bin-targets ()
+  "Get list of binary targets from Cargo.toml."
+  (let ((cargo-toml (expand-file-name "Cargo.toml"
+                                      (locate-dominating-file
+                                       default-directory "Cargo.toml"))))
+    (when (file-exists-p cargo-toml)
+      (with-temp-buffer
+        (insert-file-contents cargo-toml)
+        (let ((bins '()))
+          (while (re-search-forward "^\\[\\[bin\\]\\]" nil t)
+            (when (re-search-forward "name[[:space:]]*=[[:space:]]*\"\\([^\"]+\\)\"" nil t)
+              (push (match-string 1) bins)))
+          bins)))))
+
+(defun bv-rust-get-examples ()
+  "Get list of examples from examples directory."
+  (let ((examples-dir (expand-file-name "examples"
+                                        (locate-dominating-file
+                                         default-directory "Cargo.toml"))))
+    (when (file-directory-p examples-dir)
+      (mapcar (lambda (f)
+                (file-name-sans-extension f))
+              (directory-files examples-dir nil "\\.rs$"))))))
+
+;;;; Rust Playground
+(defun bv-rust-playground ()
+  "Create a new Rust playground."
+  (interactive)
+  (let* ((name (format "rust-playground-%s"
+                       (format-time-string "%Y%m%d-%H%M%S")))
+         (dir (expand-file-name name temporary-file-directory)))
+    (make-directory dir)
+    (let ((default-directory dir))
+      (shell-command "cargo init --name playground")
+      (find-file (expand-file-name "src/main.rs" dir))
+      (setq-local compile-command "cargo run"))))
+
+;;;; Macro Expansion
+(defun bv-rust-expand-macro ()
+  "Expand Rust macro at point."
+  (interactive)
+  (when (eglot-current-server)
+    (eglot-code-actions (point) (point) "rust-analyzer.expandMacro" t)))
+
+;;;; Documentation
+(defun bv-rust-doc-std ()
+  "Open Rust standard library documentation."
+  (interactive)
+  (browse-url "https://doc.rust-lang.org/std/"))
+
+(defun bv-rust-doc-search (query)
+  "Search Rust documentation for QUERY."
+  (interactive "sSearch docs for: ")
+  (browse-url (format "https://docs.rs/releases/search?query=%s" query)))
+
+;;;; Debugging Support
+(bv-with-feature dape
+  (with-eval-after-load 'dape
+    ;; Add rust-lldb configuration
+    (add-to-list 'dape-configs
+                 '(rust-lldb
+                   modes (rust-mode)
+                   command "lldb-vscode"
+                   :type "lldb"
+                   :request "launch"
+                   :program (lambda ()
+                              (let ((bin (bv-rust-get-debug-binary)))
+                                (read-file-name "Binary: " nil nil t bin)))
+                   :cwd dape-cwd-fn
+                   :stopOnEntry nil))
+    
+    ;; Add rust-gdb configuration
+    (add-to-list 'dape-configs
+                 '(rust-gdb
+                   modes (rust-mode)
+                   command "gdb"
+                   :type "gdb"
+                   :request "launch"
+                   :target (lambda ()
+                            (let ((bin (bv-rust-get-debug-binary)))
+                              (read-file-name "Binary: " nil nil t bin)))
+                   :cwd dape-cwd-fn))))
+
+(defun bv-rust-get-debug-binary ()
+  "Get path to debug binary."
+  (let* ((root (locate-dominating-file default-directory "Cargo.toml"))
+         (target-dir (expand-file-name "target/debug" root)))
+    (when (file-directory-p target-dir)
+      (car (directory-files target-dir t "^[^.].*[^.]$" t))))))
+
+;;;; Cargo.toml Support
+(use-package toml-mode
+  :mode ("Cargo\\.lock\\'" "\\.cargo/config\\'" "\\.cargo/credentials\\'")
+  )
+
+;;;; Snippets Support
+(bv-with-feature tempel
+  (with-eval-after-load 'tempel
+    (defvar bv-rust-tempel-templates
+      '(rust-mode
+        (test "#[test]\nfn " (p "test_name") "() {\n    " r> "\n}")
+        (bench "#[bench]\nfn " (p "bench_name") "(b: &mut Bencher) {\n    " r> "\n}")
+        (derive "#[derive(" (p "Debug") ")]\n")
+        (println "println!(\"" (p "{}") "\", " (p "value") ");")
+        (eprintln "eprintln!(\"" (p "{}") "\", " (p "value") ");")
+        (todo "todo!(\"" (p "implement this") "\")")
+        (unimplemented "unimplemented!(\"" (p "not implemented") "\")")
+        (result "Result<" (p "T") ", " (p "E") ">")
+        (option "Option<" (p "T") ">")
+        (match "match " (p "expr") " {\n    " r> "\n}")
+        (impl "impl " (p "Type") " {\n    " r> "\n}")
+        (struct "struct " (p "Name") " {\n    " r> "\n}")
+        (enum "enum " (p "Name") " {\n    " r> "\n}")
+        (trait "trait " (p "Name") " {\n    " r> "\n}"))
+      "Rust templates for Tempel.")
+    
+    (add-to-list 'tempel-template-sources 'bv-rust-tempel-templates)))
+
+;;;; Keybindings
+(with-eval-after-load 'rust-mode
+  (define-key rust-mode-map (kbd "C-c C-d") nil) ; Remove default
+  (define-key rust-mode-map (kbd "C-c d s") 'bv-rust-doc-std)
+  (define-key rust-mode-map (kbd "C-c d d") 'bv-rust-doc-search)
+  (define-key rust-mode-map (kbd "C-c r r") 'bv-rust-run-bin)
+  (define-key rust-mode-map (kbd "C-c r e") 'bv-rust-run-example)
+  (define-key rust-mode-map (kbd "C-c r t") 'bv-rust-test-current)
+  (define-key rust-mode-map (kbd "C-c r p") 'bv-rust-playground)
+  (define-key rust-mode-map (kbd "C-c r m") 'bv-rust-expand-macro)
+  (define-key rust-mode-map (kbd "C-c c a") 'bv-rust-cargo-add)
+  (define-key rust-mode-map (kbd "C-c c r") 'bv-rust-cargo-rm)
+  (define-key rust-mode-map (kbd "C-c c u") 'bv-rust-cargo-upgrade)
+  (define-key rust-mode-map (kbd "C-c c U") 'bv-rust-cargo-update))
+
+;;;; Feature Definition
+(defun bv-rust-load ()
+  "Load Rust configuration."
+  (add-to-list 'bv-enabled-features 'rust)
+  
+  ;; Check for required tools
+  (dolist (tool '("rustc" "cargo" "rust-analyzer"))
+    (unless (executable-find tool)
+      (message "Warning: %s not found in PATH" tool)))
+  
+  ;; Check for optional tools
+  (dolist (tool '("cargo-edit" "rustfmt" "clippy"))
+    (unless (or (executable-find tool)
+                (executable-find (concat "cargo-" tool)))
+      (message "Optional tool %s not found. Some features may be unavailable." tool)))
+  
+  ;; Add rust to org-babel
+  (bv-with-feature org
+    (with-eval-after-load 'org
+      (add-to-list 'org-babel-load-languages '(rust . t)))))
+
+(provide 'bv-lang-rust)
+;;; bv-lang-rust.el ends here

--- a/emacs/lisp/bv-lang-systems.el
+++ b/emacs/lisp/bv-lang-systems.el
@@ -1,0 +1,438 @@
+;;; bv-lang-systems.el --- C/C++ systems programming -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Modern C/C++ development with eglot, clangd, CMake, and debugging support.
+
+;;; Code:
+
+;;;; Dependencies
+(require 'bv-core)
+(require 'bv-development)
+
+;;;; Custom Variables
+(defgroup bv-systems nil
+  "C/C++ systems programming configuration."
+  :group 'bv-languages)
+
+(defcustom bv-systems-c-style "linux"
+  "C/C++ coding style."
+  :type '(choice (const "linux")
+                 (const "gnu")
+                 (const "k&r")
+                 (const "bsd")
+                 (const "stroustrup")
+                 (const "ellemtel")
+                 (const "cc-mode"))
+  :group 'bv-systems)
+
+(defcustom bv-systems-clang-format-on-save t
+  "Run clang-format on save."
+  :type 'boolean
+  :group 'bv-systems)
+
+(defcustom bv-systems-clangd-args
+  '("--header-insertion=never"
+    "--completion-style=detailed"
+    "--clang-tidy"
+    "--suggest-missing-includes")
+  "Arguments to pass to clangd."
+  :type '(repeat string)
+  :group 'bv-systems)
+
+(defcustom bv-systems-cmake-build-type "Debug"
+  "Default CMake build type."
+  :type '(choice (const "Debug")
+                 (const "Release")
+                 (const "RelWithDebInfo")
+                 (const "MinSizeRel"))
+  :group 'bv-systems)
+
+(defcustom bv-systems-default-c-standard "c17"
+  "Default C standard."
+  :type '(choice (const "c89")
+                 (const "c99")
+                 (const "c11")
+                 (const "c17")
+                 (const "c23"))
+  :group 'bv-systems)
+
+(defcustom bv-systems-default-cpp-standard "c++20"
+  "Default C++ standard."
+  :type '(choice (const "c++98")
+                 (const "c++11")
+                 (const "c++14")
+                 (const "c++17")
+                 (const "c++20")
+                 (const "c++23"))
+  :group 'bv-systems)
+
+;;;; Project Detection
+(defvar bv-systems-project-indicators
+  '("CMakeLists.txt"
+    "meson.build"
+    "Makefile"
+    "compile_commands.json"
+    ".clangd"
+    ".clang-format"
+    ".clang-tidy"
+    "configure.ac"
+    "BUILD.bazel")
+  "Files indicating a C/C++ project root.")
+
+(defun bv-systems-find-project-root ()
+  "Find C/C++ project root."
+  (locate-dominating-file
+   default-directory
+   (lambda (dir)
+     (cl-some (lambda (indicator)
+                (file-exists-p (expand-file-name indicator dir)))
+              bv-systems-project-indicators))))
+
+;;;; C/C++ Mode
+(use-package cc-mode
+  :ensure nil
+  :mode (("\\.c\\'" . c-mode)
+         ("\\.cc\\'" . c++-mode)
+         ("\\.cpp\\'" . c++-mode)
+         ("\\.cxx\\'" . c++-mode)
+         ("\\.c\\+\\+\\'" . c++-mode)
+         ("\\.h\\'" . c++-mode)
+         ("\\.hpp\\'" . c++-mode)
+         ("\\.hxx\\'" . c++-mode)
+         ("\\.h\\+\\+\\'" . c++-mode)
+         ("\\.ipp\\'" . c++-mode)
+         ("\\.tpp\\'" . c++-mode))
+  :hook ((c-mode . bv-systems-setup)
+         (c++-mode . bv-systems-setup))
+  :custom
+  (c-basic-offset 4)
+  :config
+  ;; Modern C++ syntax support
+  (c-add-style "modern-cpp"
+               '("stroustrup"
+                 (c-basic-offset . 4)
+                 (c-offsets-alist
+                  (innamespace . 0)
+                  (inline-open . 0)
+                  (inlambda . 0)
+                  (access-label . -)
+                  (case-label . +)
+                  (statement-case-intro . +))))
+  
+  (defun bv-systems-setup ()
+    "Setup C/C++ mode."
+    (c-set-style (if (string= bv-systems-c-style "modern-cpp")
+                     "modern-cpp"
+                   bv-systems-c-style))
+    (setq-local comment-start "// ")
+    (setq-local comment-end "")
+    (setq-local indent-tabs-mode nil)
+    (setq-local show-trailing-whitespace t)
+    
+    ;; Enable modern C++ font-lock
+    (when (derived-mode-p 'c++-mode)
+      (setq-local c++-font-lock-extra-types
+                  '("std::string" "std::vector" "std::map" "std::unique_ptr"
+                    "std::shared_ptr" "std::optional" "std::variant"
+                    "std::span" "std::string_view" "size_t" "ssize_t"
+                    "uint8_t" "uint16_t" "uint32_t" "uint64_t"
+                    "int8_t" "int16_t" "int32_t" "int64_t")))
+    
+    ;; Clang-format on save
+    (when (and bv-systems-clang-format-on-save
+               (executable-find "clang-format"))
+      (add-hook 'before-save-hook 'bv-systems-clang-format-buffer nil t))))
+
+;;;; Clang Format
+(use-package clang-format
+  :defer t
+  :config
+  (defun bv-systems-clang-format-buffer ()
+    "Format buffer with clang-format if .clang-format exists."
+    (when (and (derived-mode-p 'c-mode 'c++-mode)
+               (locate-dominating-file default-directory ".clang-format"))
+      (clang-format-buffer)))
+  
+  (defun bv-systems-setup-clang-format ()
+    "Create a default .clang-format file."
+    (interactive)
+    (let ((root (or (bv-systems-find-project-root)
+                    default-directory)))
+      (with-temp-file (expand-file-name ".clang-format" root)
+        (insert "BasedOnStyle: LLVM\n")
+        (insert "IndentWidth: 4\n")
+        (insert (format "Standard: %s\n" 
+                        (if (derived-mode-p 'c++-mode)
+                            bv-systems-default-cpp-standard
+                          bv-systems-default-c-standard)))
+        (insert "ColumnLimit: 100\n")
+        (insert "AllowShortFunctionsOnASingleLine: Empty\n")
+        (insert "BreakBeforeBraces: Attach\n")
+        (insert "AlwaysBreakTemplateDeclarations: Yes\n")))))
+
+;;;; CMake Support
+(use-package cmake-mode
+  :mode (("CMakeLists\\.txt\\'" . cmake-mode)
+         ("\\.cmake\\'" . cmake-mode))
+  :config
+  (defun bv-systems-cmake-configure ()
+    "Configure CMake project."
+    (interactive)
+    (let* ((root (or (bv-systems-find-project-root)
+                     default-directory))
+           (build-dir (expand-file-name 
+                       (format "build-%s" (downcase bv-systems-cmake-build-type))
+                       root)))
+      (unless (file-directory-p build-dir)
+        (make-directory build-dir t))
+      (let ((default-directory build-dir))
+        (compile (format "cmake -DCMAKE_BUILD_TYPE=%s -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .."
+                         bv-systems-cmake-build-type)))))
+  
+  (defun bv-systems-cmake-build ()
+    "Build CMake project."
+    (interactive)
+    (let* ((root (or (bv-systems-find-project-root)
+                     default-directory))
+           (build-dir (expand-file-name 
+                       (format "build-%s" (downcase bv-systems-cmake-build-type))
+                       root)))
+      (if (file-directory-p build-dir)
+          (let ((default-directory build-dir))
+            (compile "cmake --build . --parallel"))
+        (message "Build directory not found. Run bv-systems-cmake-configure first."))))
+  
+  (defun bv-systems-cmake-clean ()
+    "Clean CMake build."
+    (interactive)
+    (let* ((root (or (bv-systems-find-project-root)
+                     default-directory))
+           (build-dir (expand-file-name 
+                       (format "build-%s" (downcase bv-systems-cmake-build-type))
+                       root)))
+      (when (file-directory-p build-dir)
+        (let ((default-directory build-dir))
+          (compile "cmake --build . --target clean"))))))
+
+;;;; Eglot + Clangd Configuration
+(with-eval-after-load 'eglot
+  ;; Configure clangd
+  (add-to-list 'eglot-server-programs
+               `((c-mode c++-mode) . ("clangd" ,@bv-systems-clangd-args)))
+  
+  ;; Enhanced clangd configuration
+  (defun bv-systems-eglot-config ()
+    "Configure eglot for C/C++."
+    (when (derived-mode-p 'c-mode 'c++-mode)
+      ;; Ensure compile_commands.json is found
+      (let ((compile-commands (bv-systems-find-compile-commands)))
+        (when compile-commands
+          (setq-local eglot-workspace-configuration
+                      `(:clangd (:compilationDatabasePath 
+                                 ,(file-name-directory compile-commands))))))))
+  
+  (add-hook 'eglot-managed-mode-hook 'bv-systems-eglot-config))
+
+(defun bv-systems-find-compile-commands ()
+  "Find compile_commands.json file."
+  (when-let ((root (bv-systems-find-project-root)))
+    (or (let ((build-dir (expand-file-name 
+                          (format "build-%s" (downcase bv-systems-cmake-build-type))
+                          root)))
+          (when (file-exists-p (expand-file-name "compile_commands.json" build-dir))
+            (expand-file-name "compile_commands.json" build-dir)))
+        (when (file-exists-p (expand-file-name "compile_commands.json" root))
+          (expand-file-name "compile_commands.json" root))
+        (when (file-exists-p (expand-file-name "build/compile_commands.json" root))
+          (expand-file-name "build/compile_commands.json" root)))))
+
+;;;; Header/Source Navigation
+(defun bv-systems-find-other-file ()
+  "Switch between header and source file."
+  (interactive)
+  (let* ((file (file-name-nondirectory buffer-file-name))
+         (base (file-name-sans-extension file))
+         (ext (file-name-extension file))
+         (other-exts (cond
+                      ((member ext '("c" "cc" "cpp" "cxx" "c++"))
+                       '("h" "hpp" "hxx" "h++"))
+                      ((member ext '("h" "hpp" "hxx" "h++"))
+                       '("c" "cc" "cpp" "cxx" "c++"))
+                      (t nil))))
+    (when other-exts
+      (let ((other-file
+             (cl-find-if
+              'file-exists-p
+              (cl-mapcan
+               (lambda (other-ext)
+                 (list
+                  (expand-file-name (concat base "." other-ext))
+                  (expand-file-name (concat base "." other-ext) "../include")
+                  (expand-file-name (concat base "." other-ext) "../src")
+                  (expand-file-name (concat base "." other-ext) "../../include")
+                  (expand-file-name (concat base "." other-ext) "../../src")))
+               other-exts))))
+        (if other-file
+            (find-file other-file)
+          (message "Other file not found")))))
+
+;;;; Include Path Management
+(use-package cmake-ide
+  :defer t
+  :config
+  (cmake-ide-setup))
+
+(defun bv-systems-add-include-path ()
+  "Add directory to include path."
+  (interactive)
+  (let ((dir (read-directory-name "Include directory: ")))
+    (when dir
+      (add-to-list 'cc-search-directories dir)
+      (when (eglot-current-server)
+        (eglot-signal-didChangeConfiguration (eglot-current-server))))))
+
+;;;; Modern C++ Snippets
+(bv-with-feature tempel
+  (with-eval-after-load 'tempel
+    (defvar bv-systems-cpp-templates
+      '(c++-mode
+        ;; Modern C++ patterns
+        (class "class " (p "Name") " {\npublic:\n    " p> "\n};\n")
+        (struct "struct " (p "Name") " {\n    " p> "\n};\n")
+        (enum "enum class " (p "Name") " {\n    " p> "\n};\n")
+        (ns "namespace " (p "name") " {\n" r> "\n} // namespace " (s name))
+        (lambda "[](" p ") { " p " }")
+        (auto "auto " (p "var") " = " p ";")
+        (for "for (const auto& " (p "elem") " : " (p "container") ") {\n    " r> "\n}")
+        (unique "std::unique_ptr<" (p "T") "> " (p "ptr") "(new " (s T) ");")
+        (shared "std::shared_ptr<" (p "T") "> " (p "ptr") " = std::make_shared<" (s T) ">();")
+        (vector "std::vector<" (p "T") "> " (p "vec") ";")
+        (map "std::map<" (p "K") ", " (p "V") "> " (p "map") ";")
+        (optional "std::optional<" (p "T") "> " (p "opt") ";")
+        (variant "std::variant<" (p "Types...") "> " (p "var") ";")
+        ;; Testing
+        (test "TEST(" (p "TestCase") ", " (p "TestName") ") {\n    " r> "\n}")
+        (gtest "#include <gtest/gtest.h>\n\n" p)
+        ;; Headers
+        (guard "#ifndef " (p (upcase (concat (file-name-base) "_H"))) n
+               "#define " (s (upcase (concat (file-name-base) "_H"))) n n
+               r n n
+               "#endif // " (s (upcase (concat (file-name-base) "_H"))))
+        (pragma "#pragma once\n")
+        ;; Common includes
+        (inc "#include <" (p "header") ">")
+        (incl "#include \"" (p "header") "\""))
+      "Modern C++ templates.")
+    
+    (add-to-list 'tempel-template-sources 'bv-systems-cpp-templates)))
+
+;;;; Debugging with DAP
+(bv-with-feature dape
+  (with-eval-after-load 'dape
+    ;; GDB configuration
+    (add-to-list 'dape-configs
+                 '(cpp-gdb
+                   modes (c-mode c++-mode)
+                   command "gdb"
+                   command-args ("--interpreter=dap")
+                   :request "launch"
+                   :program (lambda ()
+                              (let ((exe (bv-systems-find-executable)))
+                                (read-file-name "Executable: " nil nil t exe)))
+                   :args []
+                   :cwd dape-cwd-fn
+                   :stopAtBeginningOfMainSubprogram nil))
+    
+    ;; LLDB configuration
+    (add-to-list 'dape-configs
+                 '(cpp-lldb
+                   modes (c-mode c++-mode)
+                   command "lldb-vscode"
+                   :request "launch"
+                   :program (lambda ()
+                              (let ((exe (bv-systems-find-executable)))
+                                (read-file-name "Executable: " nil nil t exe)))
+                   :args []
+                   :cwd dape-cwd-fn
+                   :stopOnEntry nil))))
+
+(defun bv-systems-find-executable ()
+  "Find likely executable in build directory."
+  (when-let* ((root (bv-systems-find-project-root))
+              (build-dir (expand-file-name 
+                          (format "build-%s" (downcase bv-systems-cmake-build-type))
+                          root)))
+    (when (file-directory-p build-dir)
+      (car (directory-files build-dir t "^[^.].*[^.]$" t))))))
+
+;;;; Compilation
+(defun bv-systems-compile ()
+  "Smart compile for C/C++ projects."
+  (interactive)
+  (let ((root (bv-systems-find-project-root)))
+    (cond
+     ;; CMake project
+     ((and root (file-exists-p (expand-file-name "CMakeLists.txt" root)))
+      (bv-systems-cmake-build))
+     ;; Makefile
+     ((and root (file-exists-p (expand-file-name "Makefile" root)))
+      (let ((default-directory root))
+        (compile "make -j$(nproc)")))
+     ;; Single file
+     (t
+      (compile (format "%s -std=%s -Wall -g -o %s %s"
+                       (if (derived-mode-p 'c++-mode) "g++" "gcc")
+                       (if (derived-mode-p 'c++-mode)
+                           bv-systems-default-cpp-standard
+                         bv-systems-default-c-standard)
+                       (file-name-sans-extension buffer-file-name)
+                       buffer-file-name))))))
+
+;;;; Documentation
+(defun bv-systems-cpp-reference ()
+  "Open C++ reference documentation."
+  (interactive)
+  (browse-url "https://en.cppreference.com/"))
+
+(defun bv-systems-search-cppreference (query)
+  "Search cppreference for QUERY."
+  (interactive "sSearch C++ reference for: ")
+  (browse-url (format "https://en.cppreference.com/mwiki/index.php?search=%s" 
+                      (url-encode-url query))))
+
+;;;; Keybindings
+(with-eval-after-load 'cc-mode
+  (dolist (map (list c-mode-map c++-mode-map))
+    (define-key map (kbd "C-c C-o") 'bv-systems-find-other-file)
+    (define-key map (kbd "C-c C-c") 'bv-systems-compile)
+    (define-key map (kbd "C-c c c") 'bv-systems-cmake-configure)
+    (define-key map (kbd "C-c c b") 'bv-systems-cmake-build)
+    (define-key map (kbd "C-c c C") 'bv-systems-cmake-clean)
+    (define-key map (kbd "C-c d d") 'bv-systems-cpp-reference)
+    (define-key map (kbd "C-c d s") 'bv-systems-search-cppreference)
+    (define-key map (kbd "C-c i") 'bv-systems-add-include-path)
+    (define-key map (kbd "C-c f") 'clang-format-buffer)
+    (define-key map (kbd "C-c F") 'clang-format-region)))
+
+;;;; Feature Definition
+(defun bv-systems-load ()
+  "Load C/C++ configuration."
+  (add-to-list 'bv-enabled-features 'systems)
+  
+  ;; Check for required tools
+  (unless (executable-find "clangd")
+    (message "Warning: clangd not found. Install with your package manager."))
+  
+  (unless (executable-find "clang-format")
+    (message "Note: clang-format not found. Formatting disabled."))
+  
+  (unless (executable-find "cmake")
+    (message "Note: cmake not found. CMake features unavailable."))
+  
+  ;; Add to org-babel
+  (bv-with-feature org
+    (with-eval-after-load 'org
+      (add-to-list 'org-babel-load-languages '(C . t)))))
+
+(provide 'bv-lang-systems)
+;;; bv-lang-systems.el ends here


### PR DESCRIPTION
## Summary
- add language modules for Python, Rust, Lisp and C/C++
- enable Phase 3 language support in `init.el`
- update CHANGELOG

## Testing
- `bash -n setup.sh`
- `bash -n setup-dev.sh`
- `bash -n scripts/gnome-keybindings.sh`
- `bash -n scripts/latex-preview.sh`
- `bash -n scripts/style.sh`


------
https://chatgpt.com/codex/tasks/task_e_684a6fd4f7fc832b8d4922b5a8b29677