### PR TITLE
Fix Smartparens M-s binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Balanced unmatched parentheses across core and multimedia modules.
 - Guarded fringe configuration to avoid errors in non-graphical builds.
 - Fixed invalid dictionary syntax and stray parens in `bv-writing.el`.
+- Removed invalid `M-s` unbinding that caused a smartparens error.
 - Added prefix map to resolve `P P` keybinding error in `bv-productivity.el`.
 - Fixed syntax error in `bv-writing.el` at line 118 caused by unmatched closing bracket.
 - Resolved keybinding conflict in `bv-communication.el` where 'w' was used as both a command and prefix key.

--- a/emacs/lisp/bv-development.el
+++ b/emacs/lisp/bv-development.el
@@ -138,8 +138,9 @@
   (when bv-dev-paredit-bindings
     (sp-use-paredit-bindings))
 
-  ;; Remove conflicting binding
-  (define-key smartparens-mode-map (kbd "M-s") nil)
+  ;; Remove conflicting binding using bind-key helper
+  (require 'bind-key)
+  (unbind-key "M-s" smartparens-mode-map)
 
   ;; Show smartparens mode
   (if bv-dev-smartparens-show-pairs


### PR DESCRIPTION
## Summary
- use bind-key to properly unbind `M-s` in smartparens
- document the fix in the changelog

## Testing
- `git diff --staged`


------
https://chatgpt.com/codex/tasks/task_e_684d93717820832b8f2ff2dcb64a5851