### PR TITLE
Fix Emacs initialization errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Removed URL rewrite aliases from `git/gitconfig`.
 - Pruned deprecated and platform-specific options from `git/gitconfig`.
 ### Fixed
+- Addressed syntax errors in `bv-writing.el` and `bv-core.el` that
+  prevented productivity modules from loading.
 - Balanced parentheses in `emacs/lisp/bv-core.el`.
 - Added missing closing parenthesis in `bv-core.el` to fix initialization error.
 - Added `bv-leader` macro and corrected quoting in completion and writing modules.

--- a/emacs/lisp/bv-core.el
+++ b/emacs/lisp/bv-core.el
@@ -256,7 +256,7 @@ BINDINGS is a flat list of key/command pairs."
                                  (prin1-to-string value)))))
              bv-config-values)
 
-    (display-buffer (current-buffer))))
+    (display-buffer (current-buffer)))
   )
 
 (provide 'bv-core)

--- a/emacs/lisp/bv-writing.el
+++ b/emacs/lisp/bv-writing.el
@@ -116,6 +116,7 @@
     (setq ispell-dictionary "en_US")
     (setq ispell-local-dictionary-alist
           '(("en_US" "[[:alpha:]]" "[^[:alpha:]]" "['"]" nil ("-d" "en_US") nil utf-8)))
+    )
   
   (setq ispell-dictionary bv-writing-default-dictionary)
   (setq ispell-personal-dictionary bv-writing-personal-dictionary)


### PR DESCRIPTION
## Summary
- fix missing closing paren in bv-writing hunspell config
- remove extra paren in bv-core config reporting helper
- document fix in changelog

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684adde73dfc832ba1ca7552cc8f273e