### PR TITLE
Fix unbalanced paren in bv-ensure macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Phase 5 modules are now enabled in `init.el`.
 - Removed URL rewrite aliases from `git/gitconfig`.
 - Pruned deprecated and platform-specific options from `git/gitconfig`.
+### Fixed
+- Balanced parentheses in `emacs/lisp/bv-core.el`.
 ### Removed
 - Old Emacs configuration to prepare for a new setup.
 - Removed Airflow container service from `ragnar` machine.

--- a/emacs/lisp/bv-core.el
+++ b/emacs/lisp/bv-core.el
@@ -127,7 +127,7 @@
                         ,value
                         ,(if (symbolp predicate)
                              (symbol-name predicate)
-                           "custom predicate")))))
+                           "custom predicate"))))))
 
 (defun bv-validate-type (value type)
   "Validate that VALUE matches TYPE specification."


### PR DESCRIPTION
## Summary
- close `bv-ensure` macro definition in `bv-core.el`
- document fix in `CHANGELOG.md`

## Testing
- `bash scripts/style.sh` *(fails: `guix` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab9a90430832b860c38a241af67f7