### PR TITLE
Add extended productivity modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   and Git integration. Phase 2 now enabled in `init.el`.
 - Language support modules for Python, Rust, Lisp and C/C++.
 - Research modules for Org, research, reading, and writing.
+- Shell, productivity, communication and multimedia modules.
 ### Changed
 - Phase 3 modules are now enabled in `init.el`.
 - Updated comments to reflect active module loading.
 - Phase 4 modules are now enabled in `init.el`.
+- Phase 5 modules are now enabled in `init.el`.
 ### Removed
 - Old Emacs configuration to prepare for a new setup.

--- a/emacs/init.el
+++ b/emacs/init.el
@@ -190,14 +190,14 @@
       (bv-require bv-reading)
       (bv-require bv-writing))))
 
-;; Phase 5: Extended Productivity (Medium) - DISABLED
-;; (with-eval-after-load 'bv-core
-;;   (run-with-idle-timer 1.5 nil
-;;     (lambda ()
-;;       (bv-require bv-shell)
-;;       (bv-require bv-productivity)
-;;       (bv-require bv-communication)
-;;       (bv-require bv-multimedia))))
+;; Phase 5: Extended Productivity (Medium)
+(with-eval-after-load 'bv-core
+  (run-with-idle-timer 1.5 nil
+    (lambda ()
+      (bv-require bv-shell)
+      (bv-require bv-productivity)
+      (bv-require bv-communication)
+      (bv-require bv-multimedia))))
 
 ;; Interactive loaders for disabled phases
 (defun bv-load-research-features ()

--- a/emacs/lisp/bv-communication.el
+++ b/emacs/lisp/bv-communication.el
@@ -1,0 +1,143 @@
+;;; bv-communication.el --- Communication and sharing tools -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Minimal communication tools focusing on code/text sharing and
+;; optional messaging integration. Lower priority features that
+;; can be enabled as needed.
+
+;;; Code:
+
+(require 'bv-core)
+
+;;;; Custom Variables
+(defgroup bv-communication nil
+  "Communication and sharing configuration."
+  :group 'bv)
+
+;;; Webpaste - Code/Text Sharing
+(defcustom bv-communication-webpaste-providers
+  '("dpaste.com" "ix.io" "paste.rs")
+  "List of paste providers in order of preference.
+Recommended providers:
+- dpaste.com: Good for code, syntax highlighting
+- ix.io: Minimal, fast, command-line friendly
+- paste.rs: Rust playground, good for Rust code"
+  :type '(repeat string)
+  :group 'bv-communication)
+
+;;;; Configuration
+
+;;; Webpaste - Essential for sharing code snippets
+(use-package webpaste
+  :defer t
+  :config
+  (setq webpaste-provider-priority bv-communication-webpaste-providers)
+  (setq webpaste-paste-confirmation t)
+  (setq webpaste-paste-raw-text t)
+  (setq webpaste-return-url-type 'url)
+  
+  (setq webpaste-add-line-numbers nil)
+  
+  (setq webpaste-providers-alist
+        '(("dpaste.com"
+           :uri "https://dpaste.com/api/"
+           :post-field "content"
+           :post-type "application/x-www-form-urlencoded"
+           :success-lambda (lambda () (webpaste--return-url
+                                       (concat "https://dpaste.com/"
+                                               (cdr (assoc 'slug (json-read)))))
+           )
+           :format-url (lambda (url) url))
+          
+          ("ix.io"
+           :uri "http://ix.io"
+           :post-field "f:1"
+           :post-type "application/x-www-form-urlencoded"
+           :success-lambda (lambda () (webpaste--return-url
+                                       (buffer-substring-no-properties
+                                        (point-min) (point-max))))
+           :format-url (lambda (url) url))
+          
+          ("paste.rs"
+           :uri "https://paste.rs"
+           :post-type "text/plain"
+           :success-lambda (lambda () (webpaste--return-url
+                                       (buffer-substring-no-properties
+                                        (point-min) (point-max))))
+           :format-url (lambda (url) url))))
+  
+  :bind (("C-c w p" . webpaste-paste-region-or-buffer)
+         ("C-c w r" . webpaste-paste-region)
+         ("C-c w b" . webpaste-paste-buffer)))
+
+;;; Email Integration (optional - uncomment if needed)
+;; (use-package notmuch
+;;   :defer t
+;;   :config
+;;   (setq notmuch-search-oldest-first nil)
+;;   (setq notmuch-show-logo nil)
+;;   (setq notmuch-message-headers-visible nil)
+;;   :bind (("C-c m" . notmuch)))
+
+;;; Simple IRC (optional - for technical discussions)
+;; (use-package erc
+;;   :defer t
+;;   :config
+;;   (setq erc-server "irc.libera.chat"
+;;         erc-port 6667
+;;         erc-nick "username"
+;;         erc-user-full-name "Full Name"
+;;         erc-autojoin-channels-alist '(("libera.chat" "#emacs"))
+;;         erc-kill-buffer-on-part t
+;;         erc-auto-query 'bury)
+;;   :bind (("C-c i" . erc)))
+
+;;; Link Sharing Utilities
+(defun bv-communication-yank-code-link (start end)
+  "Share code region with link to current file location."
+  (interactive "r")
+  (let* ((file (buffer-file-name))
+         (line-start (line-number-at-pos start))
+         (line-end (line-number-at-pos end))
+         (url (if (and file (vc-git-root file))
+                  (let ((remote (shell-command-to-string
+                                 "git remote get-url origin")))
+                    (when (string-match "github\\|gitlab" remote)
+                      (format "%s#L%d-L%d"
+                              (string-trim remote)
+                              line-start line-end)))
+                (format "%s:%d-%d" (or file "buffer") line-start line-end))))
+    (kill-new url)
+    (message "Link copied: %s" url)))
+
+(defun bv-communication-share-snippet (start end)
+  "Share code snippet with context."
+  (interactive "r")
+  (let* ((code (buffer-substring-no-properties start end))
+         (mode (symbol-name major-mode))
+         (context (format ";;; %s snippet\n;;; From: %s\n\n"
+                          mode
+                          (or (buffer-file-name) "scratch"))))
+    (with-temp-buffer
+      (insert context)
+      (insert code)
+      (webpaste-paste-buffer))))
+
+;;; Global Keybindings
+(with-eval-after-load 'bv-core
+  (bv-leader
+    "w" '(:ignore t :which-key "webpaste/share")
+    "w p" #'webpaste-paste-region-or-buffer
+    "w r" #'webpaste-paste-region
+    "w b" #'webpaste-paste-buffer
+    "w l" #'bv-communication-yank-code-link
+    "w s" #'bv-communication-share-snippet))
+
+;;;; Feature Definition
+(defun bv-communication-load ()
+  "Load communication configuration."
+  (add-to-list 'bv-enabled-features 'communication)
+  (message "Communication tools loaded"))
+
+(provide 'bv-communication)
+;;; bv-communication.el ends here

--- a/emacs/lisp/bv-multimedia.el
+++ b/emacs/lisp/bv-multimedia.el
@@ -1,0 +1,161 @@
+;;; bv-multimedia.el --- Media playback and external app integration -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Optional multimedia features including media playback and
+;; external application integration. Load only if needed.
+
+;;; Code:
+
+(require 'bv-core)
+
+;;;; Custom Variables
+(defgroup bv-multimedia nil
+  "Multimedia and external app configuration."
+  :group 'bv)
+
+;;; EMMS Configuration
+(defcustom bv-multimedia-music-directory
+  (expand-file-name "~/Music")
+  "Default music directory."
+  :type 'directory
+  :group 'bv-multimedia)
+
+(defcustom bv-multimedia-emms-directory
+  (expand-file-name "emms" user-emacs-directory)
+  "Directory for EMMS data."
+  :type 'directory
+  :group 'bv-multimedia)
+
+;;;; Configuration
+
+;;; Basic Media Playback (optional)
+(use-package emms
+  :defer t
+  :init
+  (unless (file-exists-p bv-multimedia-emms-directory)
+    (make-directory bv-multimedia-emms-directory t))
+  
+  :config
+  (require 'emms-setup)
+  (emms-all)
+  
+  (setq emms-directory bv-multimedia-emms-directory)
+  (setq emms-source-file-default-directory bv-multimedia-music-directory)
+  
+  ;; Player configuration - use simplest available
+  (setq emms-player-list
+        (cond
+         ((executable-find "mpv")
+          '(emms-player-mpv))
+         ((executable-find "mplayer")
+          '(emms-player-mplayer))
+         ((executable-find "vlc")
+          '(emms-player-vlc))
+         (t '(emms-player-mpd))))
+  
+  (setq emms-info-functions
+        '(emms-info-native
+          emms-info-metaflac
+          emms-info-ogginfo))
+  
+  (setq emms-playlist-buffer-name "*Music*")
+  (setq emms-playlist-mode-center-when-go t)
+  
+  (setq emms-history-file
+        (expand-file-name "history" emms-directory))
+  
+  (setq emms-mode-line-mode-line-function 'emms-mode-line-playlist-current)
+  (setq emms-mode-line-format " [%s]")
+  
+  (setq emms-player-mpd-connect-function 'emms-player-mpd-connect)
+  
+  :bind (("C-c e e" . emms)
+         ("C-c e b" . emms-smart-browse)
+         ("C-c e p" . emms-playlist-mode-go)
+         ("C-c e s" . emms-start)
+         ("C-c e S" . emms-stop)
+         ("C-c e n" . emms-next)
+         ("C-c e p" . emms-previous)
+         ("C-c e P" . emms-pause)))
+
+;;; Simple media controls
+(defhydra bv-multimedia-hydra (:color pink :hint nil)
+  "
+Media Control
+_p_: play/pause  _s_: stop  _n_: next  _b_: previous
+_+_: volume up   _-_: volume down  _m_: mute
+_l_: playlist    _q_: quit
+"
+  ("p" emms-pause)
+  ("s" emms-stop)
+  ("n" emms-next)
+  ("b" emms-previous)
+  ("+" emms-volume-raise)
+  ("-" emms-volume-lower)
+  ("m" emms-volume-toggle-mute)
+  ("l" emms-playlist-mode-go)
+  ("q" nil :exit t))
+
+;;; External App Integration
+
+(defun bv-multimedia-open-externally ()
+  "Open current file with system's default application."
+  (interactive)
+  (let ((file (or (buffer-file-name)
+                  (when (derived-mode-p 'dired-mode)
+                    (dired-get-file-for-visit)))))
+    (when file
+      (call-process
+       (pcase system-type
+         ('darwin "open")
+         ('windows-nt "start")
+         (_ "xdg-open"))
+       nil 0 nil file))))
+
+(defun bv-multimedia-play-url (url)
+  "Play URL with mpv or browser."
+  (interactive "sURL: ")
+  (if (executable-find "mpv")
+      (start-process "mpv" nil "mpv" url)
+    (browse-url url)))
+
+(defun bv-multimedia-screenshot (prefix)
+  "Take a screenshot. With PREFIX, select region."
+  (interactive "P")
+  (let* ((timestamp (format-time-string "%Y%m%d-%H%M%S"))
+         (filename (expand-file-name 
+                    (format "screenshot-%s.png" timestamp)
+                    "~/Pictures/"))
+         (command (pcase system-type
+                    ('darwin (if prefix
+                                 "screencapture -i %s"
+                               "screencapture %s"))
+                    (_ (if prefix
+                           "scrot -s %s"
+                         "scrot %s"))))
+    (shell-command (format command filename))
+    (message "Screenshot saved: %s" filename)
+    (kill-new filename)))
+
+;;; Global Keybindings
+(with-eval-after-load 'bv-core
+  (bv-leader
+    "M" '(:ignore t :which-key "multimedia")
+    "M m" #'bv-multimedia-hydra/body
+    "M o" #'bv-multimedia-open-externally
+    "M u" #'bv-multimedia-play-url
+    "M s" #'bv-multimedia-screenshot))
+
+;;;; Feature Definition
+(defun bv-multimedia-load ()
+  "Load multimedia configuration."
+  (add-to-list 'bv-enabled-features 'multimedia)
+  
+  ;; Only start EMMS if music directory exists
+  (when (file-directory-p bv-multimedia-music-directory)
+    (require 'emms-setup))
+  
+  (message "Multimedia tools loaded"))
+
+(provide 'bv-multimedia)
+;;; bv-multimedia.el ends here

--- a/emacs/lisp/bv-productivity.el
+++ b/emacs/lisp/bv-productivity.el
@@ -1,0 +1,445 @@
+;;; bv-productivity.el --- Workflow optimization and productivity tools -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Productivity tools including LLM integration, advanced calculator,
+;; notifications, pomodoro timer, time tracking, and workflow optimizations.
+
+;;; Code:
+
+(require 'bv-core)
+
+;;;; Custom Variables
+(defgroup bv-productivity nil
+  "Productivity and workflow configuration."
+  :group 'bv)
+
+;;; LLM Integration
+(defcustom bv-productivity-gptel-api-key-command
+  '("pass" "show" "openai/api-key")
+  "Command to retrieve GPT API key."
+  :type '(repeat string)
+  :group 'bv-productivity)
+
+(defcustom bv-productivity-gptel-default-mode 'org-mode
+  "Default mode for GPT responses."
+  :type '(choice (const :tag "Org mode" org-mode)
+                 (const :tag "Markdown" markdown-mode)
+                 (const :tag "Text" text-mode))
+  :group 'bv-productivity)
+
+(defcustom bv-productivity-gptel-model "gpt-4"
+  "Default GPT model to use."
+  :type 'string
+  :group 'bv-productivity)
+
+;;; Calculator
+(defcustom bv-productivity-calc-currency 'USD
+  "Base currency for calculations."
+  :type 'symbol
+  :group 'bv-productivity)
+
+(defcustom bv-productivity-calc-currency-update-interval 7
+  "Days between currency exchange rate updates."
+  :type 'integer
+  :group 'bv-productivity)
+
+;;; Notifications
+(defcustom bv-productivity-notifications-icon nil
+  "Icon to use for notifications."
+  :type '(choice (const :tag "Default" nil)
+                 file)
+  :group 'bv-productivity)
+
+(defcustom bv-productivity-notifications-app-name "Emacs"
+  "Application name for notifications."
+  :type 'string
+  :group 'bv-productivity)
+
+;;; Pomodoro
+(defcustom bv-productivity-pomodoro-length 25
+  "Length of a pomodoro in minutes."
+  :type 'integer
+  :group 'bv-productivity)
+
+(defcustom bv-productivity-pomodoro-short-break 5
+  "Length of short break in minutes."
+  :type 'integer
+  :group 'bv-productivity)
+
+(defcustom bv-productivity-pomodoro-long-break 15
+  "Length of long break in minutes."
+  :type 'integer
+  :group 'bv-productivity)
+
+(defcustom bv-productivity-pomodoro-long-break-after 4
+  "Number of pomodoros before a long break."
+  :type 'integer
+  :group 'bv-productivity)
+
+;;; Time Tracking
+(defcustom bv-productivity-time-tracking-file
+  (expand-file-name "time-log.org" org-directory)
+  "File for time tracking entries."
+  :type 'file
+  :group 'bv-productivity)
+
+;;;; Configuration
+
+;;; LLM Integration (GPT)
+(use-package gptel
+  :defer t
+  :config
+  (defun bv-productivity-gptel-get-api-key ()
+    "Get API key for gptel."
+    (string-trim-right
+     (with-output-to-string
+       (let ((exit (apply #'call-process
+                          (car bv-productivity-gptel-api-key-command)
+                          nil standard-output nil
+                          (cdr bv-productivity-gptel-api-key-command))))
+         (unless (zerop exit)
+           (error "Failed to get gptel API key")))))
+  )
+  
+  (setq gptel-api-key #'bv-productivity-gptel-get-api-key)
+  (setq gptel-default-mode bv-productivity-gptel-default-mode)
+  (setq gptel-model bv-productivity-gptel-model)
+  
+  (setq gptel-directives
+        '((default . "You are a helpful assistant.")
+          (programming . "You are a programming assistant. Provide concise code examples.")
+          (writing . "You are a writing assistant. Help improve clarity and style.")
+          (research . "You are a research assistant. Provide accurate, well-sourced information.")))
+  
+  :bind (("C-c g g" . gptel)
+         ("C-c g s" . gptel-send)
+         ("C-c g m" . gptel-menu)
+         ("C-c g r" . gptel-rewrite)
+         ("C-c g a" . gptel-add)
+         ("C-c g f" . gptel-refactor-or-rewrite)))
+
+(use-package gptel-quick
+  :after gptel
+  :bind ("C-c g q" . gptel-quick))
+
+;;; Calculator
+(use-package calc
+  :defer t
+  :config
+  (setq calc-algebraic-mode t)
+  (setq calc-symbolic-mode t)
+  (setq calc-display-trail nil)
+  
+  :bind (("C-c k" . calc-dispatch)
+         ("C-x * *" . calc)))
+
+(use-package calc-currency
+  :after calc
+  :config
+  (require 'xdg)
+  (setq calc-currency-exchange-rates-file
+        (expand-file-name "emacs/calc-currency-rates.el"
+                          (xdg-cache-home)))
+  (setq calc-currency-base-currency bv-productivity-calc-currency)
+  (setq calc-currency-update-interval bv-productivity-calc-currency-update-interval)
+  
+  (add-hook 'calc-start-hook 'calc-currency-load))
+
+;;; Desktop Notifications
+(use-package ednc
+  :defer t
+  :init
+  (defvar bv-ednc-map (make-sparse-keymap)
+    "Keymap for EDNC commands.")
+  
+  :config
+  (ednc-mode 1)
+  
+  (defun bv-ednc--notify ()
+    "Display the latest EDNC notification."
+    (when (ednc-notifications)
+      (ednc-format-notification (car (ednc-notifications)))))
+  
+  (defun bv-ednc-show-notification-log ()
+    "Switch to the EDNC log buffer."
+    (interactive)
+    (when (get-buffer ednc-log-name)
+      (switch-to-buffer ednc-log-name)))
+  
+  (defun bv-ednc-dismiss-all-notifications ()
+    "Dismiss all EDNC notifications."
+    (interactive)
+    (mapc 'ednc-dismiss-notification (cdr ednc--state)))
+  
+  (defun bv-ednc-update-notifications (&rest _)
+    "Update the display of EDNC notifications."
+    (force-mode-line-update t))
+  
+  (add-hook 'ednc-notification-presentation-functions
+            #'bv-ednc-update-notifications)
+  
+  (with-eval-after-load 'notifications
+    (setq notifications-application-name bv-productivity-notifications-app-name)
+    (when bv-productivity-notifications-icon
+      (setq notifications-application-icon bv-productivity-notifications-icon)))
+  
+  :bind-keymap ("C-c n" . bv-ednc-map)
+  :bind (:map bv-ednc-map
+              ("n" . ednc-pop-to-notification-in-log-buffer)
+              ("l" . bv-ednc-show-notification-log)
+              ("d" . ednc-dismiss-notification)
+              ("D" . bv-ednc-dismiss-all-notifications)))
+
+;;; Pomodoro Timer
+(use-package pomidor
+  :defer t
+  :config
+  (setq pomidor-seconds (* bv-productivity-pomodoro-length 60))
+  (setq pomidor-break-seconds (* bv-productivity-pomodoro-short-break 60))
+  (setq pomidor-long-break-seconds (* bv-productivity-pomodoro-long-break 60))
+  (setq pomidor-breaks-before-long bv-productivity-pomodoro-long-break-after)
+  
+  (setq pomidor-sound-tick nil)
+  (setq pomidor-sound-tack nil)
+  (setq pomidor-sound-overwork nil)
+  (setq pomidor-sound-break-over nil)
+  
+  (add-hook 'pomidor-break-start-hook
+            (lambda ()
+              (notifications-notify
+               :title "Pomodoro Break"
+               :body "Time for a break!"
+               :app-name "Emacs Pomodoro")))
+  
+  (add-hook 'pomidor-overwork-hook
+            (lambda ()
+              (notifications-notify
+               :title "Pomodoro Complete"
+               :body "Great work! Time to start break."
+               :app-name "Emacs Pomodoro")))
+  
+  :bind (("C-c p p" . pomidor)
+         :map pomidor-mode-map
+         ("q" . quit-window)
+         ("Q" . pomidor-quit)
+         ("R" . pomidor-reset)
+         ("SPC" . pomidor-break)
+         ("RET" . pomidor-stop)))
+
+;; Alternative: org-pomodoro integration
+(use-package org-pomodoro
+  :after org
+  :config
+  (setq org-pomodoro-length bv-productivity-pomodoro-length)
+  (setq org-pomodoro-short-break-length bv-productivity-pomodoro-short-break)
+  (setq org-pomodoro-long-break-length bv-productivity-pomodoro-long-break)
+  (setq org-pomodoro-long-break-frequency bv-productivity-pomodoro-long-break-after)
+  
+  (setq org-pomodoro-finished-sound-p t)
+  (setq org-pomodoro-overtime-sound-p t)
+  (setq org-pomodoro-clock-break t)
+  
+  :bind (:map org-mode-map
+              ("C-c p o" . org-pomodoro)))
+
+;;; Time Tracking
+(use-package org-clock
+  :after org
+  :config
+  (setq org-clock-persist t)
+  (setq org-clock-persist-file
+        (expand-file-name "org-clock-save.el" user-emacs-directory))
+  (setq org-clock-in-resume t)
+  (setq org-clock-out-remove-zero-time-clocks t)
+  (setq org-clock-report-include-clocking-task t)
+  (setq org-clock-idle-time 10)
+  
+  (setq org-clock-mode-line-total 'current)
+  (setq org-clock-clocked-in-display 'mode-line)
+  
+  (setq org-clock-auto-clock-resolution 'when-no-clock-is-running)
+  
+  (org-clock-persistence-insinuate)
+  
+  :bind (("C-c t i" . org-clock-in)
+         ("C-c t o" . org-clock-out)
+         ("C-c t c" . org-clock-in-last)
+         ("C-c t g" . org-clock-goto)
+         ("C-c t d" . org-clock-display)
+         ("C-c t r" . org-clock-report)
+         ("C-c t e" . org-clock-modify-effort-estimate)))
+
+;; Chronos - Simple timer
+(use-package chronos
+  :defer t
+  :config
+  (setq chronos-notification-type 'notifications)
+  (setq chronos-shell-notify-command "")
+  (setq chronos-expiry-functions '(chronos-desktop-notifications-notify))
+  
+  :bind (("C-c t t" . chronos-add-timer)
+         ("C-c t l" . chronos-list)))
+
+;;; Custom Productivity Commands
+
+(defun bv-productivity-focus-mode ()
+  "Enter focus mode - minimal distractions."
+  (interactive)
+  (when (fboundp 'olivetti-mode)
+    (olivetti-mode 1))
+  (display-line-numbers-mode -1)
+  (setq mode-line-format nil)
+  (message "Focus mode enabled"))
+
+(defun bv-productivity-unfocus-mode ()
+  "Exit focus mode."
+  (interactive)
+  (when (fboundp 'olivetti-mode)
+    (olivetti-mode -1))
+  (display-line-numbers-mode 1)
+  (kill-local-variable 'mode-line-format)
+  (message "Focus mode disabled"))
+
+(defun bv-productivity-insert-timestamp ()
+  "Insert current timestamp."
+  (interactive)
+  (insert (format-time-string "%Y-%m-%d %H:%M:%S")))
+
+(defun bv-productivity-insert-date ()
+  "Insert current date."
+  (interactive)
+  (insert (format-time-string "%Y-%m-%d")))
+
+(defun bv-productivity-open-time-log ()
+  "Open time tracking file."
+  (interactive)
+  (find-file bv-productivity-time-tracking-file))
+
+(defun bv-productivity-quick-note ()
+  "Quickly capture a note with timestamp."
+  (interactive)
+  (let* ((note (read-string "Quick note: "))
+         (timestamp (format-time-string "%Y-%m-%d %H:%M"))
+         (entry (format "* %s %s\n" timestamp note)))
+    (with-current-buffer (find-file-noselect bv-productivity-time-tracking-file)
+      (goto-char (point-max))
+      (insert entry)
+      (save-buffer))
+    (message "Note captured: %s" note)))
+
+(defun bv-productivity-meeting-template ()
+  "Insert meeting template."
+  (interactive)
+  (insert (format "* Meeting: %s\n" (read-string "Meeting title: ")))
+  (insert (format "** Date: %s\n" (format-time-string "%Y-%m-%d %H:%M")))
+  (insert "** Attendees:\n- \n")
+  (insert "** Agenda:\n- \n")
+  (insert "** Notes:\n\n")
+  (insert "** Action Items:\n- [ ] \n")
+  (insert "** Next Steps:\n- \n"))
+
+(defun bv-productivity-daily-review ()
+  "Create daily review entry."
+  (interactive)
+  (let ((date (format-time-string "%Y-%m-%d")))
+    (find-file bv-productivity-time-tracking-file)
+    (goto-char (point-max))
+    (insert (format "\n* Daily Review: %s\n" date))
+    (insert "** What went well:\n- \n")
+    (insert "** What could be improved:\n- \n")
+    (insert "** Key accomplishments:\n- \n")
+    (insert "** Tomorrow's priorities:\n- \n")))
+
+(defun bv-productivity-weekly-summary ()
+  "Generate weekly time summary."
+  (interactive)
+  (require 'org-clock)
+  (let ((start (org-read-date nil nil "-mon"))
+        (end (org-read-date nil nil "+sun")))
+    (org-clock-report 
+     nil 
+     (list :tstart start :tend end :maxlevel 3))))
+
+;;; Hydra for Quick Access
+(use-package hydra
+  :defer t)
+
+(defhydra bv-productivity-hydra (:color blue :hint nil)
+  "
+Productivity Tools
+
+Timer           Focus              Quick
+-------         -------            -------
+_p_: Pomodoro   _f_: Focus mode    _n_: Quick note
+_t_: Timer      _F_: Unfocus       _d_: Insert date
+_i_: Clock in   _m_: Meeting       _T_: Insert timestamp
+_o_: Clock out  _r_: Daily review  _w_: Weekly summary
+
+_q_: Quit
+"
+  ("p" pomidor)
+  ("t" chronos-add-timer)
+  ("i" org-clock-in)
+  ("o" org-clock-out)
+  ("f" bv-productivity-focus-mode)
+  ("F" bv-productivity-unfocus-mode)
+  ("n" bv-productivity-quick-note)
+  ("d" bv-productivity-insert-date)
+  ("T" bv-productivity-insert-timestamp)
+  ("m" bv-productivity-meeting-template)
+  ("r" bv-productivity-daily-review)
+  ("w" bv-productivity-weekly-summary)
+  ("q" nil :exit t))
+
+;;; Global Keybindings
+(with-eval-after-load 'bv-core
+  (bv-leader
+    "P" '(:ignore t :which-key "productivity")
+    "P P" #'bv-productivity-hydra/body
+    "P g" #'gptel
+    "P c" #'calc
+    "P p" #'pomidor
+    "P i" #'org-clock-in
+    "P o" #'org-clock-out
+    "P n" #'bv-productivity-quick-note
+    "P f" #'bv-productivity-focus-mode
+    "P t" #'chronos-add-timer))
+
+;;; Mode Line Integration
+(defun bv-productivity-mode-line-indicator ()
+  "Mode line indicator for productivity status."
+  (let ((indicators '()))
+    ;; Pomodoro indicator
+    (when (and (boundp 'pomidor-timer) pomidor-timer)
+      (push "[🍅]" indicators))
+    ;; Clock indicator
+    (when (org-clocking-p)
+      (push (format "[⏰ %s]" (org-clock-get-clock-string)) indicators))
+    ;; Notification count
+    (when (and (fboundp 'ednc-notifications) (ednc-notifications))
+      (push (format "[🔔 %d]" (length (ednc-notifications))) indicators))
+    (when indicators
+      (string-join indicators " "))))
+
+;; Add to mode line
+(add-to-list 'global-mode-string '(:eval (bv-productivity-mode-line-indicator)) t)
+
+;;;; Feature Definition
+(defun bv-productivity-load ()
+  "Load productivity configuration."
+  (add-to-list 'bv-enabled-features 'productivity)
+  
+  ;; Create time log file if needed
+  (unless (file-exists-p bv-productivity-time-tracking-file)
+    (with-temp-file bv-productivity-time-tracking-file
+      (insert "#+TITLE: Time Tracking Log\n")
+      (insert "#+STARTUP: logdrawer\n\n")))
+  
+  ;; Start notification service
+  (when (display-graphic-p)
+    (ednc-mode 1))
+  
+  (message "Productivity tools loaded"))
+
+(provide 'bv-productivity)
+;;; bv-productivity.el ends here

--- a/emacs/lisp/bv-shell.el
+++ b/emacs/lisp/bv-shell.el
@@ -1,0 +1,350 @@
+;;; bv-shell.el --- Shell and terminal configuration -*- lexical-binding: t -*-
+
+;;; Commentary:
+;; Shell and terminal configuration with per-project environments,
+;; directory tracking, and modern terminal emulation.
+
+;;; Code:
+
+(require 'bv-core)
+
+;;;; Custom Variables
+
+(defgroup bv-shell nil
+  "Shell and terminal configuration."
+  :group 'bv)
+
+(defcustom bv-shell-default-shell 'eshell
+  "Default shell to use for shell commands."
+  :type '(choice (const :tag "Eshell" eshell)
+                 (const :tag "Shell" shell)
+                 (const :tag "Eat" eat)
+                 (const :tag "Vterm" vterm))
+  :group 'bv-shell)
+
+(defcustom bv-shell-pop-rule '(window-height . 0.3)
+  "Display rule for shell popup windows."
+  :type 'sexp
+  :group 'bv-shell)
+
+(defcustom bv-shell-history-size 10000
+  "Number of history items to keep."
+  :type 'integer
+  :group 'bv-shell)
+
+(defcustom bv-shell-per-project t
+  "Create separate shell buffers per project."
+  :type 'boolean
+  :group 'bv-shell)
+
+;;;; Comint Base Configuration
+
+(use-package comint
+  :hook ((comint-mode . bv-shell--comint-setup))
+  :config
+  (setq comint-prompt-read-only t
+        comint-buffer-maximum-size 10000
+        comint-input-ignoredups t
+        comint-completion-addsuffix t
+        comint-completion-autolist t
+        comint-scroll-show-maximum-output nil
+        comint-scroll-to-bottom-on-input 'this
+        comint-scroll-to-bottom-on-output 'others
+        comint-output-filter-functions
+        '(ansi-color-process-output
+          comint-watch-for-password-prompt
+          comint-truncate-buffer))
+  
+  (defun bv-shell--comint-setup ()
+    "Setup comint buffers."
+    (ansi-color-for-comint-mode-on)
+    (setq-local completion-at-point-functions
+                '(comint-completion-at-point)))
+  
+  (defun bv-comint-clear-buffer ()
+    "Clear comint buffer."
+    (interactive)
+    (let ((comint-buffer-maximum-size 0))
+      (comint-truncate-buffer)))
+  
+  (define-key comint-mode-map (kbd "C-c M-o") #'bv-comint-clear-buffer)
+  
+  ;; Integration with consult
+  (bv-with-feature completion
+    (defun bv-comint-history ()
+      "Search comint history with consult."
+      (interactive)
+      (require 'consult)
+      (consult-history comint-input-ring))
+    
+    (define-key comint-mode-map (kbd "M-r") #'bv-comint-history)))
+
+;;;; Eshell Configuration
+
+(use-package eshell
+  :commands (eshell bv-project-eshell)
+  :bind (("s-e" . bv-project-eshell)
+         :map eshell-mode-map
+         ("C-c M-o" . eshell/clear)
+         ("s-e" . bv-eshell-toggle))
+  :init
+  (defconst bv-eshell-directory
+    (expand-file-name "eshell" bv-var-dir)
+    "Directory for eshell data.")
+  
+  (unless (file-directory-p bv-eshell-directory)
+    (make-directory bv-eshell-directory t))
+  
+  :config
+  (setq eshell-aliases-file (expand-file-name "alias" bv-eshell-directory)
+        eshell-history-file-name (expand-file-name "history" bv-eshell-directory)
+        eshell-last-dir-ring-file-name (expand-file-name "lastdir" bv-eshell-directory))
+  
+  (setq eshell-history-size bv-shell-history-size
+        eshell-buffer-maximum-lines 10000
+        eshell-hist-ignoredups t
+        eshell-scroll-to-bottom-on-input 'this
+        eshell-destroy-buffer-when-process-dies t
+        eshell-visual-commands '("vim" "vi" "screen" "top" "less" "more" "lynx"
+                                 "ncftp" "pine" "tin" "trn" "elm" "htop")
+        eshell-visual-subcommands '(("git" "log" "diff" "show"))
+        eshell-prefer-lisp-functions nil
+        eshell-prefer-lisp-variables nil)
+  
+  (defun bv-eshell-prompt ()
+    "Generate eshell prompt."
+    (concat
+     (propertize (user-login-name) 'face 'font-lock-builtin-face)
+     "@"
+     (propertize (system-name) 'face 'font-lock-warning-face)
+     " "
+     (propertize (abbreviate-file-name (eshell/pwd))
+                 'face 'font-lock-constant-face)
+     (when (and (executable-find "git")
+                (locate-dominating-file default-directory ".git"))
+       (concat " "
+               (propertize
+                (string-trim
+                 (shell-command-to-string "git branch --show-current"))
+                'face 'font-lock-keyword-face)))
+     (propertize "\n❯ " 'face 'success)))
+  
+  (setq eshell-prompt-function #'bv-eshell-prompt
+        eshell-prompt-regexp "^❯ ")
+  
+  (defun bv-eshell-setup-aliases ()
+    "Setup useful eshell aliases."
+    (eshell/alias "e" "find-file $1")
+    (eshell/alias "ee" "find-file-other-window $1")
+    (eshell/alias "d" "dired $1")
+    (eshell/alias "ll" "ls -la")
+    (eshell/alias "la" "ls -la")
+    (eshell/alias "l" "ls -l")
+    (eshell/alias "gs" "magit-status")
+    (eshell/alias "gd" "magit-diff-unstaged")
+    (eshell/alias "gds" "magit-diff-staged"))
+  
+  (add-hook 'eshell-mode-hook #'bv-eshell-setup-aliases)
+  
+  (defun eshell/clear ()
+    "Clear eshell buffer."
+    (interactive)
+    (let ((inhibit-read-only t))
+      (erase-buffer)
+      (eshell-send-input)))
+  
+  (defun bv-project-eshell (&optional arg)
+    "Open eshell for current project.
+With prefix ARG, create new eshell buffer."
+    (interactive "P")
+    (if (and bv-shell-per-project (project-current))
+        (let* ((default-directory (project-root (project-current)))
+               (eshell-buffer-name (project-prefixed-buffer-name "eshell")))
+          (eshell arg))
+      (eshell arg)))
+  
+  (defun bv-eshell-toggle ()
+    "Toggle between eshell and previous buffer."
+    (interactive)
+    (if (eq major-mode 'eshell-mode)
+        (switch-to-prev-buffer)
+      (bv-project-eshell)))
+  
+  (add-hook 'eshell-mode-hook
+            (lambda ()
+              (setq-local truncate-lines nil)
+              (setq-local global-hl-line-mode nil)))
+  
+  ;; Integration with eat
+  (bv-with-feature shell
+    (when (and (executable-find "eat")
+               (require 'eat nil t))
+      (add-hook 'eshell-load-hook #'eat-eshell-mode)
+      (add-hook 'eshell-load-hook #'eat-eshell-visual-command-mode))))
+
+;; Eshell syntax highlighting
+(use-package eshell-syntax-highlighting
+  :after eshell
+  :config
+  (eshell-syntax-highlighting-global-mode 1))
+
+;; Better eshell prompt
+(use-package eshell-prompt-extras
+  :after eshell
+  :config
+  (setq epe-git-dirty-char "±")
+  (setq eshell-highlight-prompt nil
+        eshell-prompt-function #'epe-theme-lambda))
+
+;;;; Eat - Modern Terminal Emulator
+
+(use-package eat
+  :commands (eat bv-project-eat)
+  :bind (("C-x t" . bv-project-eat)
+         :map eat-mode-map
+         ("C-c M-o" . eat-clear))
+  :custom
+  (eat-kill-buffer-on-exit t)
+  (eat-term-scrollback-size nil)
+  (eat-enable-mouse t)
+  :config
+  (defun bv-project-eat (&optional arg)
+    "Open eat terminal for current project.
+With prefix ARG, create new terminal."
+    (interactive "P")
+    (if (and bv-shell-per-project (project-current))
+        (let* ((default-directory (project-root (project-current)))
+               (eat-buffer-name (project-prefixed-buffer-name "eat")))
+          (eat nil arg))
+      (eat nil arg)))
+  
+  (defun eat-clear ()
+    "Clear eat terminal."
+    (interactive)
+    (eat-clear-screen)))
+
+;;;; Shell Mode Configuration
+
+(use-package shell
+  :commands (shell bv-project-shell)
+  :bind (("C-x s" . bv-project-shell))
+  :config
+  (setq shell-prompt-pattern "^[^#$%>\n]*[#$%>] *"
+        shell-completion-execonly nil
+        shell-completion-fignore '("~" "#" "%"))
+  
+  (defun bv-project-shell (&optional arg)
+    "Open shell for current project.
+With prefix ARG, create new shell."
+    (interactive "P")
+    (if (and bv-shell-per-project (project-current))
+        (let* ((default-directory (project-root (project-current)))
+               (shell-buffer-name (project-prefixed-buffer-name "shell")))
+          (shell arg))
+      (shell arg)))
+  
+  (add-hook 'shell-mode-hook #'shell-dirtrack-mode)
+  (add-hook 'shell-mode-hook #'ansi-color-for-comint-mode-on))
+
+;;;; Shell Script Support
+
+(use-package sh-script
+  :mode (("\\.sh\\'" . sh-mode)
+         ("\\.bash\\'" . sh-mode)
+         ("\\.zsh\\'" . sh-mode)
+         ("\\.*rc\\'" . sh-mode))
+  :config
+  (setq sh-basic-offset 2
+        sh-indentation 2
+        sh-indent-comment nil
+        sh-first-lines-indent nil)
+  
+  (add-hook 'after-save-hook
+            #'executable-make-buffer-file-executable-if-script-p))
+
+;;;; Directory Tracking
+
+(defun bv-shell-sync-dir-with-prompt ()
+  "Sync shell directory with prompt."
+  (when (memq major-mode '(shell-mode eshell-mode))
+    (let ((dir (or (ignore-errors
+                     (file-name-directory
+                      (or (buffer-file-name)
+                          list-buffers-directory
+                          default-directory)))
+                   default-directory)))
+      (cd dir))))
+
+(add-hook 'shell-mode-hook
+          (lambda ()
+            (add-hook 'comint-output-filter-functions
+                      #'bv-shell-sync-dir-with-prompt nil t)))
+
+;;;; Visual Enhancements
+
+(add-to-list 'display-buffer-alist
+             '("\\*Async Shell Command\\*"
+               (display-buffer-no-window)))
+
+(defun bv-shell-command-with-compile (command &optional output-buffer error-buffer)
+  "Execute COMMAND with output in compilation mode."
+  (interactive (list (read-shell-command "Shell command: ")
+                     current-prefix-arg
+                     shell-command-default-error-buffer))
+  (let ((compilation-buffer-name-function
+         (lambda (_) (or output-buffer "*Shell Command Output*"))))
+    (compile command)))
+
+(global-set-key (kbd "M-&") #'bv-shell-command-with-compile)
+
+;;;; Quick Shell Access
+
+(defun bv-shell-popup ()
+  "Pop up a shell in a small window."
+  (interactive)
+  (let ((shell-fn (cl-case bv-shell-default-shell
+                    (eshell #'bv-project-eshell)
+                    (eat #'bv-project-eat)
+                    (shell #'bv-project-shell)
+                    (t #'eshell))))
+    (let ((display-buffer-alist
+           `((,(rx bos "*" (or "eshell" "shell" "eat") "*")
+              (display-buffer-in-side-window)
+              (side . bottom)
+              ,bv-shell-pop-rule))))
+      (call-interactively shell-fn))))
+
+(global-set-key (kbd "C-c !") #'bv-shell-popup)
+
+;;;; Integration with Project System
+
+(with-eval-after-load 'project
+  (define-key project-prefix-map "s" #'bv-project-shell)
+  (define-key project-prefix-map "e" #'bv-project-eshell)
+  (define-key project-prefix-map "t" #'bv-project-eat)
+  
+  (add-to-list 'project-switch-commands
+               '(bv-project-eshell "Eshell") t)
+  (add-to-list 'project-switch-commands
+               '(bv-project-shell "Shell") t))
+
+;;;; Org Babel Shell Support
+
+(bv-with-feature org
+  (with-eval-after-load 'org
+    (add-to-list 'org-structure-template-alist
+                 '("sh" . "src sh"))
+    (add-to-list 'org-structure-template-alist
+                 '("bash" . "src bash")))
+  
+  (with-eval-after-load 'ob-core
+    (require 'ob-shell)))
+
+;;;; Feature Definition
+
+(defun bv-shell-load ()
+  "Load shell configuration."
+  (add-to-list 'bv-enabled-features 'shell))
+
+(provide 'bv-shell)
+;;; bv-shell.el ends here


### PR DESCRIPTION
## Summary
- add comprehensive shell configuration
- add productivity, multimedia, and communication modules
- enable Phase 5 loading in `init.el`
- document new modules in CHANGELOG

## Testing
- `./scripts/style.sh`

------
https://chatgpt.com/codex/tasks/task_e_684a7c65c780832b89623223a1319deb