### PR TITLE
Fix unmatched parens in Emacs modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Corrected dictionary list syntax and removed conflicting GPT keybindings.
 - Fixed duplicate multimedia playlist keybinding and ensured parentheses
   balance in `bv-multimedia.el`.
+- Balanced unmatched parentheses across core and multimedia modules.
 ### Removed
 - Old Emacs configuration to prepare for a new setup.
 - Removed Airflow container service from `ragnar` machine.

--- a/emacs/lisp/bv-core.el
+++ b/emacs/lisp/bv-core.el
@@ -214,7 +214,7 @@ BINDINGS is a flat list of key/command pairs."
       (let ((key (pop bindings))
             (cmd (pop bindings)))
         (when (and cmd (not (keywordp cmd)))
-          (push `(define-key bv-app-map (kbd ,key) ,cmd) forms)))
+          (push `(define-key bv-app-map (kbd ,key) ,cmd) forms))))
     `(progn ,@(nreverse forms))))
 
 ;;;; Package Management Helpers

--- a/emacs/lisp/bv-multimedia.el
+++ b/emacs/lisp/bv-multimedia.el
@@ -135,7 +135,7 @@ _l_: playlist    _q_: quit
                          "scrot %s"))))
     (shell-command (format command filename))
     (message "Screenshot saved: %s" filename)
-    (kill-new filename)))
+    (kill-new filename))))
 
 ;;; Global Keybindings
 (with-eval-after-load 'bv-core


### PR DESCRIPTION
## Summary
- correct missing closing parens in `bv-core.el`
- fix screenshot helper in `bv-multimedia.el`
- note fix in changelog

## Testing
- `emacs --batch emacs/lisp/bv-core.el --eval '(check-parens)'`
- `emacs --batch emacs/lisp/bv-multimedia.el --eval '(check-parens)'`
- `for f in emacs/lisp/*.el; do emacs --batch $f --eval '(check-parens)'; done`

------
https://chatgpt.com/codex/tasks/task_e_684ae55d6cc8832ba28ce1800c8aa5c0