### PR TITLE
Remove remote rewrite from gitconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Updated comments to reflect active module loading.
 - Phase 4 modules are now enabled in `init.el`.
 - Phase 5 modules are now enabled in `init.el`.
+- Removed URL rewrite aliases from `git/gitconfig`.
 ### Removed
 - Old Emacs configuration to prepare for a new setup.
 - Removed Airflow container service from `ragnar` machine.

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -160,14 +160,6 @@
 [credential]
 	helper = cache --timeout=3600
 
-[url "git@github.com:"]
-	insteadOf = https://github.com/
-	pushInsteadOf = https://github.com/
-
-[url "git@gitlab.com:"]
-	insteadOf = https://gitlab.com/
-	pushInsteadOf = https://gitlab.com/
-
 [filter "lfs"]
 	clean = git-lfs clean -- %f
 	smudge = git-lfs smudge -- %f


### PR DESCRIPTION
## Summary
- drop ssh rewrite blocks from git/gitconfig
- note the change in CHANGELOG

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a89df730c832bb970902cb8fec279