### PR TITLE
Guard fringe setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed duplicate multimedia playlist keybinding and ensured parentheses
   balance in `bv-multimedia.el`.
 - Balanced unmatched parentheses across core and multimedia modules.
+- Guarded fringe configuration to avoid errors in non-graphical builds.
 ### Removed
 - Old Emacs configuration to prepare for a new setup.
 - Removed Airflow container service from `ragnar` machine.

--- a/emacs/lisp/bv-ui.el
+++ b/emacs/lisp/bv-ui.el
@@ -112,9 +112,9 @@
   (when (fboundp 'tool-bar-mode) (tool-bar-mode -1))
   (when (fboundp 'scroll-bar-mode) (scroll-bar-mode -1))
 
-  ;; Set fringe width
-  (when bv-ui-fringes
-    (set-fringe-mode bv-ui-fringes))
+  ;; Set fringe width when available
+  (when (and bv-ui-fringes (fboundp 'set-fringe-style))
+    (set-fringe-style bv-ui-fringes))
 
   ;; Window dividers
   (setq window-divider-default-right-width bv-ui-margin)


### PR DESCRIPTION
## Summary
- avoid calling `set-fringe-mode` when unavailable
- note fringe guard in the changelog

## Testing
- `emacs --batch -Q --eval "(add-to-list 'load-path \"emacs/lisp\") (byte-compile-file \"emacs/lisp/bv-ui.el\")"`
- `emacs --batch -Q --eval "(add-to-list 'load-path \"emacs/lisp\") (byte-compile-file \"emacs/lisp/bv-core.el\")"`

------
https://chatgpt.com/codex/tasks/task_e_684aee57521c832b81236d9b7de09e2c