### PR TITLE
Enable research modules in Emacs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Core productivity modules for completion, navigation, development,
   and Git integration. Phase 2 now enabled in `init.el`.
 - Language support modules for Python, Rust, Lisp and C/C++.
+- Research modules for Org, research, reading, and writing.
 ### Changed
 - Phase 3 modules are now enabled in `init.el`.
 - Updated comments to reflect active module loading.
+- Phase 4 modules are now enabled in `init.el`.
 ### Removed
 - Old Emacs configuration to prepare for a new setup.

--- a/emacs/init.el
+++ b/emacs/init.el
@@ -181,14 +181,14 @@
       (bv-require bv-lang-systems noerror)
       (bv-require bv-lang-haskell noerror))))
 
-;; Phase 4: Research Infrastructure (High) - DISABLED
-;; (with-eval-after-load 'bv-core
-;;   (run-with-idle-timer 1.0 nil
-;;     (lambda ()
-;;       (bv-require bv-org)
-;;       (bv-require bv-research)
-;;       (bv-require bv-reading)
-;;       (bv-require bv-writing))))
+;; Phase 4: Research Infrastructure (High)
+(with-eval-after-load 'bv-core
+  (run-with-idle-timer 1.0 nil
+    (lambda ()
+      (bv-require bv-org)
+      (bv-require bv-research)
+      (bv-require bv-reading)
+      (bv-require bv-writing))))
 
 ;; Phase 5: Extended Productivity (Medium) - DISABLED
 ;; (with-eval-after-load 'bv-core

--- a/emacs/lisp/bv-org.el
+++ b/emacs/lisp/bv-org.el
@@ -1,0 +1,484 @@
+;;; bv-org.el --- Org mode configuration -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Org mode configuration with agenda, babel, export, and visual enhancements.
+
+;;; Code:
+
+(require 'bv-core)
+
+;;;; Custom Variables
+(defgroup bv-org nil
+  "Org mode configuration."
+  :group 'bv)
+
+(defcustom bv-org-directory "~/org"
+  "Directory for org files."
+  :type 'directory
+  :group 'bv-org)
+
+(defcustom bv-org-default-notes-file "todo.org"
+  "Default file for capturing notes."
+  :type 'string
+  :group 'bv-org)
+
+(defcustom bv-org-agenda-files nil
+  "Files to include in agenda."
+  :type '(repeat file)
+  :group 'bv-org)
+
+(defcustom bv-org-rename-buffer-to-title t
+  "Rename org buffers to their #+TITLE."
+  :type 'boolean
+  :group 'bv-org)
+
+(defcustom bv-org-indent-mode t
+  "Enable org-indent-mode by default."
+  :type 'boolean
+  :group 'bv-org)
+
+(defcustom bv-org-modern-mode t
+  "Enable org-modern for visual enhancements."
+  :type 'boolean
+  :group 'bv-org)
+
+(defcustom bv-org-auto-update-toc nil
+  "Automatically update table of contents."
+  :type 'boolean
+  :group 'bv-org)
+
+(defcustom bv-org-todo-keywords
+  '((sequence "TODO(t)" "NEXT(n)" "PROJ(p)" "|" "DONE(d)")
+    (sequence "WAITING(w@/!)" "HOLD(h@/!)" "|" "CANCELLED(c@/!)"))
+  "Org todo keywords."
+  :type '(repeat (cons (choice :tag "Type"
+                               (const :tag "Sequence" sequence)
+                               (const :tag "Type" type))
+                       (repeat :tag "Keywords" string)))
+  :group 'bv-org)
+
+(defcustom bv-org-capture-templates
+  '(("t" "Todo" entry (file+headline bv-org-default-notes-file "Inbox")
+     "* TODO %?\n  %U\n  %a")
+    ("n" "Note" entry (file+headline bv-org-default-notes-file "Notes")
+     "* %? :NOTE:\n  %U\n  %a")
+    ("j" "Journal" entry (file+datetree "journal.org")
+     "* %?\n  %U")
+    ("m" "Meeting" entry (file+headline bv-org-default-notes-file "Meetings")
+     "* MEETING %? :MEETING:\n  %U")
+    ("i" "Idea" entry (file+headline bv-org-default-notes-file "Ideas")
+     "* IDEA %? :IDEA:\n  %U"))
+  "Org capture templates."
+  :type 'sexp
+  :group 'bv-org)
+
+;;;; Core Org Configuration
+(use-package org
+  :mode ("\\.org\\'" . org-mode)
+  :bind (("C-c c" . org-capture)
+         ("C-c a" . org-agenda)
+         ("C-c l" . org-store-link)
+         :map org-mode-map
+         ("C-c C-x C-s" . bv-org-mark-done-and-archive)
+         ("C-c C-x C-a" . org-archive-subtree)
+         ("C-c t" . org-todo))
+  :custom
+  ;; General
+  (org-directory bv-org-directory)
+  (org-default-notes-file (expand-file-name bv-org-default-notes-file 
+                                            bv-org-directory))
+  (org-startup-indented bv-org-indent-mode)
+  (org-startup-folded 'content)
+  (org-startup-with-inline-images t)
+  (org-image-actual-width '(400))
+  
+  ;; Appearance
+  (org-ellipsis " ⤵")
+  (org-hide-emphasis-markers t)
+  (org-hide-leading-stars t)
+  (org-fontify-todo-headline t)
+  (org-fontify-done-headline t)
+  (org-fontify-quote-and-verse-blocks t)
+  
+  ;; Behavior
+  (org-adapt-indentation nil)
+  (org-edit-src-content-indentation 0)
+  (org-special-ctrl-a/e t)
+  (org-special-ctrl-k t)
+  (org-M-RET-may-split-line '((default . nil)))
+  (org-insert-heading-respect-content t)
+  (org-return-follows-link t)
+  (org-use-speed-commands t)
+  
+  ;; Logging
+  (org-log-into-drawer t)
+  (org-log-done 'time)
+  (org-log-refile 'time)
+  
+  ;; Refile
+  (org-refile-targets '((nil :maxlevel . 3)
+                       (org-agenda-files :maxlevel . 3)))
+  (org-refile-use-outline-path 'file)
+  (org-outline-path-complete-in-steps nil)
+  (org-refile-allow-creating-parent-nodes 'confirm)
+  
+  ;; Tags
+  (org-fast-tag-selection-single-key t)
+  (org-tags-column -80)
+  
+  ;; Todo keywords
+  (org-todo-keywords bv-org-todo-keywords)
+  (org-todo-keyword-faces
+   '(("TODO" . org-todo)
+     ("NEXT" . (:foreground "#FFA500" :weight bold))
+     ("PROJ" . (:foreground "#9370DB" :weight bold))
+     ("WAITING" . org-warning)
+     ("HOLD" . (:foreground "#888888" :weight bold))
+     ("CANCELLED" . (:foreground "#888888" :strike-through t))))
+  
+  ;; Priorities
+  (org-priority-highest ?A)
+  (org-priority-lowest ?C)
+  (org-priority-faces
+   '((?A . (:foreground "#FF0000" :weight bold))
+     (?B . (:foreground "#FFA500"))
+     (?C . (:foreground "#00AA00"))))
+  
+  ;; Archive
+  (org-archive-location "%s_archive::* Archived Tasks")
+  
+  ;; Capture
+  (org-capture-templates bv-org-capture-templates)
+  
+  :config
+  ;; Load modules
+  (require 'org-protocol)
+  (require 'org-habit)
+  (require 'org-id)
+  
+  (setq org-id-locations-file
+        (expand-file-name "org-id-locations" bv-cache-dir))
+  
+  (setq org-list-demote-modify-bullet
+        '(("+" . "-") ("-" . "+") ("*" . "+")))
+  
+  (setq org-src-fontify-natively t)
+  (setq org-src-tab-acts-natively t)
+  (setq org-src-preserve-indentation t)
+  
+  (custom-set-faces
+   '(org-ellipsis ((t (:inherit font-lock-comment-face :weight normal))))
+   '(org-document-title ((t (:height 1.5 :weight bold)))))
+  
+  ;; Rename buffer to title
+  (defun bv-org-rename-buffer-to-title (&optional end)
+    "Rename buffer to value of #+TITLE:."
+    (interactive)
+    (when bv-org-rename-buffer-to-title
+      (let ((case-fold-search t)
+            (beg (or (and end (point)) (point-min))))
+        (save-excursion
+          (when end
+            (goto-char end)
+            (setq end (line-end-position)))
+          (goto-char beg)
+          (when (re-search-forward
+                 "^[[:space:]]*#\\+TITLE:[[:space:]]*\\(.*?\\)[[:space:]]*$"
+                 end t)
+            (rename-buffer (match-string 1) t)))))
+    nil)
+  
+  (defun bv-org-rename-buffer-to-title-config ()
+    "Configure Org to rename buffer to value of #+TITLE:."
+    (font-lock-add-keywords nil '(bv-org-rename-buffer-to-title)))
+  
+  (when bv-org-rename-buffer-to-title
+    (add-hook 'org-mode-hook 'bv-org-rename-buffer-to-title-config))
+  
+  (defun bv-org-mark-done-and-archive ()
+    "Mark the state of the current subtree as DONE and archive it."
+    (interactive)
+    (org-todo 'done)
+    (org-archive-subtree)))
+
+;;;; Org Modern
+(use-package org-modern
+  :hook (org-mode . (lambda ()
+                      (when bv-org-modern-mode
+                        (org-modern-mode 1))))
+  :custom
+  (org-modern-star '("◉" "○" "◈" "◇" "✳" "◆" "▶"))
+  (org-modern-list '((?+ . "➤") (?- . "–") (?* . "•")))
+  (org-modern-checkbox '((?X . "☑") (?- . "☐") (?\s . "☐")))
+  (org-modern-table-vertical 1)
+  (org-modern-table-horizontal 0.2)
+  (org-modern-priority nil)
+  (org-modern-todo nil)
+  (org-modern-tag nil)
+  (org-modern-timestamp nil)
+  (org-modern-statistics nil)
+  (org-modern-progress nil)
+  :config
+  (custom-set-faces
+   '(org-modern-symbol ((t (:family "Iosevka"))))))
+
+;;;; Org Appear
+(use-package org-appear
+  :hook (org-mode . org-appear-mode)
+  :custom
+  (org-appear-autoemphasis t)
+  (org-appear-autolinks t)
+  (org-appear-autosubmarkers t)
+  (org-appear-autoentities t)
+  (org-appear-autokeywords t)
+  (org-appear-delay 0.3))
+
+;;;; Table of Contents
+(use-package org-make-toc
+  :when bv-org-auto-update-toc
+  :hook (org-mode . org-make-toc-mode))
+
+;;;; Org Agenda
+(use-package org-agenda
+  :after org
+  :bind (:map org-agenda-mode-map
+              ("r" . org-agenda-redo)
+              ("R" . org-agenda-redo-all)
+              ("c" . org-agenda-capture))
+  :custom
+  (org-agenda-files (or bv-org-agenda-files
+                       (list org-directory)))
+  (org-agenda-window-setup 'current-window)
+  (org-agenda-restore-windows-after-quit t)
+  (org-agenda-sticky t)
+  (org-agenda-span 'day)
+  (org-agenda-start-on-weekday 1)
+  (org-agenda-include-diary nil)
+  (org-agenda-show-future-repeats 'next)
+  (org-agenda-skip-scheduled-if-done t)
+  (org-agenda-skip-deadline-if-done t)
+  (org-agenda-block-separator ?─)
+  (org-agenda-compact-blocks nil)
+  (org-agenda-time-grid
+   '((daily today require-timed)
+     (800 1000 1200 1400 1600 1800 2000)
+     " ┄┄┄┄┄ " "┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄"))
+  (org-agenda-current-time-string
+   "⭠ now ─────────────────────────────────────────────────")
+  (org-agenda-start-with-log-mode t)
+  (org-agenda-log-mode-items '(closed clock state))
+  (org-agenda-custom-commands
+   '(("d" "Daily Review"
+      ((agenda "" ((org-agenda-span 1)
+                   (org-agenda-scheduled-leaders '("" "Sched.%2dx: "))
+                   (org-scheduled-past-days 0)
+                   (org-agenda-day-face-function
+                    (lambda (date) 'org-agenda-date))
+                   (org-agenda-format-date "%A %-e %B %Y")
+                   (org-agenda-overriding-header "Today's Agenda")))
+       (todo "NEXT"
+             ((org-agenda-overriding-header "Next Actions")))
+       (todo "WAITING"
+             ((org-agenda-overriding-header "Waiting For")))))
+     
+     ("w" "Weekly Review"
+      ((agenda "" ((org-agenda-span 'week)
+                   (org-agenda-start-day "-1d")
+                   (org-agenda-overriding-header "Week Overview")))
+       (todo "PROJ"
+             ((org-agenda-overriding-header "Active Projects")))
+       (todo "TODO"
+             ((org-agenda-overriding-header "All TODOs")))))
+     
+     ("p" "Projects"
+      ((todo "PROJ"
+             ((org-agenda-overriding-header "All Projects")))
+       (tags-todo "PROJECT"
+                  ((org-agenda-overriding-header "Project Tasks")))))))
+  
+  :config
+  (defun bv-org-agenda-category (&optional len)
+    "Get category of the Org Agenda item at point."
+    (let* ((filename (when buffer-file-name
+                       (file-name-sans-extension
+                        (file-name-nondirectory buffer-file-name))))
+           (title (cadr (assoc "TITLE"
+                               (org-collect-keywords '("title")))))
+           (category (org-get-category))
+           (result (or (if (and title (string= category filename))
+                           title
+                         category)
+                       "")))
+      (if (numberp len)
+          (s-truncate len (s-pad-right len " " result))
+        result)))
+  
+  (setq org-agenda-prefix-format
+        '((agenda . " %i %(bv-org-agenda-category 12)%?-12t% s")
+          (todo . " %i %(bv-org-agenda-category 12) ")
+          (tags . " %i %(bv-org-agenda-category 12) ")
+          (search . " %i %(bv-org-agenda-category 12) "))))
+
+;;;; Org Super Agenda
+(use-package org-super-agenda
+  :after org-agenda
+  :config
+  (org-super-agenda-mode)
+  (setq org-super-agenda-groups
+        '((:name "Important"
+                 :priority "A")
+          (:name "Today"
+                 :time-grid t
+                 :scheduled today
+                 :deadline today)
+          (:name "Due Soon"
+                 :deadline future)
+          (:name "Overdue"
+                 :deadline past)
+          (:name "Next Actions"
+                 :todo "NEXT")
+          (:name "Projects"
+                 :todo "PROJ")
+          (:name "Waiting"
+                 :todo "WAITING")
+          (:name "Maybe"
+                 :tag "maybe"
+                 :order 100))))
+
+;;;; Org Wild Notifier
+(use-package org-wild-notifier
+  :after org
+  :config
+  (org-wild-notifier-mode)
+  (setq org-wild-notifier-alert-time '(10 5))
+  (setq org-wild-notifier-keyword-whitelist '("TODO" "NEXT"))
+  (setq org-wild-notifier-notification-title "Org Agenda"))
+
+;;;; Org Babel
+(use-package ob
+  :after org
+  :config
+  (setq org-confirm-babel-evaluate nil)
+  
+  (org-babel-do-load-languages
+   'org-babel-load-languages
+   '((emacs-lisp . t)
+     (shell . t)
+     (python . t)
+     (js . t)
+     (css . t)
+     (dot . t)
+     (plantuml . t)))
+  
+  (require 'org-tempo)
+  (dolist (template '(("sh" . "src shell")
+                     ("el" . "src emacs-lisp")
+                     ("py" . "src python")
+                     ("js" . "src js")
+                     ("json" . "src json")
+                     ("css" . "src css")
+                     ("dot" . "src dot")
+                     ("plantuml" . "src plantuml")))
+    (add-to-list 'org-structure-template-alist template)))
+
+;;;; Org Export
+(use-package ox
+  :after org
+  :custom
+  (org-export-with-toc t)
+  (org-export-with-tags 'not-in-toc)
+  (org-export-with-todo-keywords t)
+  (org-export-with-timestamps t)
+  (org-export-preserve-breaks nil)
+  (org-export-with-sub-superscripts '{})
+  (org-export-with-smart-quotes t)
+  (org-export-backends '(ascii html icalendar latex md odt))
+  :config
+  (setq org-html-doctype "html5")
+  (setq org-html-html5-fancy t)
+  (setq org-html-postamble nil)
+  (setq org-html-head-include-default-style nil)
+  (setq org-html-head-include-scripts nil)
+  (setq org-html-head
+        "<link rel=\"stylesheet\" type=\"text/css\" href=\"https://gongzhitaao.org/orgcss/org.css\"/>")
+  )
+
+;;;; Stable HTML IDs
+(use-package ox-html-stable-ids
+  :after ox
+  :config
+  (org-html-stable-ids-add))
+
+;;;; Additional Org Packages
+(use-package org-contrib
+  :after org)
+
+(use-package htmlize
+  :defer t)
+
+;;;; Timer Functions
+(defun bv-org-timer-reset ()
+  "Set `org-timer-mode-line-string' to nil."
+  (interactive)
+  (setq org-timer-mode-line-string nil))
+
+(defun bv-org-timer-update-mode-line ()
+  "Update the timer in the mode line without surrounding brackets."
+  (if org-timer-pause-time
+      nil
+    (setq org-timer-mode-line-string
+          (substring (org-timer-value-string) 0 -1))
+    (force-mode-line-update)))
+
+(advice-add 'org-timer-update-mode-line
+            :override 'bv-org-timer-update-mode-line)
+(add-hook 'org-timer-stop-hook 'bv-org-timer-reset)
+
+;;;; Keybindings
+(defvar bv-org-timer-map (make-sparse-keymap)
+  "Keymap for org-timer commands.")
+
+(define-key bv-org-timer-map "s" 'org-timer-start)
+(define-key bv-org-timer-map "q" 'org-timer-stop)
+(define-key bv-org-timer-map "p" 'org-timer-pause-or-continue)
+(define-key bv-org-timer-map "t" 'org-timer-set-timer)
+
+(with-eval-after-load 'bv-core
+  (define-key bv-app-map "o" bv-org-timer-map))
+
+;;;; Templates
+(bv-with-feature tempel
+  (with-eval-after-load 'tempel
+    (defvar bv-org-tempel-templates
+      '(org-mode
+        (title "#+title: " p n "#+author: " user-full-name n
+               "#+date: " (format-time-string "%Y-%m-%d") n n)
+        (quote "#+begin_quote" n> r> n> "#+end_quote")
+        (example "#+begin_example" n> r> n> "#+end_example")
+        (center "#+begin_center" n> r> n> "#+end_center")
+        (comment "#+begin_comment" n> r> n> "#+end_comment")
+        (verse "#+begin_verse" n> r> n> "#+end_verse")
+        (src "#+begin_src " p n> r> n> "#+end_src" :post (org-edit-src-code))
+        (elisp "#+begin_src emacs-lisp" n> r> n "#+end_src" :post (org-edit-src-code))
+        (properties ":PROPERTIES:" n ":ID: " (org-id-new) n ":END:")
+        (drawer ":" p ":" n r n ":END:")
+        (options "#+OPTIONS: " p)
+        (latex "#+begin_export latex" n> r> n> "#+end_export")
+        (html "#+begin_export html" n> r> n> "#+end_export"))
+      "Org mode templates.")
+    
+    (add-to-list 'tempel-template-sources 'bv-org-tempel-templates)))
+
+;;;; Olivetti Integration
+(use-package olivetti
+  :hook (org-mode . olivetti-mode)
+  :custom
+  (olivetti-body-width 85))
+
+;;;; Feature Definition
+(defun bv-org-load ()
+  "Load Org mode configuration."
+  (add-to-list 'bv-enabled-features 'org))
+
+(provide 'bv-org)
+;;; bv-org.el ends here

--- a/emacs/lisp/bv-reading.el
+++ b/emacs/lisp/bv-reading.el
@@ -1,0 +1,466 @@
+;;; bv-reading.el --- Document and feed reading -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Reading environment for RSS feeds, PDFs, EPUBs, and info documents.
+;; Includes elfeed with saved searches, pdf-tools, nov.el, and enhanced info mode.
+
+;;; Code:
+
+(require 'bv-core)
+
+;;;; Custom Variables
+(defgroup bv-reading nil
+  "Document and feed reading configuration."
+  :group 'bv)
+
+(defcustom bv-reading-directory "~/reading"
+  "Directory for reading materials."
+  :type 'directory
+  :group 'bv-reading)
+
+(defcustom bv-reading-elfeed-directory "~/reading/elfeed"
+  "Directory for elfeed database and configuration."
+  :type 'directory
+  :group 'bv-reading)
+
+(defcustom bv-reading-elfeed-org-files
+  (list (expand-file-name "feeds.org" bv-reading-elfeed-directory))
+  "Org files containing elfeed subscriptions."
+  :type '(repeat file)
+  :group 'bv-reading)
+
+(defcustom bv-reading-elfeed-default-filter "@2-weeks-ago +unread"
+  "Default filter for elfeed."
+  :type 'string
+  :group 'bv-reading)
+
+(defcustom bv-reading-pdf-continuous-scroll t
+  "Enable continuous scroll in PDF viewing."
+  :type 'boolean
+  :group 'bv-reading)
+
+(defcustom bv-reading-nov-text-width t
+  "Text width for nov.el. t means use full window width."
+  :type '(choice (const :tag "Full width" t)
+                 (integer :tag "Fixed width"))
+  :group 'bv-reading)
+
+;;;; Elfeed - RSS/Atom Reader
+(use-package elfeed
+  :bind (("C-x w" . elfeed)
+         :map elfeed-search-mode-map
+         ("q" . bv-reading-elfeed-quit)
+         ("Q" . kill-buffer)
+         ("g" . elfeed-update)
+         ("G" . elfeed-search-update--force)
+         ("f" . bv-reading-elfeed-search-filter)
+         ("F" . bv-reading-elfeed-reset-filter)
+         ("s" . bv-reading-elfeed-save-search)
+         ("S" . bv-reading-elfeed-load-search)
+         ("t" . elfeed-search-set-tag)
+         ("T" . elfeed-search-unset-tag)
+         ("r" . elfeed-search-untag-all-unread)
+         ("R" . elfeed-mark-all-as-read)
+         ("b" . elfeed-search-browse-url)
+         ("y" . elfeed-search-yank)
+         ("+" . elfeed-search-tag-all)
+         ("-" . elfeed-search-untag-all)
+         :map elfeed-show-mode-map
+         ("q" . bv-reading-elfeed-kill-buffer)
+         ("Q" . kill-current-buffer)
+         ("n" . elfeed-show-next)
+         ("p" . elfeed-show-prev)
+         ("b" . elfeed-show-visit)
+         ("y" . elfeed-show-yank)
+         ("t" . elfeed-show-tag)
+         ("T" . elfeed-show-untag)
+         ("s" . bv-reading-elfeed-show-save)
+         ("S" . bv-reading-elfeed-show-save-to-org))
+  :custom
+  (elfeed-db-directory
+   (expand-file-name "db" bv-reading-elfeed-directory))
+  (elfeed-enclosure-default-dir
+   (expand-file-name "enclosures" bv-reading-elfeed-directory))
+  (elfeed-search-filter bv-reading-elfeed-default-filter)
+  (elfeed-search-title-max-width 100)
+  (elfeed-search-title-min-width 30)
+  (elfeed-search-trailing-width 30)
+  (elfeed-show-unique-buffers t)
+  (elfeed-sort-order 'descending)
+  :config
+  ;; Create directories
+  (dolist (dir (list elfeed-db-directory
+                     elfeed-enclosure-default-dir
+                     bv-reading-elfeed-directory))
+    (unless (file-directory-p dir)
+      (make-directory dir t)))
+  
+  ;; Custom faces
+  (custom-set-faces
+   '(elfeed-search-title-face ((t (:foreground "gray50"))))
+   '(elfeed-search-unread-title-face ((t (:weight bold))))
+   '(elfeed-search-date-face ((t (:foreground "gray60"))))
+   '(elfeed-search-feed-face ((t (:foreground "gray70"))))
+   '(elfeed-search-tag-face ((t (:foreground "gray80")))) )
+  
+  ;; Saved searches
+  (defvar bv-reading-elfeed-saved-searches
+    '(("All unread" . "@2-weeks-ago +unread")
+      ("Today" . "@1-day-ago")
+      ("This week" . "@1-week-ago")
+      ("Programming" . "@2-weeks-ago +unread +programming")
+      ("Research" . "@2-weeks-ago +unread +research")
+      ("News" . "@1-day-ago +unread +news")
+      ("Videos" . "@1-week-ago +unread +video")
+      ("Starred" . "+starred")
+      ("Later" . "+later +unread"))
+    "Saved elfeed searches.")
+  
+  (defun bv-reading-elfeed-quit ()
+    "Quit elfeed and bury buffers."
+    (interactive)
+    (elfeed-search-quit-window)
+    (when (get-buffer "*elfeed-log*")
+      (kill-buffer "*elfeed-log*")))
+  
+  (defun bv-reading-elfeed-kill-buffer ()
+    "Kill buffer and return to search."
+    (interactive)
+    (let ((buf (current-buffer)))
+      (elfeed-show-refresh)
+      (elfeed-search-show-entry)
+      (kill-buffer buf)))
+  
+  (defun bv-reading-elfeed-search-filter ()
+    "Set a custom filter interactively."
+    (interactive)
+    (let ((filter (read-string "Filter: " elfeed-search-filter)))
+      (elfeed-search-set-filter filter)))
+  
+  (defun bv-reading-elfeed-reset-filter ()
+    "Reset filter to default."
+    (interactive)
+    (elfeed-search-set-filter bv-reading-elfeed-default-filter))
+  
+  (defun bv-reading-elfeed-save-search ()
+    "Save current search filter."
+    (interactive)
+    (let ((name (read-string "Save search as: "))
+          (filter elfeed-search-filter))
+      (add-to-list 'bv-reading-elfeed-saved-searches
+                   (cons name filter))
+      (message "Saved search: %s" name)))
+  
+  (defun bv-reading-elfeed-load-search ()
+    "Load a saved search."
+    (interactive)
+    (let* ((searches bv-reading-elfeed-saved-searches)
+           (choice (completing-read "Load search: "
+                                    (mapcar #'car searches))))
+      (when-let ((filter (cdr (assoc choice searches))))
+        (elfeed-search-set-filter filter))))
+  
+  (defun bv-reading-elfeed-show-save ()
+    "Save current entry to reading list."
+    (interactive)
+    (elfeed-show-tag 'later)
+    (message "Saved for later reading"))
+  
+  (defun bv-reading-elfeed-show-save-to-org ()
+    "Save current entry to org file."
+    (interactive)
+    (let ((entry elfeed-show-entry))
+      (org-capture nil "e")
+      (insert (elfeed-entry-title entry))
+      (org-capture-finalize)))
+  
+  (defun elfeed-mark-all-as-read ()
+    (interactive)
+    (mark-whole-buffer)
+    (elfeed-search-untag-all-unread)))
+
+;;;; Elfeed Org
+(use-package elfeed-org
+  :after elfeed
+  :config
+  (elfeed-org)
+  (setq rmh-elfeed-org-files bv-reading-elfeed-org-files)
+  
+  ;; Create initial feeds.org
+  (let ((feeds-file (car bv-reading-elfeed-org-files)))
+    (unless (file-exists-p feeds-file)
+      (with-temp-file feeds-file
+        (insert "#+TITLE: Elfeed Subscriptions\n\n")
+        (insert "* Feeds :elfeed:\n")
+        (insert "** Programming :programming:\n")
+        (insert "*** [[https://news.ycombinator.com/rss][Hacker News]]\n")
+        (insert "*** [[https://lobste.rs/rss][Lobsters]]\n")
+        (insert "** Research :research:\n")
+        (insert "*** [[https://arxiv.org/rss/cs.AI][arXiv AI]]\n")
+        (insert "** News :news:\n")
+        (insert "** Blogs :blog:\n")))))
+
+;;;; Elfeed Capture Template
+(with-eval-after-load 'org-capture
+  (add-to-list 'org-capture-templates
+               '("e" "Elfeed" entry
+                 (file+headline bv-reading-elfeed-org-files "Saved")
+                 "*** %:annotation\n:PROPERTIES:\n:CREATED: %U\n:END:\n%i\n"
+                 :immediate-finish t)))
+
+;;;; PDF Tools
+(use-package pdf-tools
+  :mode ("\\.pdf\\'" . pdf-view-mode)
+  :magic ("%PDF" . pdf-view-mode)
+  :bind (:map pdf-view-mode-map
+              ("h" . pdf-annot-add-highlight-markup-annotation)
+              ("t" . pdf-annot-add-text-annotation)
+              ("D" . pdf-annot-delete)
+              ("n" . pdf-view-next-page)
+              ("p" . pdf-view-previous-page)
+              ("d" . pdf-view-next-page)
+              ("u" . pdf-view-previous-page)
+              ("g" . pdf-view-goto-page)
+              ("G" . pdf-view-last-page)
+              ("l" . image-forward-hscroll)
+              ("h" . image-backward-hscroll)
+              ("j" . pdf-view-next-line-or-next-page)
+              ("k" . pdf-view-previous-line-or-previous-page)
+              ("0" . image-bol)
+              ("$" . image-eol)
+              ("m" . pdf-view-set-slice-using-mouse)
+              ("r" . pdf-view-reset-slice)
+              ("R" . pdf-view-rotate)
+              ("+" . pdf-view-enlarge)
+              ("-" . pdf-view-shrink)
+              ("=" . pdf-view-fit-page-to-window)
+              ("f" . pdf-view-fit-page-to-window)
+              ("w" . pdf-view-fit-width-to-window)
+              ("W" . pdf-view-fit-height-to-window)
+              ("/" . pdf-occur)
+              ("C-s" . isearch-forward)
+              ("C-r" . isearch-backward)
+              ("q" . kill-current-buffer))
+  :custom
+  (pdf-view-display-size 'fit-page)
+  (pdf-view-resize-factor 1.05)
+  (pdf-view-continuous-scroll-mode bv-reading-pdf-continuous-scroll)
+  (pdf-view-midnight-colors '("#DCDCCC" . "#383838"))
+  :config
+  (pdf-tools-install :no-query)
+  
+  (defun bv-reading-pdf-view-theme-toggle ()
+    "Toggle between day and night themes in PDF view."
+    (interactive)
+    (if pdf-view-midnight-minor-mode
+        (pdf-view-midnight-minor-mode -1)
+      (pdf-view-midnight-minor-mode 1)))
+  
+  (define-key pdf-view-mode-map "M" 'bv-reading-pdf-view-theme-toggle)
+  
+  ;; Theme integration
+  (bv-with-feature modus-themes
+    (defun bv-reading-pdf-view-themed ()
+      "Apply theme to PDF based on current theme."
+      (when (derived-mode-p 'pdf-view-mode)
+        (if (bv-modus-themes--dark-theme-p)
+            (pdf-view-midnight-minor-mode 1)
+          (pdf-view-midnight-minor-mode -1))))
+    
+    (add-hook 'pdf-view-mode-hook 'bv-reading-pdf-view-themed)
+    (with-eval-after-load 'pdf-view
+      (add-hook 'bv-modus-themes-after-enable-theme-hook
+                (lambda ()
+                  (dolist (buf (buffer-list))
+                    (with-current-buffer buf
+                      (when (derived-mode-p 'pdf-view-mode)
+                        (bv-reading-pdf-view-themed)))))))))
+
+;;;; SavePlace PDF View
+(use-package saveplace-pdf-view
+  :after pdf-tools
+  :config
+  (save-place-mode 1))
+
+;;;; Nov.el - EPUB Reader
+(use-package nov
+  :mode ("\\.epub\\'" . nov-mode)
+  :bind (:map nov-mode-map
+              ("n" . nov-next-document)
+              ("p" . nov-previous-document)
+              ("t" . nov-goto-toc)
+              ("l" . nov-history-back)
+              ("r" . nov-history-forward)
+              ("m" . nov-display-metadata)
+              ("f" . nov-toggle-font-type)
+              ("+" . nov-increase-font-size)
+              ("-" . nov-decrease-font-size)
+              ("=" . nov-default-font-size)
+              ("S" . nov-save-place)
+              ("q" . kill-current-buffer))
+  :custom
+  (nov-text-width bv-reading-nov-text-width)
+  (nov-save-place-file (expand-file-name "nov-places" bv-cache-dir))
+  :config
+  (add-hook 'nov-mode-hook 'visual-line-mode)
+  
+  (bv-with-feature monocle
+    (add-hook 'nov-mode-hook (lambda () (olivetti-mode 1))))
+  
+  (setq nov-shr-rendering-functions
+        '(nov-render-title
+          nov-render-author
+          nov-render-metadata
+          nov-render-content))
+  
+  ;; Justify text
+  (use-package justify-kp
+    :hook (nov-mode . justify-kp-mode)
+    :config
+    (defun bv-reading-nov-window-configuration-change-hook ()
+      (bv-reading-nov-post-html-render-hook)
+      (remove-hook 'window-configuration-change-hook
+                   'bv-reading-nov-window-configuration-change-hook
+                   t))
+    
+    (defun bv-reading-nov-post-html-render-hook ()
+      "Justify text after rendering."
+      (if (get-buffer-window)
+          (let ((max-width (pj-line-width))
+                buffer-read-only)
+            (save-excursion
+              (goto-char (point-min))
+              (while (not (eobp))
+                (when (not (looking-at "^[[:space:]-]*$"))
+                  (goto-char (line-end-position))
+                  (when (> (shr-pixel-column) max-width)
+                    (goto-char (line-beginning-position))
+                    (pj-justify)))
+                (forward-line 1))))
+        (add-hook 'window-configuration-change-hook
+                  'bv-reading-nov-window-configuration-change-hook
+                  nil t)))
+    
+    (add-hook 'nov-post-html-render-hook
+              'bv-reading-nov-post-html-render-hook)) )
+
+;;;; Info Mode Enhancement
+(use-package info
+  :bind (:map Info-mode-map
+              ("n" . Info-next)
+              ("p" . Info-prev)
+              ("u" . Info-up)
+              ("b" . Info-history-back)
+              ("f" . Info-history-forward)
+              ("s" . Info-search)
+              ("S" . Info-search-case-sensitively)
+              ("i" . Info-index)
+              ("I" . Info-virtual-index)
+              ("g" . Info-goto-node)
+              ("t" . Info-top-node)
+              ("T" . Info-toc)
+              ("m" . Info-menu)
+              ("d" . Info-directory)
+              ("?" . Info-summary)
+              ("q" . kill-this-buffer))
+  :custom
+  (Info-use-header-line nil)
+  (Info-fontify-maximum-menu-size 100000)
+  :config
+  (set-face-attribute 'info-title-1 nil :height 1.3)
+  (set-face-attribute 'info-title-2 nil :height 1.2)
+  (set-face-attribute 'info-title-3 nil :height 1.1)
+  
+  (add-hook 'Info-mode-hook 'visual-line-mode))
+
+;;;; Info Plus
+(use-package info+
+  :after info
+  :config
+  (setq Info-fontify-quotations t)
+  (setq Info-fontify-reference-items-flag t)
+  (setq Info-saved-history-file
+        (expand-file-name "info-history" bv-cache-dir))
+  (setq Info-persist-history-mode t))
+
+;;;; Enhanced Info Faces
+(bv-with-feature modus-themes
+  (with-eval-after-load 'info
+    (defun bv-reading-info-set-custom-faces ()
+      "Apply custom faces to Info mode."
+      (face-remap-add-relative 'default :inherit 'variable-pitch)
+      (face-remap-add-relative 'fixed-pitch :inherit 'default))
+    
+    (add-hook 'Info-mode-hook 'bv-reading-info-set-custom-faces)))
+
+;;;; Reading List Management
+(defvar bv-reading-list-file
+  (expand-file-name "reading-list.org" bv-reading-directory)
+  "File to store reading list.")
+
+(defun bv-reading-add-to-list (title url &optional notes)
+  "Add TITLE with URL to reading list with optional NOTES."
+  (interactive "sTitle: \nsURL: ")
+  (with-current-buffer (find-file-noselect bv-reading-list-file)
+    (goto-char (point-max))
+    (insert (format "* TODO %s\n" title))
+    (insert (format "  :PROPERTIES:\n  :URL: %s\n  :ADDED: %s\n  :END:\n"
+                    url (format-time-string "%Y-%m-%d %H:%M")))
+    (when notes
+      (insert (format "  %s\n" notes)))
+    (save-buffer))
+  (message "Added to reading list: %s" title))
+
+;;;; Unified Reading Interface
+(defun bv-reading-open-url (url)
+  "Open URL in appropriate reader based on content type."
+  (interactive "sURL: ")
+  (cond
+   ((string-match-p "\\.pdf\\'" url)
+    (url-copy-file url (make-temp-file "pdf-" nil ".pdf") t)
+    (find-file (make-temp-file "pdf-" nil ".pdf")))
+   ((string-match-p "\\.epub\\'" url)
+    (url-copy-file url (make-temp-file "epub-" nil ".epub") t)
+    (find-file (make-temp-file "epub-" nil ".epub")))
+   ((string-match-p "^\\(https?\\|feed\\)://" url)
+    (browse-url url))
+   (t
+    (message "Unknown URL type: %s" url))))
+
+;;;; Keybindings
+(with-eval-after-load 'bv-core
+  (define-prefix-command 'bv-reading-map)
+  (define-key bv-app-map "R" 'bv-reading-map)
+  
+  (define-key bv-reading-map "e" 'elfeed)
+  (define-key bv-reading-map "p" 'pdf-tools-install)
+  (define-key bv-reading-map "i" 'info)
+  (define-key bv-reading-map "l" (lambda () (interactive)
+                                    (find-file bv-reading-list-file)))
+  (define-key bv-reading-map "a" 'bv-reading-add-to-list)
+  (define-key bv-reading-map "u" 'bv-reading-open-url))
+
+;;;; Feature Definition
+(defun bv-reading-load ()
+  "Load reading configuration."
+  (add-to-list 'bv-enabled-features 'reading)
+  
+  ;; Create directories
+  (dolist (dir (list bv-reading-directory
+                     bv-reading-elfeed-directory))
+    (unless (file-directory-p dir)
+      (make-directory dir t)))
+  
+  ;; Create reading list file
+  (unless (file-exists-p bv-reading-list-file)
+    (with-temp-file bv-reading-list-file
+      (insert "#+TITLE: Reading List\n")
+      (insert "#+STARTUP: overview\n\n")))
+  
+  ;; Add Info directories
+  (with-eval-after-load 'info
+    (add-to-list 'Info-directory-list
+                 (expand-file-name "info" bv-reading-directory))))
+
+(provide 'bv-reading)
+;;; bv-reading.el ends here

--- a/emacs/lisp/bv-research.el
+++ b/emacs/lisp/bv-research.el
@@ -1,0 +1,407 @@
+;;; bv-research.el --- Research and knowledge management -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Research environment with Zettelkasten (org-roam), bibliography management (citar), 
+;; and PDF annotation workflow.
+
+;;; Code:
+
+(require 'bv-core)
+(require 'bv-org)
+
+;;;; Custom Variables
+(defgroup bv-research nil
+  "Research and knowledge management configuration."
+  :group 'bv)
+
+(defcustom bv-research-directory "~/research"
+  "Root directory for research files."
+  :type 'directory
+  :group 'bv-research)
+
+(defcustom bv-research-roam-directory "~/research/roam"
+  "Directory for org-roam notes."
+  :type 'directory
+  :group 'bv-research)
+
+(defcustom bv-research-bibliography-directory "~/research/bibliography"
+  "Directory for bibliography files and PDFs."
+  :type 'directory
+  :group 'bv-research)
+
+(defcustom bv-research-global-bibliography
+  '("~/research/bibliography/references.bib")
+  "List of bibliography files."
+  :type '(repeat file)
+  :group 'bv-research)
+
+(defcustom bv-research-library-paths
+  '("~/research/bibliography/pdfs")
+  "Paths to PDF libraries."
+  :type '(repeat directory)
+  :group 'bv-research)
+
+(defcustom bv-research-notes-paths
+  '("~/research/roam/references")
+  "Paths for literature notes."
+  :type '(repeat directory)
+  :group 'bv-research)
+
+(defcustom bv-research-capture-templates t
+  "Use default capture templates for research."
+  :type 'boolean
+  :group 'bv-research)
+
+(defcustom bv-research-org-roam-todo t
+  "Enable org-roam based task management."
+  :type 'boolean
+  :group 'bv-research)
+
+(defcustom bv-research-bibtex-dialect 'biblatex
+  "BibTeX dialect to use."
+  :type '(choice (const bibtex) (const biblatex))
+  :group 'bv-research)
+
+;;;; Org Roam - Zettelkasten
+(use-package org-roam
+  :custom
+  (org-roam-directory bv-research-roam-directory)
+  (org-roam-completion-everywhere t)
+  (org-roam-capture-templates
+   (when bv-research-capture-templates
+     '(("d" "default" plain "%?"
+        :target (file+head "${slug}.org"
+                          "#+title: ${title}\n#+date: %U\n#+filetags:\n\n")
+        :unnarrowed t)
+       ("r" "reference" plain "%?"
+        :target (file+head "references/${citar-citekey}.org"
+                          "#+title: ${citar-title}\n#+date: %U\n#+filetags: :reference:\n\n* Notes\n")
+        :unnarrowed t)
+       ("p" "project" plain "%?"
+        :target (file+head "projects/${slug}.org"
+                          "#+title: ${title}\n#+date: %U\n#+filetags: :project:\n\n* Overview\n\n* Tasks\n")
+        :unnarrowed t)
+       ("c" "concept" plain "%?"
+        :target (file+head "concepts/${slug}.org"
+                          "#+title: ${title}\n#+date: %U\n#+filetags: :concept:\n\n* Definition\n\n* Examples\n")
+        :unnarrowed t))))
+  :bind (("C-c n n" . org-roam-buffer-toggle)
+         ("C-c n f" . org-roam-node-find)
+         ("C-c n i" . org-roam-node-insert)
+         ("C-c n r" . org-roam-ref-find)
+         ("C-c n R" . bv-research-org-roam-ref-add)
+         ("C-c n g" . org-roam-graph)
+         ("C-c n c" . org-roam-capture)
+         ("C-c n j" . org-roam-dailies-goto-today)
+         ("C-c n t" . org-roam-tag-add)
+         ("C-c n T" . org-roam-tag-remove)
+         ("C-c n a" . org-roam-alias-add)
+         ("C-c n A" . org-roam-alias-remove)
+         :map org-mode-map
+         ("C-M-i" . completion-at-point))
+  :config
+  ;; Create directories
+  (dolist (dir '("" "references" "projects" "concepts" "daily"))
+    (let ((path (expand-file-name dir org-roam-directory)))
+      (unless (file-directory-p path)
+        (make-directory path t))))
+  
+  (setq org-roam-db-location
+        (expand-file-name "org-roam.db" bv-cache-dir))
+  
+  ;; Node display
+  (cl-defmethod org-roam-node-type ((node org-roam-node))
+    "Return the TYPE of NODE."
+    (condition-case nil
+        (file-name-nondirectory
+         (directory-file-name
+          (file-name-directory
+           (file-relative-name (org-roam-node-file node)
+                               org-roam-directory))))
+      (error "")))
+  
+  (setq org-roam-node-display-template
+        (concat "${type:15} ${title:80} "
+                (propertize "${tags:20}" 'face 'org-tag)))
+  
+  (org-roam-db-autosync-enable)
+  
+  (defun bv-research-org-roam-ref-add (ref node)
+    "Add REF to NODE."
+    (interactive
+     (list
+      (read-string "Ref: ")
+      (org-roam-node-read)))
+    (if-let ((file (org-roam-node-file node)))
+        (with-current-buffer (or (find-buffer-visiting file)
+                                 (find-file-noselect file))
+          (org-roam-property-add "ROAM_REFS" ref)
+          (save-buffer))
+      (org-roam-capture-
+       :keys "r"
+       :node node
+       :info `(:ref ,ref)
+       :templates org-roam-capture-templates
+       :props '(:finalize find-file))))
+  
+  ;; TODO management
+  (when bv-research-org-roam-todo
+    (defun bv-research-org-roam-todo-p ()
+      "Return non-nil if the current buffer has any to-do entry."
+      (org-element-map
+          (org-element-parse-buffer 'headline)
+          'headline
+        (lambda (h)
+          (eq (org-element-property :todo-type h) 'todo))
+        nil 'first-match))
+    
+    (defun bv-research-org-roam-update-todo-tag ()
+      "Update the todo tag in the current buffer."
+      (when (and (not (active-minibuffer-window))
+                 (org-roam-file-p))
+        (org-with-point-at 1
+          (let* ((tags (org-get-tags))
+                 (is-todo (bv-research-org-roam-todo-p)))
+            (cond ((and is-todo (not (member "todo" tags)))
+                   (org-roam-tag-add '("todo")))
+                  ((and (not is-todo) (member "todo" tags))
+                   (org-roam-tag-remove '("todo"))))))))
+    
+    (add-hook 'org-roam-find-file-hook 'bv-research-org-roam-update-todo-tag)
+    (add-hook 'before-save-hook 'bv-research-org-roam-update-todo-tag)))
+
+;;;; Citar - Bibliography Management
+(use-package citar
+  :custom
+  (org-cite-global-bibliography bv-research-global-bibliography)
+  (org-cite-insert-processor 'citar)
+  (org-cite-follow-processor 'citar)
+  (org-cite-activate-processor 'citar)
+  (citar-bibliography org-cite-global-bibliography)
+  (citar-library-paths bv-research-library-paths)
+  (citar-notes-paths bv-research-notes-paths)
+  (citar-symbols
+   `((file . (,(all-the-icons-faicon "file-o" :v-adjust -0.1) . " "))
+     (note . (,(all-the-icons-material "speaker_notes" :v-adjust -0.3) . " "))
+     (link . (,(all-the-icons-octicon "link" :v-adjust 0.01) . " "))))
+  :hook
+  (LaTeX-mode . citar-capf-setup)
+  (org-mode . citar-capf-setup)
+  :bind
+  (:map org-mode-map
+        ("C-c b" . org-cite-insert)
+        :map global-map
+        ("C-c n b" . bv-research-find-bibliography))
+  :config
+  (setq org-cite-export-processors
+        '((latex biblatex)
+          (t csl)))
+  
+  (unless (file-directory-p bv-research-bibliography-directory)
+    (make-directory bv-research-bibliography-directory t))
+  
+  (defun bv-research-find-bibliography ()
+    "Open main bibliography file."
+    (interactive)
+    (find-file (car bv-research-global-bibliography))))
+
+;;;; Citar Org Roam - Integration
+(use-package citar-org-roam
+  :after (citar org-roam)
+  :custom
+  (citar-org-roam-note-title-template "${author} - ${title}")
+  (citar-org-roam-subdir "references")
+  :config
+  (citar-org-roam-mode 1))
+
+;;;; Embark Integration
+(use-package citar-embark
+  :after (citar embark)
+  :config
+  (citar-embark-mode 1))
+
+;;;; Org Cite Configuration
+(use-package oc
+  :after org
+  :config
+  (require 'oc-biblatex)
+  (require 'oc-csl)
+  
+  (setq bibtex-dialect bv-research-bibtex-dialect)
+  (setq bibtex-align-at-equal-sign t)
+  (setq bibtex-autokey-year-title-separator "-")
+  (setq bibtex-autokey-year-length 4)
+  (setq bibtex-autokey-titleword-separator "-")
+  (setq bibtex-autokey-titlewords 3))
+
+;;;; Zotra - Zotero Integration
+(use-package zotra
+  :defer t
+  :bind (("C-c z a" . zotra-add-entry)
+         ("C-c z s" . zotra-add-entry-from-search)
+         ("C-c z u" . zotra-add-entry-from-url))
+  :custom
+  (zotra-backend 'translation-server)
+  (zotra-url-retrieve-timeout 10)
+  (zotra-default-entry-format (symbol-name bv-research-bibtex-dialect))
+  (zotra-default-bibliography (car bv-research-global-bibliography))
+  :config
+  (unless (executable-find "translation-server")
+    (message "Warning: translation-server not found. \
+Install from https://github.com/zotero/translation-server")))
+
+;;;; PDF Tools Integration
+(use-package pdf-tools
+  :defer t
+  :mode ("\\.pdf\\'" . pdf-view-mode)
+  :config
+  (pdf-tools-install)
+  
+  (defun bv-research-open-pdf (entry)
+    "Open PDF for bibliography ENTRY."
+    (interactive)
+    (when-let ((file (citar-get-files entry)))
+      (find-file (car file)))))
+
+;;;; Org Noter - PDF Annotations
+(use-package org-noter
+  :after (:any org pdf-tools)
+  :bind (:map org-mode-map
+              ("C-c N" . org-noter))
+  :custom
+  (org-noter-notes-search-path bv-research-notes-paths)
+  (org-noter-always-create-frame nil)
+  (org-noter-auto-save-last-location t)
+  (org-noter-default-notes-file-names '("notes.org"))
+  (org-noter-doc-split-fraction '(0.6 . 0.4))
+  (org-noter-kill-frame-at-session-end nil)
+  (org-noter-notes-window-location 'horizontal-split)
+  :config
+  (defun bv-research-noter-from-citar ()
+    "Open org-noter session from citar selection."
+    (interactive)
+    (let* ((entry (citar-select-ref))
+           (files (citar-get-files entry))
+           (notes (citar-get-notes entry)))
+      (when files
+        (if notes
+            (progn
+              (find-file (car notes))
+              (org-noter))
+          (message "Create a note first with citar-open-notes")))))
+
+;;;; Org Ref (Alternative - disabled by default)
+(use-package org-ref
+  :after org
+  :disabled t
+  :custom
+  (org-ref-bibliography-notes
+   (expand-file-name "notes.org" bv-research-bibliography-directory))
+  (org-ref-default-bibliography bv-research-global-bibliography)
+  (org-ref-pdf-directory (car bv-research-library-paths)))
+
+;;;; Research Workflow Commands
+(defun bv-research-new-project (name)
+  "Create a new research project with NAME."
+  (interactive "sProject name: ")
+  (let ((slug (org-roam-node--slug name)))
+    (org-roam-capture- :keys "p"
+                       :node (org-roam-node-create :title name)
+                       :props '(:finalize find-file))))
+
+(defun bv-research-literature-review ()
+  "Start a literature review session."
+  (interactive)
+  (let ((topic (read-string "Review topic: ")))
+    (org-roam-node-find nil topic)
+    (split-window-right)
+    (other-window 1)
+    (citar-open)))
+
+(defun bv-research-export-bibliography ()
+  "Export bibliography to various formats."
+  (interactive)
+  (let ((format (completing-read "Export format: "
+                                 '("html" "markdown" "plain"))))
+    (cond
+     ((string= format "html")
+      (shell-command
+       (format "pandoc %s -o bibliography.html --citeproc"
+               (car bv-research-global-bibliography))))
+     ((string= format "markdown")
+      (shell-command
+       (format "bibtex2md %s > bibliography.md"
+               (car bv-research-global-bibliography))))
+     ((string= format "plain")
+      (shell-command
+       (format "bibtex2txt %s > bibliography.txt"
+               (car bv-research-global-bibliography)))))))
+
+;;;; Templates
+(bv-with-feature tempel
+  (with-eval-after-load 'tempel
+    (defvar bv-research-tempel-templates
+      '(org-mode
+        ;; Citations
+        (cite "[[cite:@" p "]]")
+        (citet "[[citet:@" p "]]")
+        (citep "[[citep:@" p "]]")
+        (citeauthor "[[citeauthor:@" p "]]")
+        (citeyear "[[citeyear:@" p "]]")
+        
+        ;; Research notes
+        (paper "* " p " [[cite:@" p "]]\n:PROPERTIES:\n:NOTER_DOCUMENT: \n:END:\n** Summary\n** Key Points\n** Questions\n** Relevance")
+        (hypothesis "* Hypothesis: " p "\n** Background\n** Prediction\n** Method\n** Evidence")
+        (litreview "* Literature Review: " p "\n** Scope\n** Search Strategy\n** Key Papers\n** Synthesis\n** Gaps")
+        (researchq "* RQ: " p "\n** Context\n** Question\n** Importance\n** Approach"))
+      "Research-specific templates.")
+    
+    (add-to-list 'tempel-template-sources 'bv-research-tempel-templates)))
+
+;;;; Keybindings
+(with-eval-after-load 'bv-core
+  (define-prefix-command 'bv-research-map)
+  (define-key bv-app-map "r" 'bv-research-map)
+  
+  (define-key bv-research-map "p" 'bv-research-new-project)
+  (define-key bv-research-map "l" 'bv-research-literature-review)
+  (define-key bv-research-map "n" 'bv-research-noter-from-citar)
+  (define-key bv-research-map "e" 'bv-research-export-bibliography)
+  (define-key bv-research-map "b" 'citar-open)
+  (define-key bv-research-map "f" 'citar-open-files)
+  (define-key bv-research-map "N" 'citar-open-notes))
+
+;;;; Feature Definition
+(defun bv-research-load ()
+  "Load research configuration."
+  (add-to-list 'bv-enabled-features 'research)
+  
+  ;; Create research directories
+  (dolist (dir (list bv-research-directory
+                     bv-research-roam-directory
+                     bv-research-bibliography-directory
+                     (car bv-research-library-paths)
+                     (car bv-research-notes-paths)))
+    (unless (file-directory-p dir)
+      (make-directory dir t)))
+  
+  ;; Create initial bibliography file
+  (let ((bib-file (car bv-research-global-bibliography)))
+    (unless (file-exists-p bib-file)
+      (with-temp-file bib-file
+        (insert "% Bibliography file\n")
+        (insert "% Created by bv-research\n\n"))))
+  
+  ;; Update org-agenda-files for roam-todo
+  (when bv-research-org-roam-todo
+    (defun bv-research-org-roam-update-todo-files (&rest _)
+      "Update the value of `org-agenda-files'."
+      (setq org-agenda-files
+            (delete-dups
+             (append org-agenda-files
+                     (org-roam-list-files)))))
+    
+    (advice-add 'org-agenda :before 'bv-research-org-roam-update-todo-files)))
+
+(provide 'bv-research)
+;;; bv-research.el ends here

--- a/emacs/lisp/bv-writing.el
+++ b/emacs/lisp/bv-writing.el
@@ -1,0 +1,452 @@
+;;; bv-writing.el --- Writing and documentation tools -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Writing environment for academic papers, documentation, and general content.
+;; Includes spell checking, grammar checking, LaTeX, Markdown, and academic writing tools.
+
+;;; Code:
+
+(require 'bv-core)
+
+;;;; Custom Variables
+(defgroup bv-writing nil
+  "Writing and documentation configuration."
+  :group 'bv)
+
+;;; Spell Checking
+(defcustom bv-writing-spelling-program
+  (cond ((executable-find "aspell") 'aspell)
+        ((executable-find "hunspell") 'hunspell)
+        (t 'ispell))
+  "Spell checking program to use."
+  :type '(choice (const :tag "Aspell" aspell)
+                 (const :tag "Hunspell" hunspell)
+                 (const :tag "Ispell" ispell))
+  :group 'bv-writing)
+
+(defcustom bv-writing-spelling-dictionaries
+  '("en_US" "en_GB")
+  "List of dictionaries to use for spell checking."
+  :type '(repeat string)
+  :group 'bv-writing)
+
+(defcustom bv-writing-default-dictionary "en_US"
+  "Default dictionary for spell checking."
+  :type 'string
+  :group 'bv-writing)
+
+(defcustom bv-writing-personal-dictionary
+  (expand-file-name "aspell.personal" user-emacs-directory)
+  "Personal dictionary file."
+  :type 'file
+  :group 'bv-writing)
+
+(defcustom bv-writing-flyspell-prog-modes
+  '(prog-mode-hook)
+  "Hooks to enable flyspell-prog-mode."
+  :type '(repeat hook)
+  :group 'bv-writing)
+
+(defcustom bv-writing-flyspell-text-modes
+  '(text-mode-hook
+    org-mode-hook
+    markdown-mode-hook
+    LaTeX-mode-hook)
+  "Hooks to enable flyspell-mode."
+  :type '(repeat hook)
+  :group 'bv-writing)
+
+;;; Grammar Checking
+(defcustom bv-writing-grammar-checker
+  (cond ((executable-find "languagetool") 'languagetool)
+        (t 'writegood))
+  "Grammar checker to use."
+  :type '(choice (const :tag "LanguageTool" languagetool)
+                 (const :tag "Writegood Mode" writegood))
+  :group 'bv-writing)
+
+(defcustom bv-writing-languagetool-server-url
+  "http://localhost:8081"
+  "URL for LanguageTool server."
+  :type 'string
+  :group 'bv-writing)
+
+;;; LaTeX Configuration
+(defcustom bv-writing-latex-engine 'xelatex
+  "Default LaTeX engine."
+  :type '(choice (const :tag "PDFLaTeX" pdflatex)
+                 (const :tag "XeLaTeX" xelatex)
+                 (const :tag "LuaLaTeX" lualatex))
+  :group 'bv-writing)
+
+(defcustom bv-writing-latex-preview-scale 1.2
+  "Scale factor for LaTeX preview."
+  :type 'number
+  :group 'bv-writing)
+
+;;; Academic Writing
+(defcustom bv-writing-bibliography-directory
+  (expand-file-name "~/Documents/bibliography/")
+  "Directory containing bibliography files."
+  :type 'directory
+  :group 'bv-writing)
+
+(defcustom bv-writing-default-bibliography
+  (expand-file-name "references.bib" bv-writing-bibliography-directory)
+  "Default bibliography file."
+  :type 'file
+  :group 'bv-writing)
+
+;;;; Configuration
+
+;;; Core Spell Checking
+(use-package ispell
+  :defer t
+  :config
+  (setq ispell-program-name
+        (pcase bv-writing-spelling-program
+          ('aspell (executable-find "aspell"))
+          ('hunspell (executable-find "hunspell"))
+          (_ (executable-find "ispell"))))
+  
+  (when (eq bv-writing-spelling-program 'aspell)
+    (setq ispell-extra-args '("--sug-mode=ultra" "--lang=en_US")))
+  
+  (when (eq bv-writing-spelling-program 'hunspell)
+    (setq ispell-dictionary "en_US")
+    (setq ispell-local-dictionary-alist
+          '(("en_US" "[[:alpha:]]" "[^[:alpha:]]" "['"]" nil ("-d" "en_US") nil utf-8))))
+  
+  (setq ispell-dictionary bv-writing-default-dictionary)
+  (setq ispell-personal-dictionary bv-writing-personal-dictionary)
+  (setq ispell-silently-savep t))
+
+(use-package flyspell
+  :diminish
+  :hook ((text-mode . flyspell-mode)
+         (prog-mode . flyspell-prog-mode))
+  :config
+  (setq flyspell-issue-message-flag nil)
+  (setq flyspell-issue-welcome-flag nil)
+  (setq flyspell-large-region 1)
+  
+  (dolist (hook '(org-mode-hook markdown-mode-hook))
+    (add-hook hook
+              (lambda ()
+                (setq flyspell-generic-check-word-predicate
+                      'bv-writing-flyspell-generic-check-word-predicate))))
+  
+  :bind (:map flyspell-mode-map
+              ("C-;" . flyspell-correct-wrapper)))
+
+(use-package flyspell-correct
+  :after flyspell
+  :bind (:map flyspell-mode-map
+              ("C-;" . flyspell-correct-wrapper)))
+
+(use-package flyspell-correct-ivy
+  :after (flyspell-correct ivy))
+
+;;; Grammar and Style Checking
+(use-package writegood-mode
+  :diminish
+  :hook ((text-mode . writegood-mode)
+         (LaTeX-mode . writegood-mode))
+  :config
+  (setq writegood-weasel-words
+        '("very" "quite" "really" "extremely" "fairly" "pretty"
+          "somewhat" "rather" "arguably" "basically" "essentially"
+          "generally" "typically" "usually" "often" "sometimes"
+          "just" "simply" "merely" "actually" "virtually")))
+
+;; LanguageTool integration
+(use-package langtool
+  :if (executable-find "languagetool")
+  :defer t
+  :config
+  (setq langtool-language-tool-server-jar
+        "/usr/share/java/languagetool/languagetool-server.jar")
+  (setq langtool-default-language "en-US")
+  (setq langtool-mother-tongue "en")
+  :bind (("C-c L c" . langtool-check)
+         ("C-c L d" . langtool-check-done)
+         ("C-c L s" . langtool-server-mode-toggle)
+         ("C-c L n" . langtool-goto-next-error)
+         ("C-c L p" . langtool-goto-previous-error)
+         ("C-c L ." . langtool-correct-buffer)))
+
+;;; LaTeX Support
+(use-package tex
+  :defer t
+  :mode ("\\.tex\\'" . LaTeX-mode)
+  :config
+  (setq TeX-auto-save t)
+  (setq TeX-parse-self t)
+  (setq TeX-master nil)
+  (setq-default TeX-engine bv-writing-latex-engine)
+  
+  (setq LaTeX-section-hook
+        '(LaTeX-section-heading
+          LaTeX-section-title
+          LaTeX-section-toc
+          LaTeX-section-section
+          LaTeX-section-label))
+  
+  (setq TeX-PDF-mode t)
+  (setq TeX-source-correlate-mode t)
+  (setq TeX-source-correlate-method 'synctex)
+  
+  (setq TeX-view-program-selection
+        '((output-pdf "PDF Tools")
+          (output-dvi "xdvi")))
+  (setq TeX-view-program-list
+        '(("PDF Tools" TeX-pdf-tools-sync-view)))
+  
+  (setq LaTeX-clean-intermediate-suffixes
+        '("\\.aux" "\\.bbl" "\\.blg" "\\.brf" "\\.fot"
+          "\\.glo" "\\.gls" "\\.idx" "\\.ilg" "\\.ind"
+          "\\.lof" "\\.log" "\\.lot" "\\.nav" "\\.out"
+          "\\.snm" "\\.toc" "\\.url" "\\.synctex\\.gz"
+          "\\.bcf" "\\.run\\.xml" "\\.fls" "\\.fdb_latexmk"))
+  
+  (add-hook 'LaTeX-mode-hook 'turn-on-reftex)
+  (setq reftex-plug-into-AUCTeX t)
+  (add-hook 'LaTeX-mode-hook 'LaTeX-math-mode)
+  (add-hook 'LaTeX-mode-hook 'TeX-fold-mode)
+  (add-hook 'LaTeX-mode-hook 'visual-line-mode)
+  (add-hook 'LaTeX-mode-hook 'flyspell-mode)
+  (add-hook 'LaTeX-mode-hook 'LaTeX-preview-setup)
+  
+  (setq LaTeX-section-list
+        '(("part" 0)
+          ("chapter" 1)
+          ("section" 2)
+          ("subsection" 3)
+          ("subsubsection" 4)
+          ("paragraph" 5)
+          ("subparagraph" 6))))
+
+(use-package reftex
+  :defer t
+  :config
+  (setq reftex-cite-format 'natbib)
+  (setq reftex-default-bibliography (list bv-writing-default-bibliography))
+  (setq reftex-bibpath-environment-variables '("BIBINPUTS" "TEXBIB"))
+  (setq reftex-cite-prompt-optional-args t))
+
+(use-package auctex-latexmk
+  :after tex
+  :config
+  (auctex-latexmk-setup)
+  (setq auctex-latexmk-inherit-TeX-PDF-mode t))
+
+(use-package company-auctex
+  :after (tex company)
+  :config
+  (company-auctex-init))
+
+;; CDLaTeX for fast math input
+(use-package cdlatex
+  :hook ((LaTeX-mode . cdlatex-mode)
+         (org-mode . org-cdlatex-mode))
+  :config
+  (setq cdlatex-paired-parens "$[{("))
+
+;;; Markdown Support
+(use-package markdown-mode
+  :mode (("README\\.md\\'" . gfm-mode)
+         ("\\.md\\'" . markdown-mode)
+         ("\\.markdown\\'" . markdown-mode))
+  :init
+  (setq markdown-command
+        (cond ((executable-find "pandoc")
+               "pandoc -f markdown -t html5 --mathjax --highlight-style=pygments --standalone")
+              ((executable-find "markdown")
+               "markdown")
+              (t nil)))
+  :config
+  (setq markdown-enable-math t)
+  (setq markdown-enable-wiki-links t)
+  (setq markdown-italic-underscore t)
+  (setq markdown-asymmetric-header t)
+  (setq markdown-make-gfm-checkboxes-buttons t)
+  (setq markdown-gfm-uppercase-checkbox t)
+  (setq markdown-fontify-code-blocks-natively t)
+  (setq markdown-hide-urls nil)
+  (setq markdown-indent-on-enter 'indent-and-new-item)
+  (setq markdown-preview-stylesheets
+        (list "https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.1.0/github-markdown-light.min.css"))
+  
+  :bind (:map markdown-mode-map
+              ("C-c C-e" . markdown-export)
+              ("C-c C-v" . markdown-preview)
+              ("C-c C-c m" . markdown-other-window)
+              ("C-c C-c p" . markdown-preview-mode)
+              ("C-c C-c l" . markdown-live-preview-mode)
+              ("C-c C-x C-i" . markdown-insert-image)))
+
+;; Pandoc integration
+(use-package pandoc-mode
+  :hook ((markdown-mode . pandoc-mode)
+         (org-mode . pandoc-mode))
+  :config
+  (setq pandoc-data-dir (expand-file-name "pandoc/" user-emacs-directory)))
+
+;; Table of contents for markdown
+(use-package markdown-toc
+  :after markdown-mode
+  :bind (:map markdown-mode-map
+              ("C-c C-x t" . markdown-toc-generate-or-refresh-toc)))
+
+;;; Academic Writing Tools
+(use-package academic-phrases
+  :defer t
+  :bind ("C-c w a" . academic-phrases)
+  :config
+  (setq academic-phrases-by-section t))
+
+;; Better prose editing
+(use-package visual-fill-column
+  :hook ((text-mode . visual-fill-column-mode)
+         (org-mode . visual-fill-column-mode))
+  :config
+  (setq-default visual-fill-column-width 80)
+  (setq-default visual-fill-column-center-text t))
+
+;; Focus mode for writing
+(use-package olivetti
+  :defer t
+  :bind ("C-c w f" . olivetti-mode)
+  :config
+  (setq-default olivetti-body-width 80)
+  (setq olivetti-minimum-body-width 72)
+  (setq olivetti-style 'fancy))
+
+;; Word counting
+(use-package wc-mode
+  :hook ((text-mode . wc-mode)
+         (LaTeX-mode . wc-mode))
+  :config
+  (setq wc-modeline-format "[%tw/%gw]"))
+
+;;; Bibliography Management Integration
+(with-eval-after-load 'citar
+  (setq citar-bibliography (list bv-writing-default-bibliography)))
+
+;;; Export and Conversion
+(use-package ox-pandoc
+  :after org
+  :config
+  (setq org-pandoc-options-for-latex-pdf '((pdf-engine . "xelatex")))
+  (setq org-pandoc-options-for-beamer-pdf '((pdf-engine . "xelatex"))))
+
+;;; Helper Functions
+(defun bv-writing-flyspell-generic-check-word-predicate ()
+  "Don't check spelling in code blocks, links, etc."
+  (let ((face (get-text-property (point) 'face)))
+    (not (memq face '(font-lock-comment-face
+                      font-lock-doc-face
+                      font-lock-string-face
+                      font-latex-math-face
+                      org-block
+                      org-code
+                      org-date
+                      org-link
+                      org-special-keyword
+                      markdown-code-face
+                      markdown-inline-code-face
+                      markdown-pre-face
+                      markdown-url-face)))))
+
+(defun bv-writing-count-words-region (start end)
+  "Count words in region from START to END."
+  (interactive "r")
+  (let ((count (count-words start end)))
+    (message "Region has %d words" count)))
+
+(defun bv-writing-insert-citation ()
+  "Insert citation using citar if available, otherwise use reftex."
+  (interactive)
+  (cond ((fboundp 'citar-insert-citation)
+         (citar-insert-citation))
+        ((derived-mode-p 'latex-mode)
+         (reftex-citation))
+        (t (user-error "No citation method available"))))
+
+(defun bv-writing-export-to-pdf ()
+  "Export current document to PDF using appropriate method."
+  (interactive)
+  (cond ((derived-mode-p 'org-mode)
+         (org-export-dispatch nil ?p))
+        ((derived-mode-p 'markdown-mode)
+         (if (fboundp 'pandoc-convert-to-pdf)
+             (pandoc-convert-to-pdf)
+           (markdown-export)))
+        ((derived-mode-p 'latex-mode)
+         (TeX-command-master))
+        (t (user-error "Don't know how to export this document type"))))
+
+(defun bv-writing-check-grammar ()
+  "Check grammar using configured grammar checker."
+  (interactive)
+  (pcase bv-writing-grammar-checker
+    ('languagetool
+     (if (fboundp 'langtool-check)
+         (langtool-check)
+       (writegood-mode 1)))
+    ('writegood
+     (writegood-mode 1))))
+
+;;; Mode Hooks
+(defun bv-writing-text-mode-setup ()
+  "Setup for text writing modes."
+  (setq-local fill-column 80)
+  (turn-on-auto-fill)
+  (flyspell-mode 1)
+  (writegood-mode 1))
+
+(defun bv-writing-latex-mode-setup ()
+  "Additional LaTeX mode setup."
+  (setq-local TeX-electric-math '("$" . "$"))
+  (setq-local TeX-electric-sub-and-superscript t)
+  (turn-on-reftex))
+
+;;; Global Keybindings
+(with-eval-after-load 'bv-core
+  (bv-leader
+    "w" '(:ignore t :which-key "writing")
+    "w c" #'bv-writing-insert-citation
+    "w e" #'bv-writing-export-to-pdf
+    "w g" #'bv-writing-check-grammar
+    "w s" #'flyspell-correct-wrapper
+    "w S" #'ispell-buffer
+    "w w" #'bv-writing-count-words-region
+    "w f" #'olivetti-mode
+    "w a" #'academic-phrases))
+
+;;;; Feature Definition
+(defun bv-writing-load ()
+  "Load writing configuration."
+  (add-to-list 'bv-enabled-features 'writing)
+  
+  ;; Setup hooks
+  (dolist (hook bv-writing-flyspell-prog-modes)
+    (add-hook hook 'flyspell-prog-mode))
+  
+  (dolist (hook bv-writing-flyspell-text-modes)
+    (add-hook hook 'flyspell-mode))
+  
+  (add-hook 'text-mode-hook #'bv-writing-text-mode-setup)
+  (add-hook 'LaTeX-mode-hook #'bv-writing-latex-mode-setup)
+  
+  ;; Create personal dictionary
+  (let ((dict-dir (file-name-directory bv-writing-personal-dictionary)))
+    (unless (file-exists-p dict-dir)
+      (make-directory dict-dir t)))
+  
+  (unless (file-exists-p bv-writing-personal-dictionary)
+    (with-temp-file bv-writing-personal-dictionary
+      (insert "personal_ws-1.1 en 0\n"))))
+
+(provide 'bv-writing)
+;;; bv-writing.el ends here


### PR DESCRIPTION
## Summary
- turn on Phase 4 research infrastructure in `emacs/init.el`
- add Org, research, reading, and writing modules
- record research module addition in `CHANGELOG.md`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684a78fd023c832babe7f347b9078cca