### PR TITLE
Fix git-gutter optional hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Resolved keybinding conflict in `bv-communication.el` where 'w' was used as both a command and prefix key.
 - Fixed `org-clocking-p` error in `bv-productivity.el` mode-line indicator by adding proper function existence check.
 - Replaced multimedia configuration to resolve `M m` prefix key error.
+- Checked for `git-gutter` before enabling hooks to avoid missing function errors.
 ### Removed
 - Old Emacs configuration to prepare for a new setup.
 - Removed Airflow container service from `ragnar` machine.

--- a/emacs/lisp/bv-git.el
+++ b/emacs/lisp/bv-git.el
@@ -69,11 +69,13 @@
 ;;;; Git Gutter
 (use-package git-gutter
   :defer t
+  :commands git-gutter-mode
   :diminish git-gutter-mode
   :init
-  (when bv-git-enable-gutter
-    (add-hook 'prog-mode-hook 'git-gutter-mode)
-    (add-hook 'text-mode-hook 'git-gutter-mode))
+  (when (and bv-git-enable-gutter (locate-library "git-gutter"))
+    (autoload 'git-gutter-mode "git-gutter" nil t)
+    (add-hook 'prog-mode-hook #'git-gutter-mode)
+    (add-hook 'text-mode-hook #'git-gutter-mode))
   :custom
   (git-gutter:lighter " GG")
   :config


### PR DESCRIPTION
## Summary
- guard git-gutter hooks when the package isn't installed
- note the fix in the changelog

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684d75ddd474832bb8a6992ae824ce32