### PR TITLE
Update early-init with theme-aware flash prevention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Removed URL rewrite aliases from `git/gitconfig`.
 - Pruned deprecated and platform-specific options from `git/gitconfig`.
 - Removed Guix environment checks from `emacs/init.el`; rely on `EMACSLOADPATH`.
+- Replaced `emacs/early-init.el` with theme-aware flash prevention and
+  performance optimizations.
 ### Fixed
 - Addressed syntax errors in `bv-writing.el` and `bv-core.el` that
   prevented productivity modules from loading.

--- a/emacs/early-init.el
+++ b/emacs/early-init.el
@@ -1,77 +1,146 @@
 ;;; early-init.el --- Early initialization -*- lexical-binding: t; no-byte-compile: t -*-
-
 ;;; Commentary:
 ;; Early initialization for Emacs 30+
-;; Target: sub-0.5s startup time
-
+;; Optimized for fast startup with theme-aware flash prevention
 ;;; Code:
 
-;;;; Performance optimizations
+;;;; Flash Prevention
+;; Set initial background based on time to prevent white flash
+(defun bv-set-initial-background ()
+  "Set initial background color based on time of day to reduce startup flash."
+  (let ((hour (string-to-number (format-time-string "%H"))))
+    (cond
+     ;; Morning: soft light
+     ((and (>= hour 5) (< hour 10))
+      (set-face-background 'default "#fbf7f0")
+      (set-face-foreground 'default "#000000"))
+     ;; Day: full light
+     ((and (>= hour 10) (< hour 18))
+      (set-face-background 'default "#ffffff")
+      (set-face-foreground 'default "#000000"))
+     ;; Evening: soft dark
+     ((and (>= hour 18) (< hour 23))
+      (set-face-background 'default "#0d0e1c")
+      (set-face-foreground 'default "#ffffff"))
+     ;; Night: full dark
+     (t
+      (set-face-background 'default "#000000")
+      (set-face-foreground 'default "#ffffff")))))
+
+;; Apply immediately to prevent flash
+(bv-set-initial-background)
+
+;;;; Performance Optimizations
 
 ;; Defer garbage collection during startup
-(setq gc-cons-threshold most-positive-fixnum
-      gc-cons-percentage 0.6)
+(setq gc-cons-threshold (* 4 1024 1024 1024)
+      gc-cons-percentage 0.8)
+
+;; Store initial file-name-handler-alist
+(defvar bv--file-name-handler-alist file-name-handler-alist)
+(setq file-name-handler-alist nil)
 
 ;; Reset after startup
 (add-hook 'emacs-startup-hook
           (lambda ()
-            (setq gc-cons-threshold (* 100 1024 1024)
-                  gc-cons-percentage 1.0)))
+            (setq gc-cons-threshold (* 512 1024 1024)
+                  gc-cons-percentage 0.2
+                  file-name-handler-alist bv--file-name-handler-alist)))
 
-;; Prevent unwanted runtime compilation
-(setq native-comp-deferred-compilation nil
-      native-comp-jit-compilation nil)
+;; Native compilation
+(when (boundp 'native-comp-eln-load-path)
+  (setq native-comp-async-jobs-number 8)
+  (setq native-comp-async-query-on-exit nil)
+  (setq native-comp-async-report-warnings-errors nil)
+  (setq native-comp-jit-compilation t)
+  (setq native-comp-deferred-compilation t)
+  (setq native-comp-speed 3))
+
+;; Process output
+(setq read-process-output-max (* 4 1024 1024))
+
+;; Increase undo limits
+(setq undo-limit (* 16 1024 1024))
+(setq undo-strong-limit (* 24 1024 1024))
+(setq undo-outer-limit (* 128 1024 1024))
 
 ;; Disable package.el (using Guix)
 (setq package-enable-at-startup nil
       package--init-file-ensured t)
 
-;; Inhibit resizing frame
-(setq frame-inhibit-implied-resize t)
-
-;; Disable startup features
-(setq inhibit-startup-screen t
-      inhibit-startup-message t
-      inhibit-startup-echo-area-message user-login-name
-      initial-scratch-message nil)
-
 ;; Prevent stale bytecode
 (setq load-prefer-newer t)
 
-;;;; UI optimizations
+;; Better subprocess handling
+(setq process-adaptive-read-buffering nil)
 
-;; Remove all bars early
-(push '(menu-bar-lines . 0) default-frame-alist)
-(push '(tool-bar-lines . 0) default-frame-alist)
-(push '(vertical-scroll-bars) default-frame-alist)
-(push '(horizontal-scroll-bars) default-frame-alist)
+;;;; UI Optimizations
 
-;; Minimal UI with margins
-(push '(internal-border-width . 8) default-frame-alist)
-(push '(left-fringe . 8) default-frame-alist)
-(push '(right-fringe . 8) default-frame-alist)
-
-;; Frame size
-(push '(width . 140) default-frame-alist)
-(push '(height . 50) default-frame-alist)
-
-;; Disable UI elements before load
+;; Disable UI elements before they're loaded
 (setq menu-bar-mode nil
       tool-bar-mode nil
       scroll-bar-mode nil)
 
-;; Smooth scrolling
-(when (boundp 'pixel-scroll-precision-mode)
-  (setq pixel-scroll-precision-use-momentum t))
+;; Frame parameters
+(setq default-frame-alist
+      '((menu-bar-lines . 0)
+        (tool-bar-lines . 0)
+        (vertical-scroll-bars)
+        (horizontal-scroll-bars)
+        (internal-border-width . 8)
+        (left-fringe . 8)
+        (right-fringe . 8)
+        (width . 120)
+        (height . 40)
+        (alpha . (98 . 98))
+        (undecorated . t)))
 
-;; Optimize file handling
-(setq vc-handled-backends nil)  ; Disable VC early
-(setq create-lockfiles nil)
-(setq make-backup-files nil)
+;; Frame behavior
+(setq frame-resize-pixelwise t
+      frame-inhibit-implied-resize t)
+
+;; Startup settings
+(setq inhibit-startup-screen t
+      inhibit-startup-message t
+      inhibit-startup-echo-area-message user-login-name
+      initial-scratch-message nil
+      inhibit-x-resources t
+      inhibit-startup-buffer-menu t)
+
+;; Smooth scrolling preparation
+(when (boundp 'pixel-scroll-precision-mode)
+  (setq pixel-scroll-precision-use-momentum t
+        pixel-scroll-precision-interpolation-total-time 0.18
+        pixel-scroll-precision-interpolation-between-scroll 0.01))
+
+;; Font rendering
+(setq-default bidi-display-reordering 'left-to-right
+              bidi-paragraph-direction 'left-to-right)
+(setq bidi-inhibit-bpa t)
+(setq auto-window-vscroll nil)
+(setq fast-but-imprecise-scrolling t)
+(setq jit-lock-defer-time 0)
+(setq redisplay-skip-fontification-on-input t)
+
+;; File handling
+(setq vc-handled-backends nil  ; Disable VC during startup
+      create-lockfiles nil
+      make-backup-files nil
+      auto-save-default nil)
+
+;; History and cache sizes
+(setq history-length 10000
+      kill-ring-max 10000
+      mark-ring-max 64
+      global-mark-ring-max 128)
 
 ;; Silence warnings
 (setq native-comp-async-report-warnings-errors nil
       warning-minimum-level :error)
+
+;; Misc performance
+(setq idle-update-delay 0.5)
+(setq inhibit-compacting-font-caches t)
 
 (provide 'early-init)
 ;;; early-init.el ends here


### PR DESCRIPTION
## Summary
- replace `emacs/early-init.el` with optimized version
- note change in changelog

## Testing
- `emacs --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfef3b5b4832baee146a56146aee5