### PR TITLE
Replace multimedia config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed syntax error in `bv-writing.el` at line 118 caused by unmatched closing bracket.
 - Resolved keybinding conflict in `bv-communication.el` where 'w' was used as both a command and prefix key.
 - Fixed `org-clocking-p` error in `bv-productivity.el` mode-line indicator by adding proper function existence check.
+- Replaced multimedia configuration to resolve `M m` prefix key error.
 ### Removed
 - Old Emacs configuration to prepare for a new setup.
 - Removed Airflow container service from `ragnar` machine.

--- a/emacs/lisp/bv-multimedia.el
+++ b/emacs/lisp/bv-multimedia.el
@@ -135,16 +135,19 @@ _l_: playlist    _q_: quit
                          "scrot %s"))))
     (shell-command (format command filename))
     (message "Screenshot saved: %s" filename)
-    (kill-new filename))))
+    (kill-new filename)))
 
 ;;; Global Keybindings
 (with-eval-after-load 'bv-core
-  (bv-leader
-    "M" '(:ignore t :which-key "multimedia")
-    "M m" #'bv-multimedia-hydra/body
-    "M o" #'bv-multimedia-open-externally
-    "M u" #'bv-multimedia-play-url
-    "M s" #'bv-multimedia-screenshot))
+  ;; Create multimedia prefix map
+  (define-prefix-command 'bv-multimedia-map)
+  (define-key bv-app-map "M" 'bv-multimedia-map)
+  
+  ;; Bind multimedia commands
+  (define-key bv-multimedia-map "m" #'bv-multimedia-hydra/body)
+  (define-key bv-multimedia-map "o" #'bv-multimedia-open-externally)
+  (define-key bv-multimedia-map "u" #'bv-multimedia-play-url)
+  (define-key bv-multimedia-map "s" #'bv-multimedia-screenshot))
 
 ;;;; Feature Definition
 (defun bv-multimedia-load ()
@@ -153,7 +156,7 @@ _l_: playlist    _q_: quit
   
   ;; Only start EMMS if music directory exists
   (when (file-directory-p bv-multimedia-music-directory)
-    (require 'emms-setup))
+    (require 'emms-setup nil t))
   
   (message "Multimedia tools loaded"))
 


### PR DESCRIPTION
## Summary
- update multimedia module to fix prefix key issues
- note fix in changelog

## Testing
- `emacs --batch -Q --eval "(byte-compile-file \"emacs/lisp/bv-multimedia.el\")"` *(fails: emacs not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684b09b02d38832b844d66f1b0be7162