### PR TITLE
Fix Emacs profile load path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Fixed `org-clocking-p` error in `bv-productivity.el` mode-line indicator by adding proper function existence check.
 - Replaced multimedia configuration to resolve `M m` prefix key error.
 - Checked for `git-gutter` before enabling hooks to avoid missing function errors.
+- Added Guix profile directories to `load-path` to resolve missing packages like
+  `highlight-indent-guides`.
 ### Removed
 - Old Emacs configuration to prepare for a new setup.
 - Removed Airflow container service from `ragnar` machine.

--- a/emacs/init.el
+++ b/emacs/init.el
@@ -40,6 +40,18 @@
 ;; Add lisp directory to load path
 (add-to-list 'load-path bv-lisp-dir)
 
+;; Include Guix profile packages
+(dolist (profile (list (getenv "GUIX_PROFILE")
+                       (expand-file-name "~/.guix-profile")
+                       (expand-file-name "~/.guix-home/profile")))
+  (let ((site-lisp (and profile
+                        (expand-file-name "share/emacs/site-lisp" profile))))
+    (when (file-directory-p site-lisp)
+      (add-to-list 'load-path site-lisp)
+      (let ((default-directory site-lisp))
+        (normal-top-level-add-to-load-path '("."))
+        (normal-top-level-add-subdirs-to-load-path)))))
+
 ;;;; Package management setup
 ;; Skip package.el when using Guix
 (if (or (getenv "GUIX_ENVIRONMENT") 


### PR DESCRIPTION
## Summary
- load Guix profile site-lisp directories during init so packages such as `highlight-indent-guides` are found
- note this fix in the changelog

## Testing
- `./scripts/style.sh` *(fails: find: ‘guix’: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684d7bfede58832bba619fd2c1ec5d9b