### PR TITLE
Remove flymake-indicator from config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,3 +51,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Old Emacs configuration to prepare for a new setup.
 - Removed Airflow container service from `ragnar` machine.
 - Eliminated Haskell configuration and packages.
+- Removed flymake-indicator package configuration.

--- a/emacs/lisp/bv-development.el
+++ b/emacs/lisp/bv-development.el
@@ -288,10 +288,6 @@
   ;; Don't popup automatically
   (remove-hook 'flymake-diagnostic-functions #'flymake-proc-legacy-flymake))
 
-;; Flymake indicators
-(use-package flymake-indicator
-  :after flymake
-  :hook (flymake-mode . flymake-indicator-mode))
 
 ;;;; Xref - Cross References
 


### PR DESCRIPTION
## Summary
- remove the `flymake-indicator` package from `bv-development.el`
- note removal in `CHANGELOG`

## Testing
- `./scripts/style.sh` *(fails: `guix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9272577c832baaabb4a3a5a891cd