### PR TITLE
Adjust gitconfig for Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Phase 4 modules are now enabled in `init.el`.
 - Phase 5 modules are now enabled in `init.el`.
 - Removed URL rewrite aliases from `git/gitconfig`.
+- Pruned deprecated and platform-specific options from `git/gitconfig`.
 ### Removed
 - Old Emacs configuration to prepare for a new setup.
 - Removed Airflow container service from `ragnar` machine.

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -20,11 +20,8 @@
 	pager = less -FRX
 	attributesfile = ~/.gitattributes
 	compression = 9
-	precomposeUnicode = true
 	quotepath = false
 	preloadindex = true
-	fscache = true
-	untrackedCache = true
 
 [i18n]
 	commitEncoding = utf-8


### PR DESCRIPTION
## Summary
- prune deprecated and Windows-specific options from `gitconfig`
- document the update in the changelog

## Testing
- `git --no-pager show -s --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a93c67344832b94c0bf16f8019aef