### PR TITLE
Fix unmatched parenthesis in bv-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Pruned deprecated and platform-specific options from `git/gitconfig`.
 ### Fixed
 - Balanced parentheses in `emacs/lisp/bv-core.el`.
+- Added missing closing parenthesis in `bv-core.el` to fix initialization error.
 - Added `bv-leader` macro and corrected quoting in completion and writing modules.
 - Prevented startup errors when optional packages are missing.
 - Closed unmatched parentheses in `bv-research.el` and removed invalid key binding from `bv-productivity.el`.

--- a/emacs/lisp/bv-core.el
+++ b/emacs/lisp/bv-core.el
@@ -257,6 +257,7 @@ BINDINGS is a flat list of key/command pairs."
              bv-config-values)
 
     (display-buffer (current-buffer))))
+  )
 
 (provide 'bv-core)
 ;;; bv-core.el ends here


### PR DESCRIPTION
## Summary
- fix missing closing parenthesis in `bv-core.el`
- note the initialization fix in the changelog

## Testing
- `grep -o "(" -n emacs/lisp/bv-core.el | wc -l`
- `grep -o ")" -n emacs/lisp/bv-core.el | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_684ac62e7638832ba0e409db496b2036