### PR TITLE
Fix Emacs leader bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Pruned deprecated and platform-specific options from `git/gitconfig`.
 ### Fixed
 - Balanced parentheses in `emacs/lisp/bv-core.el`.
+- Added `bv-leader` macro and corrected quoting in completion and writing modules.
 - Prevented startup errors when optional packages are missing.
 - Closed unmatched parentheses in `bv-research.el` and removed invalid key binding from `bv-productivity.el`.
 ### Removed

--- a/emacs/lisp/bv-completion.el
+++ b/emacs/lisp/bv-completion.el
@@ -152,8 +152,8 @@
   (setq marginalia-align-offset 1)
 
   ;; Custom annotators
-  (add-to-list 'marginalia-prompt-categories '\("\\<buffer\\>" . buffer))
-  (add-to-list 'marginalia-prompt-categories '\("\\<file\\>" . file))
+  (add-to-list 'marginalia-prompt-categories '("\\<buffer\\>" . buffer))
+  (add-to-list 'marginalia-prompt-categories '("\\<file\\>" . file))
 
   (marginalia-mode 1))
 

--- a/emacs/lisp/bv-core.el
+++ b/emacs/lisp/bv-core.el
@@ -203,6 +203,20 @@
   "Ensure X is a list."
   (if (listp x) x (list x)))
 
+;;;; Keybinding Helpers
+
+(defmacro bv-leader (&rest bindings)
+  "Bind key sequences in `bv-app-map`.
+BINDINGS is a flat list of key/command pairs."
+  (declare (indent 1))
+  (let (forms)
+    (while bindings
+      (let ((key (pop bindings))
+            (cmd (pop bindings)))
+        (when (and cmd (not (keywordp cmd)))
+          (push `(define-key bv-app-map (kbd ,key) ,cmd) forms)))
+    `(progn ,@(nreverse forms))))
+
 ;;;; Package Management Helpers
 
 (defun bv-package-installed-p (package)


### PR DESCRIPTION
## Summary
- add missing `bv-leader` macro in `bv-core`
- correct quoting for marginalia categories
- document fixes in changelog

## Testing
- `./scripts/style.sh`

------
https://chatgpt.com/codex/tasks/task_e_684ac1a0befc832bafaa093cc5c4a69c