### PR TITLE
Harden fleetctl operations and improve Emacs remote copies

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ activate       # Source venv/bin/activate
 - [`harvester`](docs/bin/harvester.md) - Download and organize ArXiv papers
 
 ### Remote Operations
-- [`fleetctl`](docs/bin/fleetctl.md) - Private fleet inventory and reliable remote execution/sync
+- [`fleetctl`](docs/bin/fleetctl.md) - Private fleet inventory, role-based admission control, and remote execution/sync
 
 `./setup.sh` now installs the `fleetctl` operator surface from `bin/` and, when
 the `infra/fleet` pass prefix exists locally, regenerates `~/.config/fleet/`

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -102,6 +102,7 @@ class FleetSecret:
     server_alive_interval: int = 30
     server_alive_count_max: int = 3
     strict_host_key_checking: str | None = None
+    batch_mode: bool | None = None
     extra_options: dict[str, str] = field(default_factory=dict)
 
     @property
@@ -769,6 +770,7 @@ def parse_secret_dict(raw: dict[str, Any]) -> FleetSecret:
     password = optional_str(raw.get("password"))
     proxy_jump = optional_str(raw.get("proxy_jump"))
     strict_host_key_checking = optional_str(raw.get("strict_host_key_checking"))
+    batch_mode_raw = raw.get("batch_mode")
     extra_options_raw = raw.get("ssh_option", {})
     return FleetSecret(
         host=host,
@@ -785,6 +787,7 @@ def parse_secret_dict(raw: dict[str, Any]) -> FleetSecret:
         server_alive_interval=int(raw.get("server_alive_interval", 30)),
         server_alive_count_max=int(raw.get("server_alive_count_max", 3)),
         strict_host_key_checking=strict_host_key_checking,
+        batch_mode=None if batch_mode_raw is None else bool(batch_mode_raw),
         extra_options={
             str(key): str(value) for key, value in dict(extra_options_raw).items()
         },
@@ -1210,11 +1213,37 @@ def ssh_option_parts(
             "-o",
             "PubkeyAuthentication=no",
         ]
-    else:
+    elif use_batch_mode(secret):
         options += ["-o", "BatchMode=yes"]
     for key, value in secret.extra_options.items():
         options += ["-o", f"{key}={value}"]
     return options
+
+
+def interactive_terminal_available() -> bool:
+    """True when a human could answer an ssh passphrase or 2FA prompt."""
+    for stream in (sys.stdin, sys.stdout, sys.stderr):
+        try:
+            if stream is not None and stream.isatty():
+                return True
+        except (AttributeError, ValueError):
+            continue
+    return False
+
+
+def use_batch_mode(secret: FleetSecret) -> bool:
+    """Decide whether ssh should be forbidden from prompting.
+
+    `BatchMode=yes` used to be forced on every key-auth target, which makes a
+    passphrase-protected key with no agent loaded, or a site using
+    keyboard-interactive 2FA, impossible to reach at all.  Prompting is allowed
+    whenever there is a terminal to answer on; with no terminal -- cron, CI, a
+    pipeline -- batch mode still turns a silent hang into a fast clean failure.
+    `batch_mode` in the secret record overrides the heuristic either way.
+    """
+    if secret.batch_mode is not None:
+        return secret.batch_mode
+    return not interactive_terminal_available()
 
 
 def ssh_transport_prefix(secret: FleetSecret) -> list[str]:
@@ -2105,6 +2134,8 @@ def secret_to_toml(secret: FleetSecret) -> str:
             "strict_host_key_checking = "
             f"{toml_string(secret.strict_host_key_checking)}"
         )
+    if secret.batch_mode is not None:
+        lines.append(f"batch_mode = {'true' if secret.batch_mode else 'false'}")
     for key, value in sorted(secret.extra_options.items()):
         lines.append(f"ssh_option.{toml_key(key)} = {toml_string(value)}")
     return "\n".join(lines) + "\n"

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -137,6 +137,54 @@ def authorize(
     )
 
 
+def check_role_protocol(target: "TargetRecord", protocol: "ProtocolRecord") -> None:
+    """A role and a protocol must agree about whether compute is scheduled here.
+
+    `role = "login"` with a direct protocol is precisely the fail-open state this
+    section exists to prevent: the matrix would demand --admin for `exec`, and the
+    protocol would then run the job on the login node anyway.  The mirror case is
+    just as wrong -- a workstation pointed at a scheduler protocol makes `submit`
+    call `sbatch` on a box with no scheduler.
+    """
+    if target.role is None:
+        return  # inferred from the protocol, so coherent by construction
+    scheduled = protocol.kind != "direct"
+    if target.role == "login" and not scheduled:
+        raise FleetError(
+            f"target {target.name!r} declares role \"login\" but protocol "
+            f"{protocol.name!r} runs work directly. A login role means compute goes "
+            "through `fleetctl submit`, so point it at the site's scheduler protocol "
+            "or give the machine the role it really has."
+        )
+    if target.role != "login" and scheduled:
+        raise FleetError(
+            f"target {target.name!r} declares role {target.role!r} but protocol "
+            f"{protocol.name!r} is scheduler-backed. Only a login role submits "
+            "through a scheduler."
+        )
+
+
+def check_protocol_profile(
+    target: "TargetRecord",
+    protocol: "ProtocolRecord",
+    profile: "ProfileRecord",
+) -> None:
+    """A profile submits if and only if its protocol has a scheduler to submit to."""
+    submits = bool(profile.submit_command)
+    if protocol.kind != "direct" and not submits:
+        raise FleetError(
+            f"target {target.name!r} resolves to profile {profile.name!r}, which "
+            f"defines no `submit_command`, but protocol {protocol.name!r} is "
+            "scheduler-backed: `fleetctl submit` has nothing to call."
+        )
+    if protocol.kind == "direct" and submits:
+        raise FleetError(
+            f"target {target.name!r} resolves to profile {profile.name!r}, which "
+            f"defines `submit_command`, but protocol {protocol.name!r} runs work "
+            "directly: there is no scheduler on that host to accept the job."
+        )
+
+
 EXEC_REMOTE_STUB = """\
 import base64
 import json
@@ -211,7 +259,6 @@ class TargetRecord:
     secret_inline: dict[str, Any] = field(default_factory=dict)
     ssh_host_alias: str | None = None
     default_profile: str | None = None
-    scheduler: str = "none"
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -231,7 +278,6 @@ class ProfileRecord:
     """Execution behavior for one class of target."""
 
     name: str
-    kind: str = "direct"
     interpreter: str | None = "/usr/bin/env bash"
     remote_script_root: str = DEFAULT_SCRIPT_REMOTE_ROOT
     environment: dict[str, str] = field(default_factory=dict)
@@ -269,8 +315,6 @@ class ProtocolRecord:
     kind: str = "direct"
     description: str | None = None
     default_profile: str | None = None
-    scheduler_required: bool = False
-    allow_login_exec: bool = True
     smoke_gpu_probe: bool = True
     gpu_request_mode: str = "gres"
     job_runtime: str = "host"
@@ -351,6 +395,7 @@ class FleetContext:
         config_home: Path | None = None,
         state_home: Path | None = None,
         cache_home: Path | None = None,
+        strict: bool = True,
     ) -> "FleetContext":
         paths = build_paths(
             config_home=config_home,
@@ -364,7 +409,7 @@ class FleetContext:
         protocols = load_protocols(paths.protocols_dir)
         profiles = load_profiles(paths.profiles_dir)
         projects = load_projects(paths.projects_file)
-        return cls(
+        context = cls(
             paths=paths,
             config=config,
             targets=targets,
@@ -373,6 +418,29 @@ class FleetContext:
             profiles=profiles,
             projects=projects,
         )
+        if strict:
+            problems = context.coherence_problems()
+            if problems:
+                raise FleetError(
+                    "fleet config is incoherent:\n  - " + "\n  - ".join(problems)
+                )
+        return context
+
+    def coherence_problems(self) -> list[str]:
+        """Return every role/protocol/profile disagreement in the inventory.
+
+        All of them, not the first: fixing a config one error per run is why
+        people stop reading errors.  Pure TOML resolution, so this costs nothing
+        and runs on every load.
+        """
+        problems: list[str] = []
+        for target in self.targets.values():
+            try:
+                self.resolve_protocol(target)
+                self.resolve_profile(target, None, None)
+            except FleetError as exc:
+                problems.append(str(exc))
+        return problems
 
     def project_binding_for(self, path: Path | None = None) -> ProjectBinding | None:
         """Return the longest-prefix project binding for PATH or current cwd."""
@@ -480,21 +548,23 @@ class FleetContext:
             raise FleetError(
                 f"profile {chosen!r} is not configured; initialize fleet config first"
             )
-        return self.profiles[chosen]
+        profile = self.profiles[chosen]
+        check_protocol_profile(target, protocol, profile)
+        return profile
 
     def resolve_protocol(self, target: TargetRecord) -> ProtocolRecord:
         """Resolve the behavior protocol for TARGET."""
         chosen = target.protocol
         if chosen is None:
-            if target.scheduler != "none":
-                chosen = "slurm"
-            else:
-                chosen = "direct"
+            raise FleetError(
+                f"target {target.name!r} does not declare `protocol`"
+            )
         protocol = self.protocols.get(chosen)
         if protocol is None:
             raise FleetError(
                 f"target {target.name!r} refers to unknown protocol {chosen!r}"
             )
+        check_role_protocol(target, protocol)
         return protocol
 
     def resolve_secret(self, target: TargetRecord) -> FleetSecret:
@@ -622,7 +692,6 @@ TARGET_KEYS = frozenset(
         "secret",
         "ssh_host_alias",
         "default_profile",
-        "scheduler",
         "metadata",
     }
 )
@@ -636,8 +705,6 @@ PROTOCOL_KEYS = frozenset(
         "kind",
         "description",
         "default_profile",
-        "scheduler_required",
-        "allow_login_exec",
         "smoke_gpu_probe",
         "gpu_request_mode",
         "job_runtime",
@@ -670,7 +737,6 @@ PROFILE_KEYS = frozenset(
     {
         "version",
         "name",
-        "kind",
         "script",
         "environment",
         "submit_command",
@@ -717,13 +783,28 @@ SECRET_KEYS = frozenset(
 
 TRANSPORTS = ("ssh",)
 SECRET_BACKENDS = ("file", "pass", "inline")
-SCHEDULERS = ("none", "slurm")
 POOL_STRATEGIES = ("ordered", "random")
 PROTOCOL_KINDS = ("direct", "slurm")
-PROFILE_KINDS = ("direct", "scheduler")
 GPU_REQUEST_MODES = ("none", "gpus", "gres")
 AUTH_MODES = ("key", "password")
 STRICT_HOST_KEY_MODES = ("yes", "no", "off", "ask", "accept-new")
+
+# Keys that used to mean something and no longer do.  Four fields described one
+# property -- "does compute here go through a scheduler" -- and disagreed with
+# each other; `role` and `submit_command` now answer it once each.  They stay
+# *accepted* so an unmigrated fleet keeps loading, but nothing reads them, and
+# `doctor` names every file still carrying one.  Tolerating a key is a decision,
+# so it is written down here rather than hidden as a stray entry in a key set.
+DEPRECATED_TARGET_KEYS: dict[str, str] = {
+    "scheduler": "what may run here is decided by `role`; `protocol` is required",
+}
+DEPRECATED_PROTOCOL_KEYS: dict[str, str] = {
+    "scheduler_required": "the role matrix decides this for every verb",
+    "allow_login_exec": "the role matrix decides this; pass --admin per command",
+}
+DEPRECATED_PROFILE_KEYS: dict[str, str] = {
+    "kind": "derived from whether the profile defines `submit_command`",
+}
 
 
 def reject_unknown_keys(
@@ -733,10 +814,16 @@ def reject_unknown_keys(
     what: str,
     source: Path | None = None,
     guidance: dict[str, str] | None = None,
+    deprecated: dict[str, str] | None = None,
 ) -> None:
-    """Fail on any key the loader would otherwise ignore."""
+    """Fail on any key the loader would otherwise ignore.
+
+    DEPRECATED keys are accepted and ignored -- never suggested as a correction,
+    because steering a typo towards a dead field is worse than no suggestion.
+    """
     known_keys = sorted(known)
-    unknown = sorted(key for key in raw if key not in set(known_keys))
+    tolerated = set(known_keys) | set(deprecated or ())
+    unknown = sorted(key for key in raw if key not in tolerated)
     if not unknown:
         return
     hints: list[str] = []
@@ -891,7 +978,18 @@ def load_targets(path: Path) -> dict[str, TargetRecord]:
             what=what,
             source=source,
             guidance=TARGET_FILE_WARNINGS,
+            deprecated=DEPRECATED_TARGET_KEYS,
         )
+        # fleetctl used to fall back to `scheduler` when `protocol` was absent, so
+        # the obvious way to add a Slurm box -- tags and no protocol -- produced a
+        # direct target you could run training jobs on.  Naming the protocol is one
+        # word and removes the guess entirely.
+        if optional_str(raw.get("protocol")) is None:
+            raise FleetError(
+                f"{what} in {source} does not declare `protocol`. Name `direct` for "
+                "a machine you run work on yourself, or the site's protocol for a "
+                "scheduler surface; fleetctl no longer guesses."
+            )
         target = TargetRecord(
             name=name,
             enabled=bool(raw.get("enabled", True)),
@@ -925,13 +1023,6 @@ def load_targets(path: Path) -> dict[str, TargetRecord]:
             ),
             ssh_host_alias=optional_str(raw.get("ssh_host_alias")),
             default_profile=optional_str(raw.get("default_profile")),
-            scheduler=check_vocabulary(
-                str(raw.get("scheduler", "none")),
-                SCHEDULERS,
-                what=what,
-                key="scheduler",
-                source=source,
-            ),
             metadata=check_table(
                 raw.get("metadata", {}), what=f"`metadata` for {what}", source=source
             ),
@@ -981,8 +1072,6 @@ def built_in_protocols() -> dict[str, ProtocolRecord]:
         kind="direct",
         description="Direct SSH execution on a host-level workdir.",
         default_profile="plain-ssh",
-        scheduler_required=False,
-        allow_login_exec=True,
         smoke_gpu_probe=True,
         gpu_request_mode="gres",
         job_runtime="host",
@@ -993,8 +1082,6 @@ def built_in_protocols() -> dict[str, ProtocolRecord]:
         kind="slurm",
         description="Scheduler-backed login surface that submits compute via Slurm.",
         default_profile="slurm-batch",
-        scheduler_required=True,
-        allow_login_exec=False,
         smoke_gpu_probe=False,
         gpu_request_mode="gres",
         job_runtime="host",
@@ -1012,7 +1099,13 @@ def load_protocols(path: Path) -> dict[str, ProtocolRecord]:
     for name, raw, source in load_records_from_dir(path, kind="protocol"):
         what = f"protocol {name!r}"
         check_version(raw, what=what, source=source)
-        reject_unknown_keys(raw, PROTOCOL_KEYS, what=what, source=source)
+        reject_unknown_keys(
+            raw,
+            PROTOCOL_KEYS,
+            what=what,
+            source=source,
+            deprecated=DEPRECATED_PROTOCOL_KEYS,
+        )
         queues: list[QueueRecord] = []
         for item in raw.get("queue", []):
             if not isinstance(item, dict):
@@ -1080,10 +1173,6 @@ def load_protocols(path: Path) -> dict[str, ProtocolRecord]:
             description=optional_str(raw.get("description")),
             default_profile=optional_str(raw.get("default_profile"))
             or ("slurm-batch" if kind == "slurm" else "plain-ssh"),
-            scheduler_required=bool(
-                raw.get("scheduler_required", kind == "slurm")
-            ),
-            allow_login_exec=bool(raw.get("allow_login_exec", kind != "slurm")),
             smoke_gpu_probe=bool(raw.get("smoke_gpu_probe", kind != "slurm")),
             gpu_request_mode=check_vocabulary(
                 str(raw.get("gpu_request_mode", "gres")),
@@ -1134,7 +1223,13 @@ def load_profiles(path: Path) -> dict[str, ProfileRecord]:
     for name, raw, source in load_records_from_dir(path, kind="profile"):
         what = f"profile {name!r}"
         check_version(raw, what=what, source=source)
-        reject_unknown_keys(raw, PROFILE_KEYS, what=what, source=source)
+        reject_unknown_keys(
+            raw,
+            PROFILE_KEYS,
+            what=what,
+            source=source,
+            deprecated=DEPRECATED_PROFILE_KEYS,
+        )
         submit = tuple(str(item) for item in raw.get("submit_command", []))
         status = tuple(str(item) for item in raw.get("status_command", []))
         cancel = tuple(str(item) for item in raw.get("cancel_command", []))
@@ -1160,13 +1255,6 @@ def load_profiles(path: Path) -> dict[str, ProfileRecord]:
             remote_script_root = DEFAULT_SCRIPT_REMOTE_ROOT
         profiles[name] = ProfileRecord(
             name=name,
-            kind=check_vocabulary(
-                str(raw.get("kind", "direct")),
-                PROFILE_KINDS,
-                what=what,
-                key="kind",
-                source=source,
-            ),
             interpreter=interpreter,
             remote_script_root=remote_script_root,
             environment={str(key): str(value) for key, value in environment.items()},
@@ -1245,6 +1333,27 @@ def target_schema_warnings(path: Path) -> list[str]:
                 warnings.append(
                     f"target file {entry} defines `{field}`; {guidance}"
                 )
+    return warnings
+
+
+def deprecated_key_warnings(paths: FleetPaths) -> list[str]:
+    """Name every config file still carrying a key nothing reads."""
+    warnings: list[str] = []
+    for directory, dead in (
+        (paths.targets_dir, DEPRECATED_TARGET_KEYS),
+        (paths.protocols_dir, DEPRECATED_PROTOCOL_KEYS),
+        (paths.profiles_dir, DEPRECATED_PROFILE_KEYS),
+    ):
+        if not directory.exists():
+            continue
+        for entry in sorted(directory.glob("*.toml")):
+            raw = load_toml_file(entry, default={})
+            for key, why in dead.items():
+                if key in raw:
+                    warnings.append(
+                        f"{entry} still defines `{key}`, which fleetctl ignores: "
+                        f"{why}. Run `fleetctl migrate-config`."
+                    )
     return warnings
 
 
@@ -1402,6 +1511,40 @@ def ensure_job_id_pattern(profile: ProfileRecord) -> None:
             "`job_id_pattern`, so a submitted job's id could never be reported back. "
             f"Add `job_id_pattern` to profiles.d/{profile.name}.toml"
         )
+
+
+def submit_staged_script(
+    secret: "FleetSecret",
+    profile: "ProfileRecord",
+    *,
+    remote_script: str,
+    cwd: str | None,
+    ssh_runtime: dict[str, Any],
+    output_path: str | None = None,
+    error_path: str | None = None,
+) -> int:
+    """Hand one already-staged script to the profile's scheduler."""
+    submit_argv = render_template_values(
+        profile.submit_command,
+        script_path=remote_script,
+        workdir=cwd,
+    )
+    if not submit_argv:  # unreachable: check_protocol_profile ran at resolve time
+        raise FleetError(f"profile {profile.name!r} does not define `submit_command`")
+    completed = run_ssh_command(
+        secret,
+        allocate_tty=False,
+        remote_command=remote_shell_command(submit_argv, cwd=cwd),
+        capture_output=True,
+        timeout=SUBMIT_COMMAND_TIMEOUT,
+        **ssh_runtime,
+    )
+    return report_submitted_job(
+        completed,
+        profile,
+        output_path=output_path,
+        error_path=error_path,
+    )
 
 
 def report_submitted_job(
@@ -2252,6 +2395,7 @@ def target_display(
     target: TargetRecord,
     *,
     protocol_name: str,
+    role: str,
     pool_names: Iterable[str] = (),
 ) -> dict[str, Any]:
     """Render one target for table or JSON output."""
@@ -2263,7 +2407,7 @@ def target_display(
         "enabled": target.enabled,
         "tags": list(target.tags),
         "default_profile": target.default_profile or "",
-        "scheduler": target.scheduler,
+        "role": role,
         "pools": sorted(pool_names),
     }
 
@@ -2277,8 +2421,6 @@ def protocol_display(protocol: ProtocolRecord) -> dict[str, Any]:
         "description": protocol.description or "",
         "default_profile": protocol.default_profile or "",
         "default_queue": default_queue.name if default_queue is not None else "",
-        "scheduler_required": protocol.scheduler_required,
-        "allow_login_exec": protocol.allow_login_exec,
         "smoke_gpu_probe": protocol.smoke_gpu_probe,
         "gpu_request_mode": protocol.gpu_request_mode,
         "job_runtime": protocol.job_runtime,
@@ -2403,7 +2545,6 @@ def default_plain_profile_template() -> str:
     fallback = """\
 version = 1
 name = "plain-ssh"
-kind = "direct"
 
 [script]
 interpreter = "/usr/bin/env bash"
@@ -2417,7 +2558,6 @@ def default_slurm_profile_template() -> str:
     fallback = """\
 version = 1
 name = "slurm-batch"
-kind = "scheduler"
 job_id_pattern = "Submitted batch job (?P<job_id>\\\\d+)"
 submit_command = ["sbatch", "{script}"]
 status_command = ["squeue", "--jobs", "{job_id}"]
@@ -2663,8 +2803,6 @@ def target_to_toml(target: TargetRecord) -> str:
         lines.append(f"ssh_host_alias = {toml_string(target.ssh_host_alias)}")
     if target.default_profile:
         lines.append(f"default_profile = {toml_string(target.default_profile)}")
-    if target.scheduler:
-        lines.append(f"scheduler = {toml_string(target.scheduler)}")
     return "\n".join(lines) + "\n"
 
 
@@ -2952,10 +3090,12 @@ def command_list(args: argparse.Namespace) -> int:
     for target in sorted(context.targets.values(), key=lambda item: item.name):
         if args.tag and args.tag not in target.tags:
             continue
+        protocol = context.resolve_protocol(target)
         rows.append(
             target_display(
                 target,
-                protocol_name=context.resolve_protocol(target).name,
+                protocol_name=protocol.name,
+                role=resolve_role(target, protocol),
                 pool_names=pool_index.get(target.name, []),
             )
         )
@@ -2969,9 +3109,9 @@ def command_list(args: argparse.Namespace) -> int:
                     "name",
                     "enabled",
                     "transport",
+                    "role",
                     "protocol",
                     "default_profile",
-                    "scheduler",
                     "tags",
                     "pools",
                 ],
@@ -2992,9 +3132,11 @@ def command_show(args: argparse.Namespace) -> int:
 
     if selector in context.targets:
         target = context.targets[selector]
+        protocol = context.resolve_protocol(target)
         payload = target_display(
             target,
-            protocol_name=context.resolve_protocol(target).name,
+            protocol_name=protocol.name,
+            role=resolve_role(target, protocol),
         )
         payload["kind"] = "target"
         if args.secret:
@@ -3137,13 +3279,13 @@ def command_import_ssh(args: argparse.Namespace) -> int:
     secret = infer_secret_from_ssh_alias(args.alias)
     target = TargetRecord(
         name=name,
-        protocol=args.protocol or ("slurm" if args.scheduler != "none" else None),
+        role=args.role,
+        protocol=args.protocol or "direct",
         workdir=args.workdir,
         tags=tuple(args.tag),
         secret_backend="file",
         secret_ref=str(secret_path),
         default_profile=args.profile or "plain-ssh",
-        scheduler=args.scheduler,
     )
     write_text_file(target_path, target_to_toml(target), mode=PRIVATE_FILE_MODE)
     write_text_file(secret_path, secret_to_toml(secret), mode=PRIVATE_FILE_MODE)
@@ -3221,13 +3363,13 @@ def command_migrate_env(args: argparse.Namespace) -> int:
                 inferred_workdir = str(remote_root_path.parent)
         target = TargetRecord(
             name=machine,
-            protocol=args.protocol or ("slurm" if args.scheduler != "none" else None),
+            role=args.role,
+            protocol=args.protocol or "direct",
             workdir=inferred_workdir,
             tags=tuple(args.tag),
             secret_backend="file",
             secret_ref=str(secret_path),
             default_profile=args.profile or "plain-ssh",
-            scheduler=args.scheduler,
         )
         write_text_file(target_path, target_to_toml(target), mode=PRIVATE_FILE_MODE)
         write_text_file(secret_path, secret_to_toml(secret), mode=PRIVATE_FILE_MODE)
@@ -3332,6 +3474,7 @@ def command_seed_pass(args: argparse.Namespace) -> int:
             name=target.name,
             enabled=target.enabled,
             transport=target.transport,
+            role=target.role,
             protocol=target.protocol,
             workdir=target.workdir,
             tags=target.tags,
@@ -3340,7 +3483,6 @@ def command_seed_pass(args: argparse.Namespace) -> int:
             secret_inline={},
             ssh_host_alias=target.ssh_host_alias,
             default_profile=target.default_profile,
-            scheduler=target.scheduler,
             metadata=target.metadata,
         )
         target_entry = pass_entry_name(prefix, "targets", target.name)
@@ -3595,10 +3737,6 @@ def command_smoke(args: argparse.Namespace) -> int:
             f"smoke check failed for {target.name!r} with exit code {completed.returncode}",
             exit_code=completed.returncode,
         )
-    if profile.kind not in {"direct", "scheduler"}:
-        raise FleetError(
-            f"profile {profile.name!r} uses unsupported kind {profile.kind!r}"
-        )
     return 0
 
 
@@ -3779,7 +3917,13 @@ def command_submit(args: argparse.Namespace) -> int:
     ssh_runtime = ssh_runtime_kwargs(context)
     cwd = resolve_remote_root(target, binding, args.cwd)
 
-    if profile.kind == "direct":
+    # Two paths, and the profile itself says which: a profile submits if and only
+    # if it defines `submit_command`.  Dispatching on a separate `profile.kind`
+    # opened a third path, reached only when kind and protocol disagreed, that ran
+    # `sbatch` on hosts with no scheduler and reported "requires --login" for a
+    # mismatch -- an error pointing the operator at running the job on the login
+    # node.  check_protocol_profile() now makes that disagreement unrepresentable.
+    if not profile.submit_command:
         if args.native_batch:
             raise FleetError("`--native-batch` only applies to scheduler profiles")
         ensure_no_resource_flags(
@@ -3823,134 +3967,74 @@ def command_submit(args: argparse.Namespace) -> int:
             local_script,
             ssh_runtime=ssh_runtime,
         )
-        submit_argv = render_template_values(
-            profile.submit_command,
-            script_path=remote_script,
-            workdir=cwd,
-        )
-        if not submit_argv:
-            raise FleetError(
-                f"profile {profile.name!r} does not define `submit_command`"
-            )
-        completed = run_ssh_command(
-            secret,
-            allocate_tty=False,
-            remote_command=remote_shell_command(submit_argv, cwd=cwd),
-            capture_output=True,
-            timeout=SUBMIT_COMMAND_TIMEOUT,
-            **ssh_runtime,
-        )
-        return report_submitted_job(completed, profile)
-
-    if protocol.kind == "slurm":
-        if protocol.native_batch_required:
-            raise FleetError(
-                f"protocol {protocol.name!r} requires `fleetctl submit --native-batch` "
-                "so the scheduler receives the site-native batch script unchanged"
-            )
-        ensure_job_id_pattern(profile)
-        queue = resolve_queue(protocol, args.queue)
-        remote_script = stage_remote_script(
+        return submit_staged_script(
             secret,
             profile,
-            local_script,
+            remote_script=remote_script,
+            cwd=cwd,
             ssh_runtime=ssh_runtime,
         )
-        job_base_root = protocol_base_root(target, binding, args.cwd)
-        output_dir, output_path, error_path = resolve_job_output_paths(
-            protocol,
-            base_root=job_base_root,
-            output_override=args.output,
-            error_override=args.error,
-        )
-        if output_dir:
-            ensure_remote_directory(secret, output_dir, ssh_runtime=ssh_runtime)
-        job_name = sanitize_job_name(args.job_name or local_script.stem)
-        wrapper_text = render_slurm_wrapper(
-            protocol=protocol,
-            remote_script=remote_script,
-            script_args=args.script_args,
-            interpreter=args.interpreter or profile.interpreter,
-            environment=profile.environment,
-            cwd=cwd,
-            queue=queue,
-            job_name=job_name,
-            time_limit=args.time,
-            gpus=args.gpus,
-            cpus_per_task=args.cpus_per_task,
-            mem=args.mem,
-            output_path=output_path,
-            error_path=error_path,
-        )
-        with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
-            handle.write(wrapper_text)
-            wrapper_local = Path(handle.name)
-        try:
-            remote_wrapper = stage_remote_script(
-                secret,
-                profile,
-                wrapper_local,
-                ssh_runtime=ssh_runtime,
-            )
-        finally:
-            wrapper_local.unlink(missing_ok=True)
-        submit_argv = render_template_values(
-            profile.submit_command,
-            script_path=remote_wrapper,
-            workdir=cwd,
-        )
-        if not submit_argv:
-            raise FleetError(
-                f"profile {profile.name!r} does not define `submit_command`"
-            )
-        completed = run_ssh_command(
-            secret,
-            allocate_tty=False,
-            remote_command=remote_shell_command(submit_argv, cwd=cwd),
-            capture_output=True,
-            timeout=SUBMIT_COMMAND_TIMEOUT,
-            **ssh_runtime,
-        )
-        return report_submitted_job(
-            completed,
-            profile,
-            output_path=output_path,
-            error_path=error_path,
-        )
 
-    ensure_no_resource_flags(
-        args,
-        because=(
-            f"protocol {protocol.name!r} has kind={protocol.kind!r}, for which fleetctl "
-            f"renders no batch wrapper; profile {profile.name!r} submits your script "
-            "unchanged, so put the scheduler directives in the script itself"
-        ),
-    )
+    if protocol.native_batch_required:
+        raise FleetError(
+            f"protocol {protocol.name!r} requires `fleetctl submit --native-batch` "
+            "so the scheduler receives the site-native batch script unchanged"
+        )
     ensure_job_id_pattern(profile)
+    queue = resolve_queue(protocol, args.queue)
     remote_script = stage_remote_script(
         secret,
         profile,
         local_script,
         ssh_runtime=ssh_runtime,
     )
-    submit_argv = render_template_values(
-        profile.submit_command,
-        script_path=remote_script,
-        workdir=cwd,
+    job_base_root = protocol_base_root(target, binding, args.cwd)
+    output_dir, output_path, error_path = resolve_job_output_paths(
+        protocol,
+        base_root=job_base_root,
+        output_override=args.output,
+        error_override=args.error,
     )
-    if not submit_argv:
-        raise FleetError(
-            f"profile {profile.name!r} does not define `submit_command`"
+    if output_dir:
+        ensure_remote_directory(secret, output_dir, ssh_runtime=ssh_runtime)
+    job_name = sanitize_job_name(args.job_name or local_script.stem)
+    wrapper_text = render_slurm_wrapper(
+        protocol=protocol,
+        remote_script=remote_script,
+        script_args=args.script_args,
+        interpreter=args.interpreter or profile.interpreter,
+        environment=profile.environment,
+        cwd=cwd,
+        queue=queue,
+        job_name=job_name,
+        time_limit=args.time,
+        gpus=args.gpus,
+        cpus_per_task=args.cpus_per_task,
+        mem=args.mem,
+        output_path=output_path,
+        error_path=error_path,
+    )
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        handle.write(wrapper_text)
+        wrapper_local = Path(handle.name)
+    try:
+        remote_wrapper = stage_remote_script(
+            secret,
+            profile,
+            wrapper_local,
+            ssh_runtime=ssh_runtime,
         )
-    completed = run_ssh_command(
+    finally:
+        wrapper_local.unlink(missing_ok=True)
+    return submit_staged_script(
         secret,
-        allocate_tty=False,
-        remote_command=remote_shell_command(submit_argv, cwd=cwd),
-        capture_output=True,
-        timeout=SUBMIT_COMMAND_TIMEOUT,
-        **ssh_runtime,
+        profile,
+        remote_script=remote_wrapper,
+        cwd=cwd,
+        ssh_runtime=ssh_runtime,
+        output_path=output_path,
+        error_path=error_path,
     )
-    return report_submitted_job(completed, profile)
 
 
 def run_job_command(
@@ -4142,6 +4226,7 @@ def command_doctor(args: argparse.Namespace) -> int:
     problems.extend(toml_syntax_problems(paths))
     try:
         warnings.extend(target_schema_warnings(paths.targets_dir))
+        warnings.extend(deprecated_key_warnings(paths))
     except FleetError:
         pass  # already reported precisely by toml_syntax_problems above
 
@@ -4153,10 +4238,13 @@ def command_doctor(args: argparse.Namespace) -> int:
 
     context: FleetContext | None
     try:
+        # Non-strict: the per-target loop below reports each incoherence against
+        # the target that owns it, which beats one joined message.
         context = FleetContext.load(
             config_home=args.config_home,
             state_home=args.state_home,
             cache_home=args.cache_home,
+            strict=False,
         )
     except FleetError as exc:
         problems.append(f"fleet config does not load: {exc}")
@@ -4178,11 +4266,14 @@ def command_doctor(args: argparse.Namespace) -> int:
             except FleetError as exc:
                 problems.append(f"target {target.name!r}: {exc}")
                 profile = None
-            if profile is not None and protocol.kind == "slurm" and not profile.submit_command:
-                problems.append(
-                    f"target {target.name!r} resolves to profile {profile.name!r}, "
-                    f"which has no `submit_command`, but protocol {protocol.name!r} "
-                    "is scheduler-backed: `fleetctl submit` cannot work here"
+            if target.role is None:
+                # An inferred role is the conservative reading of the protocol, not
+                # a fact about the machine.  Say so once per target, by name.
+                warnings.append(
+                    f"target {target.name!r} declares no `role`; fleetctl inferred "
+                    f"{resolve_role(target, protocol)!r} from protocol "
+                    f"{protocol.name!r}. Run `fleetctl migrate-config` to make it "
+                    "explicit."
                 )
             try:
                 secret = context.resolve_secret(target)
@@ -4479,9 +4570,9 @@ def build_parser() -> argparse.ArgumentParser:
         help="Protocol name to attach to the imported target",
     )
     import_ssh_parser.add_argument(
-        "--scheduler",
-        default="none",
-        help="Scheduler label for metadata only",
+        "--role",
+        choices=ROLES,
+        help="What the imported machine is, which decides what may run on it",
     )
     import_ssh_parser.add_argument(
         "--project-path",
@@ -4525,9 +4616,9 @@ def build_parser() -> argparse.ArgumentParser:
         help="Protocol name to attach to imported targets",
     )
     migrate_env_parser.add_argument(
-        "--scheduler",
-        default="none",
-        help="Scheduler label for imported targets",
+        "--role",
+        choices=ROLES,
+        help="Role to assign to every imported machine",
     )
     migrate_env_parser.add_argument(
         "--project-path",

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -6889,7 +6889,11 @@ def command_sync(args: argparse.Namespace, context: FleetContext) -> int:
     plan = build_plan(context, args, "sync")
     target = plan.target
     secret = plan.secret
-    ssh_runtime = plan.connect()
+    # Both of these are decidable from the inventory alone -- `plan.cwd` is
+    # resolved during plan construction, and the guard compares against the
+    # target's declared `workdir` -- so they belong above `connect()`. A refusal
+    # that first pays a connection is a refusal the operator waits for, and on a
+    # bridged host that wait is a 10-second timeout before being told no.
     default_remote = (
         resolve_remote_path(args.remote_path, base=plan.cwd)
         if args.remote_path
@@ -6908,6 +6912,7 @@ def command_sync(args: argparse.Namespace, context: FleetContext) -> int:
             direction=args.direction,
             force=bool(args.force),
         )
+    ssh_runtime = plan.connect()
 
     excludes = list(DEFAULT_SYNC_EXCLUDES)
     if plan.binding is not None:

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -958,7 +958,8 @@ def ensure_sync_delete_allowed(
     if normalized in UNSAFE_SYNC_DELETE_ROOTS:
         raise FleetError(
             f"refusing `--delete` against remote path {remote_path!r} on "
-            f"{target.name!r}: that is a home directory, not a project directory"
+            f"{target.name!r}: that is a whole home or root directory, not a "
+            "project directory"
         )
     if target.workdir and normalized == target.workdir.rstrip("/") and not force:
         raise FleetError(
@@ -3419,14 +3420,49 @@ def command_job_cancel(args: argparse.Namespace) -> int:
     return run_job_command(args, profile.cancel_command)
 
 
+def toml_syntax_problems(paths: FleetPaths) -> list[str]:
+    """Report every config file that fails to parse, not just the first one.
+
+    Only positions are reported, never file content, because this walks
+    `secrets/` too.
+    """
+    candidates = [paths.config_file, paths.projects_file]
+    for directory in (
+        paths.targets_dir,
+        paths.pools_dir,
+        paths.protocols_dir,
+        paths.profiles_dir,
+        paths.secrets_dir,
+    ):
+        if directory.is_dir():
+            candidates.extend(sorted(directory.glob("*.toml")))
+    problems: list[str] = []
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+        try:
+            with candidate.open("rb") as handle:
+                tomllib.load(handle)
+        except tomllib.TOMLDecodeError as exc:
+            problems.append(f"invalid TOML in {candidate}: {exc}")
+        except OSError as exc:
+            problems.append(f"cannot read {candidate}: {exc}")
+    return problems
+
+
 def command_doctor(args: argparse.Namespace) -> int:
-    """Validate local prerequisites and private file permissions."""
-    context = FleetContext.load(
+    """Validate local prerequisites and private file permissions.
+
+    Deliberately does not require the config to load: one unparseable file used
+    to abort the command whose whole job is to find it.  Path, permission and
+    tool checks always run, every broken file is named, and the checks that do
+    need a loaded fleet are skipped with the reason reported.
+    """
+    paths = build_paths(
         config_home=args.config_home,
         state_home=args.state_home,
         cache_home=args.cache_home,
     )
-    paths = context.paths
     problems: list[str] = []
     warnings: list[str] = []
 
@@ -3453,63 +3489,81 @@ def command_doctor(args: argparse.Namespace) -> int:
         if shutil.which(command_name) is None:
             problems.append(f"missing required command: {command_name}")
 
-    warnings.extend(target_schema_warnings(paths.targets_dir))
+    problems.extend(toml_syntax_problems(paths))
+    try:
+        warnings.extend(target_schema_warnings(paths.targets_dir))
+    except FleetError:
+        pass  # already reported precisely by toml_syntax_problems above
 
-    for target in context.targets.values():
-        try:
-            protocol = context.resolve_protocol(target)
-        except FleetError as exc:
-            problems.append(str(exc))
-            continue
-        try:
-            secret = context.resolve_secret(target)
-        except FleetError as exc:
-            problems.append(str(exc))
-            continue
-        if target.secret_backend == "file" and target.secret_ref:
-            secret_path = expand_local_path(target.secret_ref)
-            if secret_path.exists():
-                mode = stat.S_IMODE(secret_path.stat().st_mode)
-                if mode & 0o077:
+    stale = paths.config_home.with_name(paths.config_home.name + ".new")
+    if stale.exists():
+        warnings.append(
+            f"leftover staging tree from an interrupted `deploy-config`: {stale}"
+        )
+
+    context: FleetContext | None
+    try:
+        context = FleetContext.load(
+            config_home=args.config_home,
+            state_home=args.state_home,
+            cache_home=args.cache_home,
+        )
+    except FleetError as exc:
+        problems.append(f"fleet config does not load: {exc}")
+        context = None
+
+    if context is not None:
+        for target in context.targets.values():
+            try:
+                protocol = context.resolve_protocol(target)
+            except FleetError as exc:
+                problems.append(str(exc))
+                continue
+            try:
+                secret = context.resolve_secret(target)
+            except FleetError as exc:
+                problems.append(str(exc))
+                continue
+            if target.secret_backend == "file" and target.secret_ref:
+                secret_path = expand_local_path(target.secret_ref)
+                if secret_path.exists():
+                    mode = stat.S_IMODE(secret_path.stat().st_mode)
+                    if mode & 0o077:
+                        problems.append(
+                            f"secret file is too permissive ({oct(mode)}): {secret_path}"
+                        )
+            if secret.auth == "password":
+                if shutil.which("sshpass") is None:
                     problems.append(
-                        f"secret file is too permissive ({oct(mode)}): {secret_path}"
+                        f"target {target.name!r} uses password auth but `sshpass` is missing"
                     )
-        if secret.auth == "password":
-            if shutil.which("sshpass") is None:
-                problems.append(
-                    f"target {target.name!r} uses password auth but `sshpass` is missing"
-                )
-        if protocol.kind == "slurm" and not protocol.queues:
-            warnings.append(
-                f"target {target.name!r} uses Slurm protocol {protocol.name!r} "
-                "without any queue presets"
-            )
-
-    for binding in context.projects:
-        for target_name in sorted(binding.remote_roots_by_target):
-            if target_name not in context.targets:
+            if protocol.kind == "slurm" and not protocol.queues:
                 warnings.append(
-                    f"project binding {binding.path} defines a landing strip for "
-                    f"unknown target {target_name!r}"
+                    f"target {target.name!r} uses Slurm protocol {protocol.name!r} "
+                    "without any queue presets"
                 )
+
+        for binding in context.projects:
+            for target_name in sorted(binding.remote_roots_by_target):
+                if target_name not in context.targets:
+                    warnings.append(
+                        f"project binding {binding.path} defines a landing strip for "
+                        f"unknown target {target_name!r}"
+                    )
 
     payload = {
         "config_home": str(paths.config_home),
-        "targets": sorted(context.targets),
-        "pools": sorted(context.pools),
-        "protocols": sorted(context.protocols),
-        "profiles": sorted(context.profiles),
+        "targets": sorted(context.targets) if context else [],
+        "pools": sorted(context.pools) if context else [],
+        "protocols": sorted(context.protocols) if context else [],
+        "profiles": sorted(context.profiles) if context else [],
         "warnings": warnings,
         "problems": problems,
     }
-    if args.json:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(json.dumps(payload, indent=2, sort_keys=True))
+    print(json.dumps(payload, indent=2, sort_keys=True))
     if problems:
         return 1
     return 0
-
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI parser."""

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -22,7 +22,7 @@ import subprocess
 import sys
 import tempfile
 import tomllib
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path, PurePosixPath
 from typing import Any, Iterable
 
@@ -552,8 +552,13 @@ class FleetContext:
         check_protocol_profile(target, protocol, profile)
         return profile
 
-    def resolve_protocol(self, target: TargetRecord) -> ProtocolRecord:
-        """Resolve the behavior protocol for TARGET."""
+    def protocol_for(self, target: TargetRecord) -> ProtocolRecord:
+        """Look up TARGET's protocol without judging whether the two agree.
+
+        Only migrate-config wants this: it has to read a stale target's protocol
+        in order to repair the target, so it cannot require the target to already
+        be coherent.  Everything else goes through resolve_protocol().
+        """
         chosen = target.protocol
         if chosen is None:
             raise FleetError(
@@ -564,6 +569,11 @@ class FleetContext:
             raise FleetError(
                 f"target {target.name!r} refers to unknown protocol {chosen!r}"
             )
+        return protocol
+
+    def resolve_protocol(self, target: TargetRecord) -> ProtocolRecord:
+        """Resolve the behavior protocol for TARGET."""
+        protocol = self.protocol_for(target)
         check_role_protocol(target, protocol)
         return protocol
 
@@ -2491,25 +2501,25 @@ def serialize_projects(projects: list[ProjectBinding]) -> str:
     for item in sorted(projects, key=lambda binding: str(binding.path)):
         lines += [
             "[[project]]",
-            f'path = "{item.path}"',
+            f"path = {toml_string(str(item.path))}",
         ]
         if item.default_target:
-            lines.append(f'default_target = "{item.default_target}"')
+            lines.append(f"default_target = {toml_string(item.default_target)}")
         if item.default_pool:
-            lines.append(f'default_pool = "{item.default_pool}"')
+            lines.append(f"default_pool = {toml_string(item.default_pool)}")
         if item.default_profile:
-            lines.append(f'default_profile = "{item.default_profile}"')
+            lines.append(f"default_profile = {toml_string(item.default_profile)}")
         if item.remote_root:
-            lines.append(f'remote_root = "{item.remote_root}"')
+            lines.append(f"remote_root = {toml_string(item.remote_root)}")
         for target_name, remote_root in sorted(item.remote_roots_by_target.items()):
             lines += [
                 "",
                 "[[project.target_root]]",
-                f'target = "{target_name}"',
-                f'remote_root = "{remote_root}"',
+                f"target = {toml_string(target_name)}",
+                f"remote_root = {toml_string(remote_root)}",
             ]
         if item.sync_excludes:
-            quoted = ", ".join(f'"{entry}"' for entry in item.sync_excludes)
+            quoted = ", ".join(toml_string(entry) for entry in item.sync_excludes)
             lines.append(f"sync_excludes = [{quoted}]")
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"
@@ -3491,6 +3501,371 @@ def command_seed_pass(args: argparse.Namespace) -> int:
 
     for entry in written:
         print(entry)
+    return 0
+
+
+def pool_to_toml(pool: PoolRecord) -> str:
+    """Serialize a pool file."""
+    lines = [
+        "version = 1",
+        f"name = {toml_string(pool.name)}",
+    ]
+    if pool.targets:
+        members = ", ".join(toml_string(name) for name in pool.targets)
+        lines.append(f"targets = [{members}]")
+    if pool.match_tags:
+        tags = ", ".join(toml_string(tag) for tag in pool.match_tags)
+        lines.append(f"match_tags = [{tags}]")
+    lines.append(f"strategy = {toml_string(pool.strategy)}")
+    if pool.default_profile:
+        lines.append(f"default_profile = {toml_string(pool.default_profile)}")
+    return "\n".join(lines) + "\n"
+
+
+def strip_top_level_keys(text: str, keys: Iterable[str]) -> tuple[str, list[str]]:
+    """Delete top-level `key = value` lines, leaving every other byte alone.
+
+    Protocol files carry `[[queue]]` tables and hand-written comments, and there
+    is no round-trip serializer for them, so a rewrite would lose both.  Only
+    lines above the first table header are considered: that is where TOML puts
+    top-level keys, and a `kind` inside `[[queue]]` is a different key that must
+    survive.  Callers pass only scalar keys, so no value can span lines.
+    """
+    wanted = set(keys)
+    kept: list[str] = []
+    removed: list[str] = []
+    reached_tables = False
+    for line in text.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith("["):
+            reached_tables = True
+        if not reached_tables and "=" in stripped and not stripped.startswith("#"):
+            key = stripped.split("=", 1)[0].strip().strip("\"'")
+            if key in wanted:
+                removed.append(key)
+                continue
+        kept.append(line)
+    return "".join(kept), removed
+
+
+def bridge_dependents(context: FleetContext) -> tuple[dict[str, list[str]], list[str]]:
+    """Map each target that is another target's SSH waypoint to who needs it.
+
+    The evidence is a secret's `proxy_jump`, so the matching happens over values
+    that must never be printed.  Only the conclusion is returned -- "numpi is the
+    waypoint for rtx1" -- never the host it resolved through.
+    """
+    secrets: dict[str, FleetSecret] = {}
+    notes: list[str] = []
+    for target in context.targets.values():
+        try:
+            secrets[target.name] = context.resolve_secret(target)
+        except FleetError:
+            notes.append(
+                f"could not read {target.name!r}'s secret, so it was neither "
+                "classified as a waypoint nor checked for one"
+            )
+    by_host = {secret.host.lower(): name for name, secret in secrets.items()}
+    dependents: dict[str, list[str]] = {}
+    for name, secret in secrets.items():
+        if not secret.proxy_jump:
+            continue
+        hop = secret.proxy_jump.rsplit("@", 1)[-1].split(":", 1)[0].strip().lower()
+        owner = by_host.get(hop) or (hop if hop in context.targets else None)
+        if owner is None:
+            notes.append(
+                f"{name!r} is reached through a waypoint that is not itself a fleet "
+                "target, so fleetctl cannot validate or reuse that hop; import it "
+                "with `fleetctl import-ssh --role bridge`"
+            )
+            continue
+        dependents.setdefault(owner, []).append(name)
+    return {name: sorted(users) for name, users in dependents.items()}, notes
+
+
+def parse_assignment(raw: str, *, flag: str) -> tuple[str, str]:
+    """Parse a `NAME=VALUE` command-line assignment."""
+    name, separator, value = raw.partition("=")
+    if not separator or not name.strip() or not value.strip():
+        raise FleetError(f"`{flag}` expects NAME=VALUE, got {raw!r}")
+    return name.strip(), value.strip()
+
+
+def command_migrate_config(args: argparse.Namespace) -> int:
+    """Write today's schema into the live fleet config, once.
+
+    Idempotent: a second run finds every role declared and every dead key gone,
+    and changes nothing.  The new tree is rendered and validated in a sibling
+    staging directory and swapped in by rename, so a migration that would produce
+    an unloadable config leaves the working one untouched.
+    """
+    live = build_paths(
+        config_home=args.config_home,
+        state_home=args.state_home,
+        cache_home=args.cache_home,
+    )
+    # Non-strict: this is the tool you reach for *because* the config is stale.
+    context = FleetContext.load(
+        config_home=args.config_home,
+        state_home=args.state_home,
+        cache_home=args.cache_home,
+        strict=False,
+    )
+    if not context.targets:
+        raise FleetError(f"no targets found under {live.targets_dir}")
+
+    overrides: dict[str, str] = {}
+    for raw in args.role:
+        name, role = parse_assignment(raw, flag="--role")
+        if name not in context.targets:
+            raise FleetError(f"--role names unknown target {name!r}; run `fleetctl list`")
+        if role not in ROLES:
+            raise FleetError(
+                f"--role {name}={role}: {role!r} is not one of {', '.join(ROLES)}"
+            )
+        overrides[name] = role
+
+    renames: dict[str, str] = {}
+    for raw in args.rename:
+        old, new = parse_assignment(raw, flag="--rename")
+        if old not in context.targets:
+            raise FleetError(f"--rename names unknown target {old!r}; run `fleetctl list`")
+        if new in context.targets:
+            raise FleetError(f"--rename target {new!r} already exists")
+        if new != Path(new).name or new.startswith("."):
+            raise FleetError(f"--rename target {new!r} is not a usable file name")
+        renames[old] = new
+
+    dependents, notes = bridge_dependents(context)
+
+    # --- decide, and be able to say why ------------------------------------
+    decisions: list[tuple[str, str, str, str]] = []  # name, new name, role, reason
+    blockers: list[str] = []
+    for name in sorted(context.targets):
+        target = context.targets[name]
+        try:
+            protocol = context.protocol_for(target)
+        except FleetError as exc:
+            blockers.append(f"{name}: {exc}")
+            continue
+        if name in overrides:
+            role, why = overrides[name], "you named it on the command line"
+        elif target.role:
+            role, why = target.role, "already declared"
+        elif name in dependents:
+            role = "bridge"
+            why = "it is the SSH waypoint for " + ", ".join(dependents[name])
+        else:
+            role = resolve_role(target, protocol)
+            why = (
+                f"protocol {protocol.name!r} is scheduler-backed"
+                if role == "login"
+                else f"protocol {protocol.name!r} runs work directly"
+            )
+        # target_to_toml() cannot express these, so a rewrite would drop them.
+        if target.metadata:
+            blockers.append(
+                f"{name}: defines `metadata`, which fleetctl does not read and this "
+                "rewrite would silently drop; delete it by hand first"
+            )
+        if target.secret_inline:
+            blockers.append(
+                f"{name}: keeps its connection details in an inline `[secret]` table, "
+                "which this rewrite would drop; move it to a secret file first"
+            )
+        decisions.append((name, renames.get(name, name), role, why))
+
+    if blockers:
+        raise FleetError(
+            "cannot migrate this config:\n  - " + "\n  - ".join(blockers)
+        )
+
+    staging_root = live.config_home.with_name(live.config_home.name + ".new")
+    if staging_root.exists():
+        shutil.rmtree(staging_root)
+    paths = build_paths(
+        config_home=staging_root,
+        state_home=args.state_home,
+        cache_home=args.cache_home,
+    )
+    changes: list[str] = []
+    previous: Path | None = None
+    try:
+        shutil.copytree(live.config_home, staging_root, symlinks=True)
+
+        # The loader keys targets on the declared `name`, not the file name, so
+        # find each record's real file rather than assuming they agree.
+        sources: dict[str, Path] = {}
+        for entry in sorted(paths.targets_dir.glob("*.toml")):
+            try:
+                raw = tomllib.loads(entry.read_text(encoding="utf-8"))
+            except (OSError, tomllib.TOMLDecodeError):
+                continue
+            sources[str(raw.get("name") or entry.stem)] = entry
+
+        # --- targets: explicit role, no dead keys, new name if asked --------
+        for old_name, new_name, role, _why in decisions:
+            target = context.targets[old_name]
+            source = sources.get(old_name)
+            secret_ref = target.secret_ref
+            if old_name != new_name and target.secret_backend == "file" and secret_ref:
+                stem = f"{old_name}.toml"
+                fleet_owned = (
+                    expand_local_path(secret_ref) == live.secrets_dir / stem
+                    and secret_ref.endswith(stem)
+                )
+                if fleet_owned:
+                    staged_old = paths.secrets_dir / stem
+                    if staged_old.exists():
+                        os.replace(staged_old, paths.secrets_dir / f"{new_name}.toml")
+                    # Rewrite only the last component, so `~/.config/fleet/...`
+                    # keeps the spelling the operator chose.
+                    secret_ref = secret_ref[: -len(stem)] + f"{new_name}.toml"
+                    changes.append(f"secrets/{stem} -> secrets/{new_name}.toml")
+                else:
+                    notes.append(
+                        f"{new_name!r} keeps pointing at {stem} because its secret_ref "
+                        "is not a plain path into the fleet secrets directory"
+                    )
+            # Targets are re-serialized whole, so a dead key disappears without
+            # being asked to -- but only if something puts the migration on the
+            # change list, which is what decides whether the swap happens at all.
+            original = source.read_text(encoding="utf-8") if source else ""
+            _, dead = strip_top_level_keys(original, DEPRECATED_TARGET_KEYS)
+            for key in dead:
+                changes.append(f"targets.d/{new_name}.toml: dropped `{key}`")
+            comments = sum(1 for line in original.splitlines() if line.strip().startswith("#"))
+            if comments:
+                notes.append(
+                    f"{new_name!r} loses {comments} comment line(s): fleetctl rewrites "
+                    "target files from the record, and the previous config is kept "
+                    "one generation in `.prev`"
+                )
+
+            replacement = replace(target, name=new_name, role=role, secret_ref=secret_ref)
+            destination = paths.targets_dir / f"{new_name}.toml"
+            if source is not None and source != destination:
+                source.unlink()
+                changes.append(f"targets.d/{source.name} -> targets.d/{destination.name}")
+            write_text_file(
+                destination, target_to_toml(replacement), mode=PRIVATE_FILE_MODE
+            )
+            if role != target.role:
+                changes.append(f"targets.d/{new_name}.toml: role = {role!r} ({_why})")
+
+        # --- protocols and profiles: drop the keys nothing reads ------------
+        for directory, staged_dir, dead in (
+            (live.protocols_dir, paths.protocols_dir, DEPRECATED_PROTOCOL_KEYS),
+            (live.profiles_dir, paths.profiles_dir, DEPRECATED_PROFILE_KEYS),
+        ):
+            if not staged_dir.exists():
+                continue
+            for entry in sorted(staged_dir.glob("*.toml")):
+                text = entry.read_text(encoding="utf-8")
+                stripped, removed = strip_top_level_keys(text, dead)
+                if not removed:
+                    continue
+                write_text_file(entry, stripped, mode=PRIVATE_FILE_MODE)
+                changes.append(
+                    f"{directory.name}/{entry.name}: dropped "
+                    + ", ".join(f"`{key}`" for key in removed)
+                )
+        # --- follow the renames through everything that names a target -----
+        if renames:
+            for pool in context.pools.values():
+                if not any(name in renames for name in pool.targets):
+                    continue
+                updated = replace(
+                    pool,
+                    targets=tuple(renames.get(name, name) for name in pool.targets),
+                )
+                write_text_file(
+                    paths.pools_dir / f"{pool.name}.toml",
+                    pool_to_toml(updated),
+                    mode=PRIVATE_FILE_MODE,
+                )
+                changes.append(f"pools.d/{pool.name}.toml: renamed members")
+            touched_projects = False
+            rebuilt: list[ProjectBinding] = []
+            for binding in context.projects:
+                roots = {
+                    renames.get(name, name): root
+                    for name, root in binding.remote_roots_by_target.items()
+                }
+                default_target = renames.get(
+                    binding.default_target or "", binding.default_target
+                )
+                if (
+                    roots != binding.remote_roots_by_target
+                    or default_target != binding.default_target
+                ):
+                    touched_projects = True
+                rebuilt.append(
+                    replace(
+                        binding,
+                        default_target=default_target,
+                        remote_roots_by_target=roots,
+                    )
+                )
+            if touched_projects:
+                write_text_file(
+                    paths.projects_file,
+                    serialize_projects(rebuilt),
+                    mode=PRIVATE_FILE_MODE,
+                )
+                changes.append("projects.toml: renamed target references")
+
+        # --- validate before anything is swapped ---------------------------
+        try:
+            staged = FleetContext.load(
+                config_home=paths.config_home,
+                state_home=paths.state_home,
+                cache_home=paths.cache_home,
+            )
+        except FleetError as exc:
+            raise FleetError(
+                f"{exc}\n\nthis is a contradiction rather than a stale field, and "
+                "migrate-config will not guess which half you meant: correct the "
+                "protocol, or name the role with `--role NAME=ROLE`. Nothing has "
+                "been changed."
+            ) from exc
+        for target in staged.targets.values():
+            if target.secret_backend != "file" or not target.secret_ref:
+                continue
+            expected = expand_local_path(target.secret_ref)
+            try:
+                relative = expected.relative_to(live.secrets_dir)
+            except ValueError:
+                continue  # points outside the fleet tree; the operator owns it
+            if not (paths.secrets_dir / relative).exists():
+                raise FleetError(
+                    f"migrated target {target.name!r} would reference a secret file "
+                    f"that the new tree does not contain ({expected}); nothing has "
+                    "been changed"
+                )
+
+        for name, new_name, role, why in decisions:
+            label = name if name == new_name else f"{name} -> {new_name}"
+            print(f"{label}\trole={role}\t({why})")
+        for note in notes:
+            print(f"note: {note}", file=sys.stderr)
+
+        if not changes:
+            print("nothing to migrate: every role is declared and no dead keys remain")
+            return 0
+        for change in changes:
+            print(f"change: {change}")
+
+        if args.dry_run:
+            print("dry run: the live config was not touched", file=sys.stderr)
+            return 0
+        previous = swap_config_tree(staging_root, live.config_home)
+    finally:
+        if staging_root.exists():
+            shutil.rmtree(staging_root, ignore_errors=True)
+
+    if previous is not None:
+        print(f"note: previous config kept at {previous}", file=sys.stderr)
     return 0
 
 
@@ -4543,6 +4918,35 @@ def build_parser() -> argparse.ArgumentParser:
         help="Print a short post-deploy summary after validation",
     )
     deploy_config_parser.set_defaults(handler=command_deploy_config)
+
+    migrate_config_parser = subparsers.add_parser(
+        "migrate-config",
+        help="Rewrite the live fleet config in the schema fleetctl reads today",
+    )
+    migrate_config_parser.add_argument(
+        "--role",
+        action="append",
+        default=[],
+        metavar="TARGET=ROLE",
+        help=(
+            "Set one target's role explicitly instead of letting fleetctl infer it "
+            f"({', '.join(ROLES)}); repeatable"
+        ),
+    )
+    migrate_config_parser.add_argument(
+        "--rename",
+        action="append",
+        default=[],
+        metavar="OLD=NEW",
+        help="Rename a target and follow the name through secrets, pools and "
+        "project bindings; repeatable",
+    )
+    migrate_config_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the migration and validate it, but leave the live config alone",
+    )
+    migrate_config_parser.set_defaults(handler=command_migrate_config)
 
     import_ssh_parser = subparsers.add_parser(
         "import-ssh",

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -13,7 +13,6 @@ import difflib
 import json
 import os
 import posixpath
-import random
 import re
 import shlex
 import shutil
@@ -270,7 +269,6 @@ class PoolRecord:
     targets: tuple[str, ...] = ()
     match_tags: tuple[str, ...] = ()
     strategy: str = "ordered"
-    default_profile: str | None = None
 
 
 @dataclass(frozen=True)
@@ -500,36 +498,38 @@ class FleetContext:
             "pass a target or pool explicitly"
         )
 
-    def select_pool(self, pool: PoolRecord) -> TargetRecord:
-        """Select one target from a logical pool."""
-        candidates: list[TargetRecord] = []
+    def pool_members(self, pool: PoolRecord) -> list[TargetRecord]:
+        """Return POOL's enabled members, in selection order.
+
+        One function, because `list` used to answer this question separately and
+        got a different answer: it ignored `enabled`, so a box withdrawn for
+        reimaging showed up as a member of a pool that would never select it.
+        A pool declares `targets` or `match_tags` -- never neither, the loader
+        refuses that -- so the two branches are exhaustive.
+        """
         if pool.targets:
+            members = []
             for name in pool.targets:
                 target = self.targets.get(name)
                 if target is None:
                     raise FleetError(
                         f"pool {pool.name!r} references missing target {name!r}"
                     )
-                if target.enabled:
-                    candidates.append(target)
+                members.append(target)
         else:
-            for target in self.targets.values():
-                if not target.enabled:
-                    continue
-                if pool.match_tags and not set(pool.match_tags).issubset(target.tags):
-                    continue
-                candidates.append(target)
+            members = [
+                target
+                for target in sorted(self.targets.values(), key=lambda item: item.name)
+                if set(pool.match_tags).issubset(target.tags)
+            ]
+        return [target for target in members if target.enabled]
 
-        if not candidates:
+    def select_pool(self, pool: PoolRecord) -> TargetRecord:
+        """Select one target from a logical pool."""
+        members = self.pool_members(pool)
+        if not members:
             raise FleetError(f"pool {pool.name!r} has no eligible targets")
-
-        if pool.strategy == "random":
-            return random.choice(candidates)
-        if pool.strategy != "ordered":
-            raise FleetError(
-                f"unsupported pool strategy {pool.strategy!r} for {pool.name!r}"
-            )
-        return candidates[0]
+        return members[0]
 
     def resolve_profile(
         self,
@@ -539,11 +539,22 @@ class FleetContext:
     ) -> ProfileRecord:
         """Resolve a profile by precedence."""
         protocol = self.resolve_protocol(target)
-        chosen = requested or target.default_profile or protocol.default_profile
-        if chosen is None and binding is not None:
-            chosen = binding.default_profile
+        # `--profile` beats the project, the project beats the machine's default,
+        # and the protocol is the floor.  The project used to be consulted only
+        # when the other three were unset, which never happened because the
+        # protocol loader always supplies one -- so `project bind --profile`
+        # persisted a value that could not take effect.
+        chosen = (
+            requested
+            or (binding.default_profile if binding is not None else None)
+            or target.default_profile
+            or protocol.default_profile
+        )
         if chosen is None:
-            chosen = "plain-ssh"
+            raise FleetError(
+                f"nothing names a profile for target {target.name!r}: give protocol "
+                f"{protocol.name!r} a `default_profile`, or pass --profile"
+            )
         if chosen not in self.profiles:
             raise FleetError(
                 f"profile {chosen!r} is not configured; initialize fleet config first"
@@ -705,9 +716,7 @@ TARGET_KEYS = frozenset(
         "metadata",
     }
 )
-POOL_KEYS = frozenset(
-    {"version", "name", "targets", "match_tags", "strategy", "default_profile"}
-)
+POOL_KEYS = frozenset({"version", "name", "targets", "match_tags", "strategy"})
 PROTOCOL_KEYS = frozenset(
     {
         "version",
@@ -793,7 +802,7 @@ SECRET_KEYS = frozenset(
 
 TRANSPORTS = ("ssh",)
 SECRET_BACKENDS = ("file", "pass", "inline")
-POOL_STRATEGIES = ("ordered", "random")
+POOL_STRATEGIES = ("ordered",)
 PROTOCOL_KINDS = ("direct", "slurm")
 GPU_REQUEST_MODES = ("none", "gpus", "gres")
 AUTH_MODES = ("key", "password")
@@ -811,6 +820,12 @@ DEPRECATED_TARGET_KEYS: dict[str, str] = {
 DEPRECATED_PROTOCOL_KEYS: dict[str, str] = {
     "scheduler_required": "the role matrix decides this for every verb",
     "allow_login_exec": "the role matrix decides this; pass --admin per command",
+}
+DEPRECATED_POOL_KEYS: dict[str, str] = {
+    "default_profile": (
+        "profile resolution never saw the pool, so this was unreachable; set it "
+        "on the target, the protocol, or the project binding"
+    ),
 }
 DEPRECATED_PROFILE_KEYS: dict[str, str] = {
     "kind": "derived from whether the profile defines `submit_command`",
@@ -1047,7 +1062,13 @@ def load_pools(path: Path) -> dict[str, PoolRecord]:
     for name, raw, source in load_records_from_dir(path, kind="pool"):
         what = f"pool {name!r}"
         check_version(raw, what=what, source=source)
-        reject_unknown_keys(raw, POOL_KEYS, what=what, source=source)
+        reject_unknown_keys(
+            raw,
+            POOL_KEYS,
+            what=what,
+            source=source,
+            deprecated=DEPRECATED_POOL_KEYS,
+        )
         pool = PoolRecord(
             name=name,
             targets=tuple(str(item) for item in raw.get("targets", [])),
@@ -1059,7 +1080,6 @@ def load_pools(path: Path) -> dict[str, PoolRecord]:
                 key="strategy",
                 source=source,
             ),
-            default_profile=optional_str(raw.get("default_profile")),
         )
         if not pool.targets and not pool.match_tags:
             # `select_pool` treats "no members declared" as "every target",
@@ -1352,6 +1372,7 @@ def deprecated_key_warnings(paths: FleetPaths) -> list[str]:
     for directory, dead in (
         (paths.targets_dir, DEPRECATED_TARGET_KEYS),
         (paths.protocols_dir, DEPRECATED_PROTOCOL_KEYS),
+        (paths.pools_dir, DEPRECATED_POOL_KEYS),
         (paths.profiles_dir, DEPRECATED_PROFILE_KEYS),
     ):
         if not directory.exists():
@@ -2619,7 +2640,6 @@ version = 1
 name = "{name}"
 strategy = "ordered"
 targets = ["target-name"]
-default_profile = "plain-ssh"
 """
 
 
@@ -3086,15 +3106,8 @@ def command_list(args: argparse.Namespace) -> int:
 
     pool_index: dict[str, list[str]] = {}
     for pool in context.pools.values():
-        names = list(pool.targets)
-        if not names and pool.match_tags:
-            names = [
-                target.name
-                for target in context.targets.values()
-                if set(pool.match_tags).issubset(target.tags)
-            ]
-        for name in names:
-            pool_index.setdefault(name, []).append(pool.name)
+        for member in context.pool_members(pool):
+            pool_index.setdefault(member.name, []).append(pool.name)
 
     rows = []
     for target in sorted(context.targets.values(), key=lambda item: item.name):
@@ -3173,17 +3186,14 @@ def command_show(args: argparse.Namespace) -> int:
             "targets": list(pool.targets),
             "match_tags": list(pool.match_tags),
             "strategy": pool.strategy,
-            "default_profile": pool.default_profile or "",
+            "members": [member.name for member in context.pool_members(pool)],
             "resolved_target": resolved.name,
             "resolved_protocol": context.resolve_protocol(resolved).name,
         }
     else:
         raise FleetError(f"unknown target or pool {args.selector!r}")
 
-    if args.json:
-        print(json.dumps(payload, indent=2, sort_keys=True))
-    else:
-        print(json.dumps(payload, indent=2, sort_keys=True))
+    print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
 
 
@@ -3517,8 +3527,6 @@ def pool_to_toml(pool: PoolRecord) -> str:
         tags = ", ".join(toml_string(tag) for tag in pool.match_tags)
         lines.append(f"match_tags = [{tags}]")
     lines.append(f"strategy = {toml_string(pool.strategy)}")
-    if pool.default_profile:
-        lines.append(f"default_profile = {toml_string(pool.default_profile)}")
     return "\n".join(lines) + "\n"
 
 
@@ -4122,21 +4130,21 @@ def command_exec(args: argparse.Namespace) -> int:
         state_home=args.state_home,
         cache_home=args.cache_home,
     )
+    # The positional is always a selector and the command always follows `--`.
+    # Guessing between the two meant `fleetctl exec htop` silently ran htop on
+    # whatever the current directory happened to be bound to.
     argv = list(args.argv)
-    selector = args.selector_override or args.selector
     if args.selector_override and args.selector:
-        normalized = context.normalize_selector(args.selector)
-        if normalized in context.targets or normalized in context.pools:
-            raise FleetError("pass either a positional selector or --target, not both")
-        argv = [args.selector, *argv]
-        selector = args.selector_override
-    if not argv and selector is not None:
-        normalized = context.normalize_selector(selector)
-        if normalized not in context.targets and normalized not in context.pools:
-            argv = [selector]
-            selector = None
+        raise FleetError(
+            f"two targets named: {args.selector!r} positionally and "
+            f"{args.selector_override!r} via --target; the command goes after `--`"
+        )
+    selector = args.selector_override or args.selector
     if not argv:
-        raise FleetError("`fleetctl exec` requires a command after `--`")
+        raise FleetError(
+            "`fleetctl exec` requires a command after `--`, as in "
+            "`fleetctl exec rtx1 -- nvidia-smi`"
+        )
     target, binding = context.resolve_target(selector, cwd=Path.cwd())
     protocol = context.resolve_protocol(target)
     authorize("exec", target, protocol, admin=bool(args.admin))
@@ -5086,7 +5094,7 @@ def build_parser() -> argparse.ArgumentParser:
     exec_parser.add_argument("--tty", action="store_true", help="Allocate a TTY")
     exec_parser.add_argument(
         "argv",
-        nargs=argparse.REMAINDER,
+        nargs="*",
         help="Command to run remotely, introduced by `--`",
     )
     exec_parser.set_defaults(handler=command_exec)
@@ -5238,22 +5246,30 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def normalize_remainder(argv: list[str]) -> list[str]:
-    """Drop the separator argparse leaves in REMAINDER lists."""
-    if argv and argv[0] == "--":
-        return argv[1:]
-    return argv
+def split_payload(argv: list[str]) -> tuple[list[str], list[str], bool]:
+    """Split ARGV at the first bare `--` into options and a verbatim payload.
+
+    Doing this before argparse means the payload cannot be reinterpreted as
+    fleetctl's own flags, and fleetctl's flags cannot be swallowed by the
+    payload, regardless of which side of the selector they appear on.  Only the
+    first separator is consumed, so `exec host -- sh -c 'a -- b'` survives.
+    """
+    if "--" not in argv:
+        return argv, [], False
+    index = argv.index("--")
+    return argv[:index], argv[index + 1 :], True
 
 
 def main() -> int:
     """CLI entry point."""
     parser = build_parser()
-    args = parser.parse_args()
+    head, payload, separated = split_payload(sys.argv[1:])
+    args = parser.parse_args(head)
 
-    if hasattr(args, "argv"):
-        args.argv = normalize_remainder(args.argv)
-    if hasattr(args, "script_args"):
-        args.script_args = normalize_remainder(args.script_args)
+    if separated:
+        for attribute in ("argv", "script_args"):
+            if hasattr(args, attribute):
+                setattr(args, attribute, payload)
 
     try:
         return int(args.handler(args))

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -224,6 +224,87 @@ class FleetError(RuntimeError):
         self.exit_code = exit_code
 
 
+# ---- SECTION: reachability -------------------------------------------------
+#
+# How a host is reached is inventory, not a credential.  It used to be a
+# `proxy_jump = "user@host"` string inside a secret file, which made the fleet's
+# topology invisible (nothing could answer "what stops working if the bridge
+# dies"), unvalidatable (a typo aimed the connection at a host with no route to
+# it), duplicated across every clustered target, and -- worst -- outside every
+# fleet-managed SSH setting, because OpenSSH resolves a ProxyJump out of
+# ~/.ssh/config with none of the private known_hosts, IdentitiesOnly, timeouts
+# or control sockets fleetctl sets up for the destination.
+#
+# `reach` is an ordered list of routes: direct first, the bridge as the fallback.
+# That ordering is the point.  A tailnet or a VPN makes the direct route work
+# most of the time, and a Raspberry Pi multiplexing every clustered connection is
+# the last thing you want in the path when you do not need it.
+
+ROUTE_DIRECT = "direct"
+ROUTE_VIA_PREFIX = "via:"
+DEFAULT_REACH = (ROUTE_DIRECT,)
+
+
+def route_bridge(route: str) -> str | None:
+    """Return the bridge target ROUTE passes through, or None if it is direct."""
+    if route.startswith(ROUTE_VIA_PREFIX):
+        return route[len(ROUTE_VIA_PREFIX) :]
+    return None
+
+
+def parse_route(value: Any, *, what: str, source: Path | None = None) -> str:
+    """Validate one route's shape.  Whether the bridge exists is a graph question."""
+    where = f" in {source}" if source is not None else ""
+    if not isinstance(value, str):
+        raise FleetError(
+            f"invalid route for {what}{where}: {value!r} is not a string; a route is "
+            f'"{ROUTE_DIRECT}" or "{ROUTE_VIA_PREFIX}<target>"'
+        )
+    route = value.strip()
+    if route == ROUTE_DIRECT:
+        return route
+    bridge = route_bridge(route)
+    if bridge and not any(character.isspace() for character in bridge):
+        return route
+    raise FleetError(
+        f"invalid route for {what}{where}: {value!r}. A route is "
+        f'"{ROUTE_DIRECT}" for a host you dial yourself, or '
+        f'"{ROUTE_VIA_PREFIX}<target>" naming the fleet target that carries the '
+        "connection."
+    )
+
+
+def parse_reach(value: Any, *, what: str, source: Path | None = None) -> tuple[str, ...]:
+    """Parse `reach` into an ordered, duplicate-free route list."""
+    where = f" in {source}" if source is not None else ""
+    raw = [value] if isinstance(value, str) else value
+    if not isinstance(raw, (list, tuple)):
+        raise FleetError(
+            f"`reach` for {what}{where} must be a route or a list of routes, not "
+            f"{type(value).__name__}"
+        )
+    ordered: list[str] = []
+    for item in raw:
+        route = parse_route(item, what=what, source=source)
+        if route in ordered:
+            raise FleetError(
+                f"`reach` for {what}{where} lists {route!r} twice; each route is "
+                "tried once, in the order written"
+            )
+        ordered.append(route)
+    if not ordered:
+        raise FleetError(
+            f"`reach` for {what}{where} is empty, so nothing could ever reach it. "
+            f'Drop the key to mean ["{ROUTE_DIRECT}"].'
+        )
+    return tuple(ordered)
+
+
+def format_reach(reach: Iterable[str]) -> str:
+    """Render a route list for one message or one table cell."""
+    return ",".join(reach)
+
+
 @dataclass(frozen=True)
 class FleetSecret:
     """Resolved connection details that should stay outside version control."""
@@ -234,7 +315,6 @@ class FleetSecret:
     auth: str = "key"
     identity_file: str | None = None
     password: str | None = None
-    proxy_jump: str | None = None
     identities_only: bool = True
     forward_agent: bool = False
     compression: bool = False
@@ -259,6 +339,7 @@ class TargetRecord:
     transport: str = "ssh"
     role: str | None = None
     protocol: str | None = None
+    reach: tuple[str, ...] = DEFAULT_REACH
     workdir: str | None = None
     tags: tuple[str, ...] = ()
     secret_backend: str = "file"
@@ -432,6 +513,83 @@ class FleetContext:
                 )
         return context
 
+    def reach_problems(self) -> list[str]:
+        """Validate the reachability graph before anything tries to use it.
+
+        A bridge is a declared job, not a side effect of being mentioned: a hop
+        must name a real, enabled target whose role is `bridge`.  That is the
+        same taint rule the verbs use, applied to transport -- carrying other
+        people's connections is something a machine opts into.
+        """
+        problems: list[str] = []
+        cycles: set[tuple[str, ...]] = set()
+        for target in sorted(self.targets.values(), key=lambda item: item.name):
+            for route in target.reach:
+                bridge_name = route_bridge(route)
+                if bridge_name is None:
+                    continue
+                if bridge_name == target.name:
+                    problems.append(
+                        f"target {target.name!r} declares {route!r}: a target "
+                        "cannot be its own bridge"
+                    )
+                    continue
+                bridge = self.targets.get(bridge_name)
+                if bridge is None:
+                    problems.append(
+                        f"target {target.name!r} declares {route!r}, but no target "
+                        f"{bridge_name!r} exists; run `fleetctl list`"
+                    )
+                    continue
+                if not bridge.enabled:
+                    problems.append(
+                        f"target {target.name!r} is reached through {bridge_name!r}, "
+                        "which is disabled -- so nothing can reach it either"
+                    )
+                try:
+                    role = resolve_role(bridge, self.resolve_protocol(bridge))
+                except FleetError as exc:
+                    problems.append(
+                        f"target {target.name!r} is reached through {bridge_name!r}, "
+                        f"whose own config does not resolve: {exc}"
+                    )
+                    continue
+                if role != "bridge":
+                    problems.append(
+                        f"target {target.name!r} is reached through {bridge_name!r}, "
+                        f"which is a {role} node. Carrying other connections is a "
+                        'declared job: set `role = "bridge"` on it, or reach '
+                        f"{target.name!r} another way"
+                    )
+            cycle = self.reach_cycle(target.name)
+            if cycle is not None:
+                cycles.add(tuple(sorted(set(cycle))))
+        for members in sorted(cycles):
+            problems.append(
+                "reach cycle between "
+                + ", ".join(repr(name) for name in members)
+                + ": every route through it would recurse until the process died"
+            )
+        return problems
+
+    def reach_cycle(
+        self, name: str, seen: tuple[str, ...] = ()
+    ) -> tuple[str, ...] | None:
+        """Return the first bridge chain that revisits a target, if one exists."""
+        if name in seen:
+            return (*seen, name)
+        target = self.targets.get(name)
+        if target is None:
+            return None
+        for route in target.reach:
+            bridge_name = route_bridge(route)
+            if bridge_name is None:
+                continue
+            cycle = self.reach_cycle(bridge_name, (*seen, name))
+            if cycle is not None:
+                return cycle
+        return None
+
     def coherence_problems(self) -> list[str]:
         """Return every role/protocol/profile disagreement in the inventory.
 
@@ -446,6 +604,7 @@ class FleetContext:
                 self.resolve_profile(target, None, None)
             except FleetError as exc:
                 problems.append(str(exc))
+        problems.extend(self.reach_problems())
         return problems
 
     def project_binding_for(self, path: Path | None = None) -> ProjectBinding | None:
@@ -596,25 +755,32 @@ class FleetContext:
         check_role_protocol(target, protocol)
         return protocol
 
-    def resolve_secret(self, target: TargetRecord) -> FleetSecret:
-        """Load sensitive connection details for TARGET."""
+    def resolve_secret_raw(
+        self, target: TargetRecord
+    ) -> tuple[dict[str, Any], Path | None]:
+        """Fetch TARGET's secret material as written, and say where it came from.
+
+        Only the migration wants this: it has to read a key the parsed record no
+        longer carries.  Everything else goes through resolve_secret().
+        """
         if target.secret_backend == "inline":
-            return parse_secret_dict(target.secret_inline)
+            return dict(target.secret_inline), None
+        if not target.secret_ref:
+            raise FleetError(f"target {target.name!r} is missing `secret_ref`")
         if target.secret_backend == "file":
-            if not target.secret_ref:
-                raise FleetError(f"target {target.name!r} is missing `secret_ref`")
             path = expand_local_path(target.secret_ref)
-            raw = load_toml_file(path)
-            return parse_secret_dict(raw, source=path)
+            return load_toml_file(path), path
         if target.secret_backend == "pass":
-            if not target.secret_ref:
-                raise FleetError(f"target {target.name!r} is missing `secret_ref`")
-            raw = parse_secret_blob(run_pass_show(target.secret_ref))
-            return parse_secret_dict(raw)
+            return parse_secret_blob(run_pass_show(target.secret_ref)), None
         raise FleetError(
             f"target {target.name!r} uses unsupported secret backend "
             f"{target.secret_backend!r}"
         )
+
+    def resolve_secret(self, target: TargetRecord) -> FleetSecret:
+        """Load sensitive connection details for TARGET."""
+        raw, source = self.resolve_secret_raw(target)
+        return parse_secret_dict(raw, source=source)
 
 
 # ---- SECTION: resolution (config + args -> Plan, no remote I/O) ------------
@@ -643,6 +809,7 @@ class Plan:
     selector: str | None
     pool: PoolRecord | None
     admin: bool
+    routes: tuple[str, ...] = DEFAULT_REACH
     _secret: FleetSecret | None = field(default=None, compare=False, repr=False)
 
     @property
@@ -659,9 +826,19 @@ class Plan:
             )
         return self._secret
 
+    @property
+    def route(self) -> str:
+        """The route this plan uses.
+
+        For a target that declares no bridge this is the only candidate; with a
+        fallback declared it is the one tried first, which is what the argv
+        builders need in order to be printable before any connection exists.
+        """
+        return self.routes[0] if self.routes else ROUTE_DIRECT
+
     def ssh_runtime(self) -> dict[str, Any]:
-        """Return the fleet-managed SSH settings for this plan."""
-        return ssh_runtime_kwargs(self.context)
+        """Return the fleet-managed SSH settings for this plan, hop included."""
+        return ssh_runtime_kwargs(self.context, target=self.target, route=self.route)
 
     def ssh_connect_argv(self) -> list[str]:
         """The ssh invocation this plan will use, without the remote command."""
@@ -679,7 +856,9 @@ class Plan:
             "selector": self.selector,
             "pool": self.pool.name if self.pool is not None else None,
             "target": self.target.name,
-            "role": self.target.role,
+            "role": resolve_role(self.target, self.protocol),
+            "reach": list(self.target.reach),
+            "route": self.route,
             "protocol": self.protocol.name,
             "protocol_kind": self.protocol.kind,
             "profile": self.profile.name,
@@ -713,7 +892,28 @@ def build_plan(context: FleetContext, args: argparse.Namespace, verb: str) -> Pl
         selector=selector,
         pool=context.pools.get(selector) if selector else None,
         admin=admin,
+        routes=resolve_routes(target, getattr(args, "route", None)),
     )
+
+
+def resolve_routes(target: TargetRecord, requested: str | None) -> tuple[str, ...]:
+    """Return the routes to try for TARGET, in order.
+
+    `--route` picks one of the declared routes rather than inventing one: a route
+    fleetctl has never been told about is a guess about someone else's network,
+    and the failure it produces is a timeout rather than an error.
+    """
+    declared = target.reach or DEFAULT_REACH
+    if requested is None:
+        return declared
+    route = parse_route(requested, what=f"--route for target {target.name!r}")
+    if route not in declared:
+        raise FleetError(
+            f"--route {route!r} is not declared for {target.name!r}, which reaches "
+            f"through [{format_reach(declared)}]. Add it to `reach` in that "
+            "target's file if the path exists."
+        )
+    return (route,)
 
 
 def build_paths(
@@ -796,7 +996,7 @@ def load_repo_template(path: str, fallback: str) -> str:
 CONFIG_VERSION = 1
 
 CONFIG_KEYS = frozenset({"version", "defaults", "ssh"})
-CONFIG_DEFAULTS_KEYS = frozenset({"redact_sensitive_output"})
+CONFIG_DEFAULTS_KEYS: frozenset[str] = frozenset()
 CONFIG_SSH_KEYS = frozenset(
     {
         "user_known_hosts_file",
@@ -813,6 +1013,7 @@ TARGET_KEYS = frozenset(
         "transport",
         "role",
         "protocol",
+        "reach",
         "workdir",
         "tags",
         "secret_backend",
@@ -894,7 +1095,6 @@ SECRET_KEYS = frozenset(
         "auth",
         "identity_file",
         "password",
-        "proxy_jump",
         "identities_only",
         "forward_agent",
         "compression",
@@ -936,6 +1136,22 @@ DEPRECATED_POOL_KEYS: dict[str, str] = {
 }
 DEPRECATED_PROFILE_KEYS: dict[str, str] = {
     "kind": "derived from whether the profile defines `submit_command`",
+}
+DEPRECATED_SECRET_KEYS: dict[str, str] = {
+    "proxy_jump": (
+        "how a host is reached is inventory, not a credential; declare "
+        '`reach = ["direct", "via:<bridge>"]` on the target instead, which is '
+        "validated at load time, reported by `list --format topology`, and "
+        "carries the bridge's own fleet SSH settings. A waypoint that is not "
+        "itself a fleet target is still expressible as `[ssh_option] ProxyJump`"
+    ),
+}
+DEPRECATED_CONFIG_DEFAULTS_KEYS: dict[str, str] = {
+    "redact_sensitive_output": (
+        "nothing ever read it; `show --secret` redacts by default and "
+        "`--sensitive` asks for the real values one command at a time, which "
+        "beats a global switch that silently changes what every command prints"
+    ),
 }
 
 
@@ -1028,7 +1244,11 @@ def validate_config_file(raw: dict[str, Any], *, source: Path) -> None:
         raw.get("defaults", {}), what="`defaults`", source=source
     )
     reject_unknown_keys(
-        defaults, CONFIG_DEFAULTS_KEYS, what="fleet config `[defaults]`", source=source
+        defaults,
+        CONFIG_DEFAULTS_KEYS,
+        what="fleet config `[defaults]`",
+        source=source,
+        deprecated=DEPRECATED_CONFIG_DEFAULTS_KEYS,
     )
     ssh_section = check_table(raw.get("ssh", {}), what="`ssh`", source=source)
     reject_unknown_keys(
@@ -1140,6 +1360,9 @@ def load_targets(path: Path) -> dict[str, TargetRecord]:
                 else None
             ),
             protocol=optional_str(raw.get("protocol")),
+            reach=parse_reach(
+                raw.get("reach", DEFAULT_REACH), what=what, source=source
+            ),
             workdir=optional_str(raw.get("workdir")),
             tags=tuple(str(item) for item in raw.get("tags", [])),
             secret_backend=check_vocabulary(
@@ -1481,6 +1704,9 @@ def deprecated_key_warnings(paths: FleetPaths) -> list[str]:
         (paths.protocols_dir, DEPRECATED_PROTOCOL_KEYS),
         (paths.pools_dir, DEPRECATED_POOL_KEYS),
         (paths.profiles_dir, DEPRECATED_PROFILE_KEYS),
+        # Only the key name is ever reported, never a value: a secret file is
+        # named and inspected here, not printed.
+        (paths.secrets_dir, DEPRECATED_SECRET_KEYS),
     ):
         if not directory.exists():
             continue
@@ -1492,15 +1718,30 @@ def deprecated_key_warnings(paths: FleetPaths) -> list[str]:
                         f"{entry} still defines `{key}`, which fleetctl ignores: "
                         f"{why}. Run `fleetctl migrate-config`."
                     )
+    config_defaults = load_toml_file(paths.config_file, default={}).get("defaults")
+    if isinstance(config_defaults, dict):
+        for key, why in DEPRECATED_CONFIG_DEFAULTS_KEYS.items():
+            if key in config_defaults:
+                warnings.append(
+                    f"{paths.config_file} still defines `[defaults] {key}`, which "
+                    f"fleetctl ignores: {why}. Run `fleetctl migrate-config`."
+                )
     return warnings
 
 
 def parse_secret_dict(raw: dict[str, Any], *, source: Path | None = None) -> FleetSecret:
     """Parse one secret record from TOML-style data."""
     # A typo here is quiet and dangerous in a different way to the other
-    # loaders: `proxyjump` instead of `proxy_jump` drops the bridge hop and
-    # sends the connection straight at a host that is not directly reachable.
-    reject_unknown_keys(raw, SECRET_KEYS, what="secret record", source=source)
+    # loaders: a misspelled `identity_file` falls back to whatever the agent
+    # happens to offer, and a misspelled `port` reaches a different service on
+    # the same host.
+    reject_unknown_keys(
+        raw,
+        SECRET_KEYS,
+        what="secret record",
+        source=source,
+        deprecated=DEPRECATED_SECRET_KEYS,
+    )
     host = optional_str(raw.get("host"))
     user = optional_str(raw.get("user"))
     if not host or not user:
@@ -1515,7 +1756,6 @@ def parse_secret_dict(raw: dict[str, Any], *, source: Path | None = None) -> Fle
     )
     identity_file = optional_str(raw.get("identity_file"))
     password = optional_str(raw.get("password"))
-    proxy_jump = optional_str(raw.get("proxy_jump"))
     strict_host_key_checking = optional_str(raw.get("strict_host_key_checking"))
     if strict_host_key_checking is not None:
         check_vocabulary(
@@ -1536,7 +1776,6 @@ def parse_secret_dict(raw: dict[str, Any], *, source: Path | None = None) -> Fle
         auth=auth,
         identity_file=identity_file,
         password=password,
-        proxy_jump=proxy_jump,
         identities_only=bool(raw.get("identities_only", True)),
         forward_agent=bool(raw.get("forward_agent", False)),
         compression=bool(raw.get("compression", False)),
@@ -1931,8 +2170,8 @@ def ssh_env(secret: FleetSecret) -> dict[str, str]:
     return env
 
 
-def ssh_runtime_kwargs(context: FleetContext) -> dict[str, Any]:
-    """Return fleet-managed SSH runtime settings."""
+def base_ssh_runtime_kwargs(context: FleetContext) -> dict[str, Any]:
+    """Return the fleet-managed SSH settings that do not depend on the route."""
     ensure_private_dir(context.paths.state_home, mode=STATE_DIR_MODE)
     ensure_private_dir(context.paths.cache_home, mode=PRIVATE_DIR_MODE)
     ensure_private_dir(context.paths.control_dir, mode=PRIVATE_DIR_MODE)
@@ -1953,6 +2192,92 @@ def ssh_runtime_kwargs(context: FleetContext) -> dict[str, Any]:
     }
 
 
+def escape_ssh_percent(text: str) -> str:
+    """Double every `%` so the ssh running a ProxyCommand leaves it alone.
+
+    A ProxyCommand is percent-expanded by the ssh that spawns it, and OpenSSH
+    only knows %%, %h, %n, %p and %r there -- an unescaped `%C` in the bridge's
+    ControlPath would abort the connection with "unknown key".  Escaping the
+    inner options exactly once per level of nesting means each ssh in the chain
+    consumes one layer and the innermost one still sees its own `%C`, which is
+    what gives every hop its own multiplexed socket.
+    """
+    return text.replace("%", "%%")
+
+
+def build_proxy_command(
+    context: FleetContext,
+    route: str,
+    base: dict[str, Any],
+    *,
+    chain: tuple[str, ...] = (),
+) -> str | None:
+    """Render the ProxyCommand that carries a connection along ROUTE.
+
+    The hop is a full fleetctl connection to the bridge -- its own secret, and
+    the same private known_hosts, IdentitiesOnly, timeouts and control socket the
+    destination gets -- and it chains, because a bridge may itself be reached
+    through one.  `-W` forwards a stream and runs nothing, which is why using a
+    bridge is transport rather than execution and needs no admission check:
+    `fleetctl exec` against that same bridge is still refused.
+    """
+    bridge_name = route_bridge(route)
+    if bridge_name is None:
+        return None
+    if bridge_name in chain:
+        raise FleetError("reach cycle: " + " -> ".join((*chain, bridge_name)))
+    bridge = context.targets.get(bridge_name)
+    if bridge is None:
+        raise FleetError(
+            f"route {route!r} names unknown target {bridge_name!r}; run `fleetctl list`"
+        )
+    ensure_target_enabled(bridge)
+    secret = context.resolve_secret(bridge)
+    if secret.auth == "password":
+        raise FleetError(
+            f"bridge {bridge_name!r} authenticates with a password, which cannot "
+            "carry another connection: sshpass hands one password to the whole "
+            "process tree, so the hop and the destination would both read it. "
+            "Give the bridge a key -- it is the host every other host is reached "
+            "through."
+        )
+    parts = ["ssh", "-W", "%h:%p", "-p", str(secret.port)]
+    parts += [
+        escape_ssh_percent(part)
+        for part in ssh_option_parts(
+            secret,
+            proxy_command=build_proxy_command(
+                context,
+                bridge.reach[0] if bridge.reach else ROUTE_DIRECT,
+                base,
+                chain=(*chain, bridge_name),
+            ),
+            **base,
+        )
+    ]
+    parts.append(secret.target)
+    return shlex.join(parts)
+
+
+def ssh_runtime_kwargs(
+    context: FleetContext,
+    *,
+    target: TargetRecord | None = None,
+    route: str | None = None,
+) -> dict[str, Any]:
+    """Return fleet-managed SSH runtime settings, TARGET's hop included.
+
+    Without a target these are the host-independent settings.  With one, the
+    route's ProxyCommand is part of the runtime, so every builder that already
+    forwarded these kwargs carries the bridge without knowing it exists.
+    """
+    base = base_ssh_runtime_kwargs(context)
+    if target is None:
+        return base
+    chosen = route or (target.reach[0] if target.reach else ROUTE_DIRECT)
+    return {**base, "proxy_command": build_proxy_command(context, chosen, base)}
+
+
 def ssh_option_parts(
     secret: FleetSecret,
     *,
@@ -1960,6 +2285,7 @@ def ssh_option_parts(
     control_path: str | None = None,
     strict_host_key_checking: str | None = None,
     update_host_keys: bool = True,
+    proxy_command: str | None = None,
 ) -> list[str]:
     """Build stable OpenSSH options for one target."""
     options = [
@@ -1981,8 +2307,8 @@ def ssh_option_parts(
             "-o",
             f"ControlPath={control_path}",
         ]
-    if secret.proxy_jump:
-        options += ["-o", f"ProxyJump={secret.proxy_jump}"]
+    if proxy_command:
+        options += ["-o", f"ProxyCommand={proxy_command}"]
     if secret.identities_only:
         options += ["-o", "IdentitiesOnly=yes"]
     if secret.forward_agent:
@@ -2057,6 +2383,7 @@ def build_ssh_command(
     control_path: str | None = None,
     strict_host_key_checking: str | None = None,
     update_host_keys: bool = True,
+    proxy_command: str | None = None,
 ) -> list[str]:
     """Build one ssh command."""
     command = ssh_transport_prefix(secret) + ["ssh"]
@@ -2069,6 +2396,7 @@ def build_ssh_command(
         control_path=control_path,
         strict_host_key_checking=strict_host_key_checking,
         update_host_keys=update_host_keys,
+        proxy_command=proxy_command,
     )
     command.append(secret.target)
     if remote_command is not None:
@@ -2085,6 +2413,7 @@ def build_scp_command(
     control_path: str | None = None,
     strict_host_key_checking: str | None = None,
     update_host_keys: bool = True,
+    proxy_command: str | None = None,
 ) -> list[str]:
     """Build one scp command."""
     command = ssh_transport_prefix(secret) + ["scp", "-P", str(secret.port)]
@@ -2094,6 +2423,7 @@ def build_scp_command(
         control_path=control_path,
         strict_host_key_checking=strict_host_key_checking,
         update_host_keys=update_host_keys,
+        proxy_command=proxy_command,
     )
     command += [source, dest]
     return command
@@ -2106,6 +2436,7 @@ def build_rsync_transport(
     control_path: str | None = None,
     strict_host_key_checking: str | None = None,
     update_host_keys: bool = True,
+    proxy_command: str | None = None,
 ) -> str:
     """Build the SSH transport string for rsync."""
     parts = ssh_transport_prefix(secret) + ["ssh", "-p", str(secret.port)]
@@ -2115,6 +2446,7 @@ def build_rsync_transport(
         control_path=control_path,
         strict_host_key_checking=strict_host_key_checking,
         update_host_keys=update_host_keys,
+        proxy_command=proxy_command,
     )
     return shlex.join(parts)
 
@@ -2155,6 +2487,7 @@ def run_ssh_command(
     control_path: str | None = None,
     strict_host_key_checking: str | None = None,
     update_host_keys: bool = True,
+    proxy_command: str | None = None,
     timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run one ssh command with fleet defaults."""
@@ -2166,6 +2499,7 @@ def run_ssh_command(
         control_path=control_path,
         strict_host_key_checking=strict_host_key_checking,
         update_host_keys=update_host_keys,
+        proxy_command=proxy_command,
     )
     return run_command(
         command,
@@ -2551,6 +2885,7 @@ def target_display(
         "name": target.name,
         "transport": target.transport,
         "protocol": protocol_name,
+        "reach": list(target.reach),
         "workdir": target.workdir or "",
         "enabled": target.enabled,
         "tags": list(target.tags),
@@ -2602,14 +2937,19 @@ def queue_display(queue: QueueRecord) -> dict[str, Any]:
 
 
 def redact_secret(secret: FleetSecret) -> dict[str, Any]:
-    """Produce a safe secret preview."""
+    """Produce a safe secret preview.
+
+    The username used to come back verbatim next to a `<redacted>` host, which is
+    half a credential and most of the way to the other half.  What is left is
+    what you actually debug with: whether an identity is configured, which port,
+    and whether a password is on file.
+    """
     return {
         "host": "<redacted>",
-        "user": secret.user,
+        "user": "<redacted>",
         "port": secret.port,
         "auth": secret.auth,
         "identity_file": secret.identity_file or "",
-        "proxy_jump": secret.proxy_jump or "",
         "password_configured": secret.password is not None,
     }
 
@@ -2818,9 +3158,6 @@ def default_config_template() -> str:
     fallback = """\
 version = 1
 
-[defaults]
-redact_sensitive_output = true
-
 [ssh]
 user_known_hosts_file = "~/.local/state/fleet/known_hosts"
 strict_host_key_checking = "accept-new"
@@ -2877,6 +3214,9 @@ name = "{name}"
 enabled = true
 transport = "ssh"
 protocol = "direct"
+# Ordered, and tried in order: direct first, a bridge as the fallback.
+# `["direct", "via:<bridge>"]` suits a host that is only sometimes dialable.
+reach = ["direct"]
 workdir = "/srv/work"
 tags = ["example"]
 secret_backend = "file"
@@ -2930,8 +3270,14 @@ def int_setting(raw: dict[str, str], key: str, default: int) -> int:
     return int(value)
 
 
-def infer_secret_from_ssh_alias(alias: str) -> FleetSecret:
-    """Resolve one existing SSH alias from the local SSH client."""
+def infer_secret_from_ssh_alias(alias: str) -> tuple[FleetSecret, str | None]:
+    """Resolve one existing SSH alias, and report any waypoint it goes through.
+
+    The hop comes back separately rather than inside the secret: a ProxyJump out
+    of ~/.ssh/config is topology, and fleetctl wants it declared as `reach` on a
+    bridge target it can validate -- so `import-ssh` says so instead of quietly
+    copying an opaque string into the secret store.
+    """
     completed = run_command(
         ["ssh", "-G", alias],
         capture_output=True,
@@ -2951,13 +3297,14 @@ def infer_secret_from_ssh_alias(alias: str) -> FleetSecret:
         )
     identity_file = optional_str(raw.get("identityfile"))
     proxy_jump = optional_str(raw.get("proxyjump"))
-    return FleetSecret(
+    if proxy_jump and proxy_jump.strip().lower() == "none":
+        proxy_jump = None  # what `ssh -G` prints when no jump is configured
+    secret = FleetSecret(
         host=host,
         user=user,
         port=int_setting(raw, "port", 22),
         auth="key",
         identity_file=identity_file,
-        proxy_jump=proxy_jump,
         identities_only=raw.get("identitiesonly", "no").lower() == "yes",
         forward_agent=raw.get("forwardagent", "no").lower() == "yes",
         compression=raw.get("compression", "no").lower() == "yes",
@@ -2966,6 +3313,7 @@ def infer_secret_from_ssh_alias(alias: str) -> FleetSecret:
         server_alive_count_max=int_setting(raw, "serveralivecountmax", 3),
         strict_host_key_checking=optional_str(raw.get("stricthostkeychecking")),
     )
+    return secret, proxy_jump
 
 
 def parse_env_file(path: Path) -> dict[str, str]:
@@ -3056,8 +3404,6 @@ def secret_to_toml(secret: FleetSecret) -> str:
         lines.append(f"identity_file = {toml_string(secret.identity_file)}")
     if secret.password:
         lines.append(f"password = {toml_string(secret.password)}")
-    if secret.proxy_jump:
-        lines.append(f"proxy_jump = {toml_string(secret.proxy_jump)}")
     lines.append(f"identities_only = {'true' if secret.identities_only else 'false'}")
     lines.append(f"forward_agent = {'true' if secret.forward_agent else 'false'}")
     lines.append(f"compression = {'true' if secret.compression else 'false'}")
@@ -3088,6 +3434,9 @@ def target_to_toml(target: TargetRecord) -> str:
         lines.append(f"role = {toml_string(target.role)}")
     if target.protocol:
         lines.append(f"protocol = {toml_string(target.protocol)}")
+    if target.reach != DEFAULT_REACH:
+        routes = ", ".join(toml_string(route) for route in target.reach)
+        lines.append(f"reach = [{routes}]")
     if target.workdir:
         lines.append(f"workdir = {toml_string(target.workdir)}")
     if target.tags:
@@ -3335,6 +3684,23 @@ def command_init(args: argparse.Namespace) -> int:
     return 0
 
 
+def reach_dependents(context: FleetContext) -> dict[str, list[str]]:
+    """Map each bridge to the targets whose declared routes go through it.
+
+    This is the answer to "what stops working if the bridge dies", which the
+    fleet could not previously produce at all: the hop lived inside each
+    dependent's secret, so the dependency existed only in a file that must not be
+    read to answer a topology question.
+    """
+    dependents: dict[str, list[str]] = {}
+    for target in context.targets.values():
+        for route in target.reach:
+            bridge_name = route_bridge(route)
+            if bridge_name is not None:
+                dependents.setdefault(bridge_name, []).append(target.name)
+    return {name: sorted(users) for name, users in dependents.items()}
+
+
 def command_list(args: argparse.Namespace, context: FleetContext) -> int:
     """List configured targets."""
     if args.format == "ssh-hosts":
@@ -3344,6 +3710,28 @@ def command_list(args: argparse.Namespace, context: FleetContext) -> int:
             if args.tag and args.tag not in target.tags:
                 continue
             print(f"fleet:{target.name}")
+        return 0
+
+    if args.format == "topology":
+        carried = reach_dependents(context)
+        rows = []
+        for target in sorted(context.targets.values(), key=lambda item: item.name):
+            if args.tag and args.tag not in target.tags:
+                continue
+            rows.append(
+                {
+                    "name": target.name,
+                    "enabled": target.enabled,
+                    "role": resolve_role(target, context.resolve_protocol(target)),
+                    "reach": list(target.reach),
+                    "carries": carried.get(target.name, []),
+                }
+            )
+        emit_rows(
+            rows,
+            ["name", "enabled", "role", "reach", "carries"],
+            as_json=bool(args.json),
+        )
         return 0
 
     pool_index: dict[str, list[str]] = {}
@@ -3404,7 +3792,6 @@ def command_show(args: argparse.Namespace, context: FleetContext) -> int:
                     "port": secret.port,
                     "auth": secret.auth,
                     "identity_file": secret.identity_file or "",
-                    "proxy_jump": secret.proxy_jump or "",
                     "password_configured": secret.password is not None,
                 }
                 if args.sensitive
@@ -3506,11 +3893,15 @@ def command_import_ssh(args: argparse.Namespace, context: FleetContext) -> int:
             f"target {name!r} already exists; rerun with --force to overwrite"
         )
 
-    secret = infer_secret_from_ssh_alias(args.alias)
+    secret, hop = infer_secret_from_ssh_alias(args.alias)
+    reach = parse_reach(
+        args.reach or DEFAULT_REACH, what=f"--reach for target {name!r}"
+    )
     target = TargetRecord(
         name=name,
         role=args.role,
         protocol=args.protocol or "direct",
+        reach=reach,
         workdir=args.workdir,
         tags=tuple(args.tag),
         secret_backend="file",
@@ -3519,6 +3910,16 @@ def command_import_ssh(args: argparse.Namespace, context: FleetContext) -> int:
     )
     write_text_file(target_path, target_to_toml(target), mode=PRIVATE_FILE_MODE)
     write_text_file(secret_path, secret_to_toml(secret), mode=PRIVATE_FILE_MODE)
+    if hop and reach == DEFAULT_REACH:
+        # Naming the hop's host here would print a fact out of ~/.ssh/config that
+        # belongs in the secret store, so say what to do rather than what it is.
+        print(
+            f"note: ssh alias {args.alias!r} reaches its host through a ProxyJump, "
+            "which fleetctl did not copy into the secret. Import that waypoint as "
+            "its own target with `--role bridge`, then re-run this with "
+            "`--reach direct --reach via:<bridge>`.",
+            file=sys.stderr,
+        )
     if args.project_path:
         update_project_binding(
             context.paths.projects_file,
@@ -3756,29 +4157,51 @@ def strip_top_level_keys(text: str, keys: Iterable[str]) -> tuple[str, list[str]
     return "".join(kept), removed
 
 
+def strip_toml_table(text: str, name: str) -> tuple[str, bool]:
+    """Remove one whole top-level `[name]` table from a TOML document."""
+    kept: list[str] = []
+    inside = False
+    removed = False
+    for line in text.splitlines(keepends=True):
+        stripped = line.strip()
+        if stripped.startswith("["):
+            inside = stripped in (f"[{name}]", f'["{name}"]', f"['{name}']")
+            removed = removed or inside
+        if inside:
+            continue
+        kept.append(line)
+    return "".join(kept), removed
+
+
 def bridge_dependents(context: FleetContext) -> tuple[dict[str, list[str]], list[str]]:
     """Map each target that is another target's SSH waypoint to who needs it.
 
-    The evidence is a secret's `proxy_jump`, so the matching happens over values
-    that must never be printed.  Only the conclusion is returned -- "numpi is the
-    waypoint for rtx1" -- never the host it resolved through.
+    Migration only.  The evidence is the deprecated `proxy_jump`, which no longer
+    survives parsing, so this reads the raw secret material -- and it reads values
+    that must never be printed, so only the conclusion comes back: "<the bridge>
+    is the waypoint for <the dependent>", never the host it resolved through.
     """
-    secrets: dict[str, FleetSecret] = {}
+    raws: dict[str, dict[str, Any]] = {}
     notes: list[str] = []
     for target in context.targets.values():
         try:
-            secrets[target.name] = context.resolve_secret(target)
+            raws[target.name], _ = context.resolve_secret_raw(target)
         except FleetError:
             notes.append(
                 f"could not read {target.name!r}'s secret, so it was neither "
                 "classified as a waypoint nor checked for one"
             )
-    by_host = {secret.host.lower(): name for name, secret in secrets.items()}
+    by_host = {
+        str(raw["host"]).lower(): name
+        for name, raw in raws.items()
+        if optional_str(raw.get("host"))
+    }
     dependents: dict[str, list[str]] = {}
-    for name, secret in secrets.items():
-        if not secret.proxy_jump:
+    for name, raw in raws.items():
+        declared = optional_str(raw.get("proxy_jump"))
+        if not declared:
             continue
-        hop = secret.proxy_jump.rsplit("@", 1)[-1].split(":", 1)[0].strip().lower()
+        hop = declared.rsplit("@", 1)[-1].split(":", 1)[0].strip().lower()
         owner = by_host.get(hop) or (hop if hop in context.targets else None)
         if owner is None:
             notes.append(
@@ -3845,6 +4268,14 @@ def command_migrate_config(args: argparse.Namespace) -> int:
         renames[old] = new
 
     dependents, notes = bridge_dependents(context)
+    # The inverse of `dependents`, so each hop can be lifted out of the secret and
+    # into the target that uses it.  Direct comes first: a bridge is the fallback,
+    # never the default path.
+    lifted_reach = {
+        user: (ROUTE_DIRECT, f"{ROUTE_VIA_PREFIX}{renames.get(owner, owner)}")
+        for owner, users in dependents.items()
+        for user in users
+    }
 
     # --- decide, and be able to say why ------------------------------------
     decisions: list[tuple[str, str, str, str]] = []  # name, new name, role, reason
@@ -3950,7 +4381,20 @@ def command_migrate_config(args: argparse.Namespace) -> int:
                     "one generation in `.prev`"
                 )
 
-            replacement = replace(target, name=new_name, role=role, secret_ref=secret_ref)
+            reach = target.reach
+            if reach == DEFAULT_REACH and old_name in lifted_reach:
+                reach = lifted_reach[old_name]
+                changes.append(
+                    f"targets.d/{new_name}.toml: reach = [{format_reach(reach)}] "
+                    "(lifted out of the secret's `proxy_jump`)"
+                )
+            replacement = replace(
+                target,
+                name=new_name,
+                role=role,
+                secret_ref=secret_ref,
+                reach=reach,
+            )
             destination = paths.targets_dir / f"{new_name}.toml"
             if source is not None and source != destination:
                 source.unlink()
@@ -3965,6 +4409,10 @@ def command_migrate_config(args: argparse.Namespace) -> int:
         for directory, staged_dir, dead in (
             (live.protocols_dir, paths.protocols_dir, DEPRECATED_PROTOCOL_KEYS),
             (live.profiles_dir, paths.profiles_dir, DEPRECATED_PROFILE_KEYS),
+            # Secrets are edited in place rather than re-serialized: rewriting one
+            # from a parsed record would drop anything the schema does not model,
+            # and these are the files you cannot afford to lose.
+            (live.secrets_dir, paths.secrets_dir, DEPRECATED_SECRET_KEYS),
         ):
             if not staged_dir.exists():
                 continue
@@ -3978,6 +4426,14 @@ def command_migrate_config(args: argparse.Namespace) -> int:
                     f"{directory.name}/{entry.name}: dropped "
                     + ", ".join(f"`{key}`" for key in removed)
                 )
+        # `[defaults]` held exactly one key and nothing ever read it.  Dropping
+        # the table rather than the key leaves no empty section behind.
+        if paths.config_file.exists():
+            text = paths.config_file.read_text(encoding="utf-8")
+            stripped, dropped = strip_toml_table(text, "defaults")
+            if dropped:
+                write_text_file(paths.config_file, stripped, mode=PRIVATE_FILE_MODE)
+                changes.append("config.toml: dropped `[defaults]`")
         # --- follow the renames through everything that names a target -----
         if renames:
             for pool in context.pools.values():
@@ -4770,7 +5226,6 @@ def probe_remote_prerequisites(context: FleetContext) -> list[str]:
     stays offline and instant.
     """
     problems: list[str] = []
-    runtime = ssh_runtime_kwargs(context)
     for target in sorted(context.targets.values(), key=lambda item: item.name):
         if not target.enabled:
             continue
@@ -4779,6 +5234,10 @@ def probe_remote_prerequisites(context: FleetContext) -> list[str]:
         except FleetError:
             continue  # already reported by the offline pass
         try:
+            # Per target, not hoisted out of the loop: the ProxyCommand is part
+            # of the runtime now, and a hoisted one would send every probe down
+            # the first target's route.
+            runtime = ssh_runtime_kwargs(context, target=target)
             completed = run_ssh_command(
                 secret,
                 allocate_tty=False,
@@ -4828,6 +5287,7 @@ def command_explain(args: argparse.Namespace, context: FleetContext) -> int:
         selector=selector,
         pool=context.pools.get(selector) if selector else None,
         admin=bool(args.admin),
+        routes=resolve_routes(target, getattr(args, "route", None)),
     )
     role = resolve_role(target, protocol)
     payload = plan.describe()
@@ -4961,6 +5421,10 @@ def command_doctor(args: argparse.Namespace) -> int:
         # A pool that cannot be selected from is a pool that aborts the first
         # command aimed at it.  `select_pool` is the only definition of pool
         # membership, so run the real thing rather than re-deriving it.
+        # The reach graph is inventory-wide, so it is checked once rather than
+        # per target: a missing bridge is one fault, not one per dependent.
+        problems.extend(context.reach_problems())
+
         for pool in context.pools.values():
             try:
                 context.select_pool(pool)
@@ -5028,6 +5492,30 @@ def command_doctor(args: argparse.Namespace) -> int:
         return 1
     return 0
 
+def add_route_flag(parser: argparse.ArgumentParser) -> None:
+    """Register `--route`, which pins one of a target's declared routes."""
+    parser.add_argument(
+        "--route",
+        metavar="ROUTE",
+        help='Use one declared route: "direct" or "via:<bridge>"',
+    )
+
+
+def add_connection_flags(parser: argparse.ArgumentParser) -> None:
+    """Register the flags every verb that opens a connection carries.
+
+    Nine subparsers repeated the same five lines for `--admin`, which is exactly
+    how a tenth verb ends up without it.  Admission and routing are both
+    properties of connecting to a host, so they are declared together, once.
+    """
+    parser.add_argument(
+        "--admin",
+        action="store_true",
+        help="Acknowledge a control-plane action on a role that repels this verb",
+    )
+    add_route_flag(parser)
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI parser."""
     parser = argparse.ArgumentParser(prog="fleetctl")
@@ -5049,9 +5537,9 @@ def build_parser() -> argparse.ArgumentParser:
     list_parser.add_argument("--json", action="store_true", help="Emit JSON")
     list_parser.add_argument(
         "--format",
-        choices=["table", "ssh-hosts"],
+        choices=["table", "ssh-hosts", "topology"],
         default="table",
-        help="Output format",
+        help="Output format; `topology` reports routes and what each bridge carries",
     )
     list_parser.add_argument("--tag", help="Filter by one target tag")
     list_parser.set_defaults(handler=command_list)
@@ -5243,6 +5731,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Host-level work directory where projects land by default",
     )
     import_ssh_parser.add_argument(
+        "--reach",
+        action="append",
+        default=[],
+        metavar="ROUTE",
+        help=(
+            'Route to the host: "direct" or "via:<bridge>". Repeatable and '
+            "ordered -- pass it twice for a fallback. Defaults to direct only."
+        ),
+    )
+    import_ssh_parser.add_argument(
         "--tag",
         action="append",
         default=[],
@@ -5336,22 +5834,14 @@ def build_parser() -> argparse.ArgumentParser:
 
     ssh_parser = subparsers.add_parser("ssh", help="Open an interactive SSH session")
     ssh_parser.add_argument("selector", nargs="?", help="Target or pool name")
-    ssh_parser.add_argument(
-        "--admin",
-        action="store_true",
-        help="Acknowledge a control-plane action on a role that repels this verb",
-    )
+    add_connection_flags(ssh_parser)
     ssh_parser.set_defaults(handler=command_ssh)
 
     smoke_parser = subparsers.add_parser("smoke", help="Run a remote smoke check")
     smoke_parser.add_argument("selector", nargs="?", help="Target or pool name")
     smoke_parser.add_argument("--profile", help="Execution profile override")
     smoke_parser.add_argument("--cwd", help="Remote working directory override")
-    smoke_parser.add_argument(
-        "--admin",
-        action="store_true",
-        help="Acknowledge a control-plane action on a role that repels this verb",
-    )
+    add_connection_flags(smoke_parser)
     smoke_parser.set_defaults(handler=command_smoke)
 
     exec_parser = subparsers.add_parser(
@@ -5362,11 +5852,7 @@ def build_parser() -> argparse.ArgumentParser:
     exec_parser.add_argument("--target", dest="selector_override", help="Target or pool name")
     exec_parser.add_argument("--profile", help="Execution profile override")
     exec_parser.add_argument("--cwd", help="Remote working directory override")
-    exec_parser.add_argument(
-        "--admin",
-        action="store_true",
-        help="Acknowledge a control-plane action on a role that repels this verb",
-    )
+    add_connection_flags(exec_parser)
     exec_parser.add_argument("--tty", action="store_true", help="Allocate a TTY")
     exec_parser.add_argument(
         "argv",
@@ -5388,11 +5874,7 @@ def build_parser() -> argparse.ArgumentParser:
     script_parser.add_argument("--target", dest="selector", help="Target or pool name")
     script_parser.add_argument("--profile", help="Execution profile override")
     script_parser.add_argument("--cwd", help="Remote working directory override")
-    script_parser.add_argument(
-        "--admin",
-        action="store_true",
-        help="Acknowledge a control-plane action on a role that repels this verb",
-    )
+    add_connection_flags(script_parser)
     script_parser.add_argument("--interpreter", help="Interpreter to prepend")
     script_parser.add_argument("--tty", action="store_true", help="Allocate a TTY")
     script_parser.add_argument(
@@ -5426,11 +5908,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Override a --delete safety refusal",
     )
-    sync_parser.add_argument(
-        "--admin",
-        action="store_true",
-        help="Acknowledge a control-plane action on a role that repels this verb",
-    )
+    add_connection_flags(sync_parser)
     sync_parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -5479,11 +5957,7 @@ def build_parser() -> argparse.ArgumentParser:
         nargs="*",
         help="Arguments for direct-profile submissions after `--`",
     )
-    submit_parser.add_argument(
-        "--admin",
-        action="store_true",
-        help="Acknowledge a control-plane action on a role that repels this verb",
-    )
+    add_connection_flags(submit_parser)
     submit_parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -5499,11 +5973,7 @@ def build_parser() -> argparse.ArgumentParser:
     status_parser.add_argument("--target", dest="selector", help="Target or pool name")
     status_parser.add_argument("--profile", help="Execution profile override")
     status_parser.add_argument("--cwd", help="Remote working directory override")
-    status_parser.add_argument(
-        "--admin",
-        action="store_true",
-        help="Acknowledge a control-plane action on a role that repels this verb",
-    )
+    add_connection_flags(status_parser)
     status_parser.set_defaults(handler=command_job_status)
 
     logs_parser = job_subparsers.add_parser("logs", help="Fetch scheduler logs")
@@ -5511,11 +5981,7 @@ def build_parser() -> argparse.ArgumentParser:
     logs_parser.add_argument("--target", dest="selector", help="Target or pool name")
     logs_parser.add_argument("--profile", help="Execution profile override")
     logs_parser.add_argument("--cwd", help="Remote working directory override")
-    logs_parser.add_argument(
-        "--admin",
-        action="store_true",
-        help="Acknowledge a control-plane action on a role that repels this verb",
-    )
+    add_connection_flags(logs_parser)
     logs_parser.set_defaults(handler=command_job_logs)
 
     cancel_parser = job_subparsers.add_parser("cancel", help="Cancel scheduler jobs")
@@ -5523,11 +5989,7 @@ def build_parser() -> argparse.ArgumentParser:
     cancel_parser.add_argument("--target", dest="selector", help="Target or pool name")
     cancel_parser.add_argument("--profile", help="Execution profile override")
     cancel_parser.add_argument("--cwd", help="Remote working directory override")
-    cancel_parser.add_argument(
-        "--admin",
-        action="store_true",
-        help="Acknowledge a control-plane action on a role that repels this verb",
-    )
+    add_connection_flags(cancel_parser)
     cancel_parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -5553,6 +6015,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Show the plan as it would resolve with --admin",
     )
+    add_route_flag(explain_parser)
     explain_parser.add_argument("--json", action="store_true", help="Emit JSON")
     explain_parser.set_defaults(handler=command_explain)
 

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -52,6 +52,12 @@ DEFAULT_SYNC_EXCLUDES = [
     "runs/",
     "*.pyc",
 ]
+# rsync's -z is zlib level 6, which is the wrong trade for this fleet: every
+# clustered connection can be multiplexed through a Raspberry Pi, so the
+# compressor saturates a core long before the link fills.  Level 1 keeps most
+# of the win on source trees and hands the CPU back.
+DEFAULT_SYNC_COMPRESS_LEVEL = 1
+MAX_SYNC_COMPRESS_LEVEL = 9
 
 # ---- SECTION: admission policy ---------------------------------------------
 #
@@ -5162,6 +5168,13 @@ def command_script(args: argparse.Namespace, context: FleetContext) -> int:
 
 def command_sync(args: argparse.Namespace, context: FleetContext) -> int:
     """Push or pull files with rsync."""
+    level = args.compress_level
+    if not 0 <= level <= MAX_SYNC_COMPRESS_LEVEL:
+        raise FleetError(
+            f"--compress-level must be 0-{MAX_SYNC_COMPRESS_LEVEL}, got {level}. "
+            "0 turns compression off; the range holds for zlib and zstd alike, "
+            "so the level stays valid whichever rsync negotiates."
+        )
     plan = build_plan(context, args, "sync")
     target = plan.target
     secret = plan.secret
@@ -5189,7 +5202,9 @@ def command_sync(args: argparse.Namespace, context: FleetContext) -> int:
     if plan.binding is not None:
         excludes.extend(plan.binding.sync_excludes)
 
-    command = ["rsync", "-az"]
+    command = ["rsync", "-a"]
+    if level:
+        command += ["-z", f"--compress-level={level}"]
     if args.delete:
         command.append("--delete")
     for pattern in excludes:
@@ -5236,6 +5251,7 @@ def command_sync(args: argparse.Namespace, context: FleetContext) -> int:
                 "local_path": local,
                 "remote_path": default_remote,
                 "delete": bool(args.delete),
+                "compress_level": level,
                 "excludes": excludes,
                 "rsync": shlex.join(command),
             },
@@ -5942,6 +5958,12 @@ REFUSALS WORTH KNOWING
 
     `sync --delete` refuses a home or root directory outright, and
     refuses the target's own workdir, or any pull, without --force.
+
+    `sync` compresses at level 1, not rsync's default 6, because a
+    transfer multiplexed through a Raspberry Pi is bound by the
+    compressor rather than the link. `--compress-level 0` turns
+    compression off for a fast local hop; 9 pays off only over a slow
+    one.
 
     `--dry-run` prints the resolved plan and exits 0, claiming nothing
     about remote state. `sync` is the exception that earns it: it runs
@@ -6768,6 +6790,16 @@ def build_parser() -> argparse.ArgumentParser:
         "--force",
         action="store_true",
         help="Override a --delete safety refusal",
+    )
+    sync_parser.add_argument(
+        "--compress-level",
+        type=int,
+        default=DEFAULT_SYNC_COMPRESS_LEVEL,
+        metavar="N",
+        help=(
+            "rsync compression level 0-9 "
+            f"(default {DEFAULT_SYNC_COMPRESS_LEVEL}; 0 disables compression)"
+        ),
     )
     add_connection_flags(sync_parser)
     sync_parser.add_argument(

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -15,6 +15,7 @@ import json
 import os
 import posixpath
 import re
+import secrets
 import shlex
 import shutil
 import stat
@@ -1442,6 +1443,10 @@ def build_plan(context: FleetContext, args: argparse.Namespace, verb: str) -> Pl
     )
     protocol = context.resolve_protocol(target)
     admin = bool(getattr(args, "admin", False))
+    # Above admission and not below it: authorize() raises, and a refused command
+    # is precisely the event an audit log exists to hold.
+    args.audit_target = target.name
+    args.audit_role = resolve_role(target, protocol)
     authorize(verb, target, protocol, admin=admin)
     profile = context.resolve_profile(target, binding, getattr(args, "profile", None))
     plan = Plan(
@@ -1471,6 +1476,11 @@ def build_plan(context: FleetContext, args: argparse.Namespace, verb: str) -> Pl
         ),
         requirements=requirements,
     )
+    # The audit line is written from main()'s `finally`, long after the plan has
+    # gone out of scope, and the route it reports has to be the one the plan ends
+    # up on rather than the first candidate -- so it keeps the plan, not a copy of
+    # a field that is still going to change.
+    args.audit_plan = plan
     capability_preflight(plan, args)
     return plan
 
@@ -2515,6 +2525,7 @@ def submit_staged_script(
     ssh_runtime: dict[str, Any],
     output_path: str | None = None,
     error_path: str | None = None,
+    ledger: tuple[FleetPaths, dict[str, Any]] | None = None,
 ) -> int:
     """Hand one already-staged script to the profile's scheduler."""
     submit_argv = render_template_values(
@@ -2537,6 +2548,7 @@ def submit_staged_script(
         profile,
         output_path=output_path,
         error_path=error_path,
+        ledger=ledger,
     )
 
 
@@ -2546,12 +2558,21 @@ def report_submitted_job(
     *,
     output_path: str | None = None,
     error_path: str | None = None,
+    ledger: tuple[FleetPaths, dict[str, Any]] | None = None,
 ) -> int:
     """Echo scheduler output and report the job id without ever losing a queued job.
 
     Once the scheduler accepts the script the job exists, so nothing here may raise:
     a traceback at this point would orphan a real allocation whose only identifier
     was in output we had not printed yet.
+
+    The ledger is stamped here rather than by the caller because this is the only
+    place holding both the parsed id and the log paths with `%j` already resolved,
+    and it is stamped last, after everything the operator sees -- so recording a
+    job can never be what comes between a queued job and its id reaching the
+    terminal.  A submission whose id could not be parsed is not recorded at all:
+    the ledger answers questions keyed on an id, and the warning below already
+    says what to do instead.
     """
     if completed.stdout:
         print(completed.stdout, end="")
@@ -2579,10 +2600,23 @@ def report_submitted_job(
     if not job_id:
         job_id = match.group(1) if match.groups() else match.group(0)
     print(f"job_id={job_id}")
-    if output_path:
-        print(f"log_out={output_path.replace('%j', job_id)}")
-    if error_path:
-        print(f"log_err={error_path.replace('%j', job_id)}")
+    resolved_out = output_path.replace("%j", job_id) if output_path else ""
+    resolved_err = error_path.replace("%j", job_id) if error_path else ""
+    if resolved_out:
+        print(f"log_out={resolved_out}")
+    if resolved_err:
+        print(f"log_err={resolved_err}")
+    if ledger is not None:
+        paths, record = ledger
+        record_submitted_job(
+            paths,
+            {
+                **record,
+                "job_id": job_id,
+                "log_out": resolved_out,
+                "log_err": resolved_err,
+            },
+        )
     return completed.returncode
 
 
@@ -3310,6 +3344,236 @@ def record_route_state(
         pass
 
 
+def jobs_ledger_file(paths: FleetPaths) -> Path:
+    """Where every submission the scheduler accepted is recorded, one line each."""
+    return paths.state_home / "jobs.jsonl"
+
+
+def audit_log_file(paths: FleetPaths) -> Path:
+    """Where every invocation that reached for a host is recorded, one line each."""
+    return paths.state_home / "audit.jsonl"
+
+
+# How many lines each of these files keeps.  A count and not an age: a thirty-day
+# array job is still the job you want `job status` to resolve, so forgetting by
+# date would drop exactly the record still in use, while forgetting by count only
+# drops a job once you have submitted two thousand newer ones.
+JSONL_KEEP_LINES = 2000
+
+
+def append_jsonl(
+    path: Path, record: dict[str, Any], *, keep: int = JSONL_KEEP_LINES
+) -> None:
+    """Append one record to a private JSON-lines file and cap the file's length.
+
+    The file is opened 0600 and re-chmodded on every append, because a plain
+    `open(path, "a")` under the usual 022 umask produces 0644, and neither of
+    these files is one to hand to every account on a shared laptop.  The chmod
+    also repairs a file written before this rule existed.
+
+    One `os.write` of one line to an O_APPEND descriptor is what keeps two
+    concurrent submits from interleaving halves of a line.  The kernel makes no
+    such promise for regular files in general, which is why `read_jsonl` skips a
+    line it cannot parse instead of trusting the file.
+
+    Trimming happens after the append and never before: the line just written is
+    the one the operator is about to look up.  It costs reading the file back on
+    every append, which is two thousand short lines against an SSH round trip --
+    and it is what makes a corrupt line disappear for good, since `read_jsonl`
+    drops it and the rewrite does not put it back.
+    """
+    ensure_private_dir(path.parent, mode=STATE_DIR_MODE)
+    handle = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, PRIVATE_FILE_MODE)
+    try:
+        os.fchmod(handle, PRIVATE_FILE_MODE)
+        os.write(handle, (json.dumps(record, sort_keys=True) + "\n").encode("utf-8"))
+    finally:
+        os.close(handle)
+    records = read_jsonl(path)
+    if len(records) > keep:
+        write_text_file(
+            path,
+            "".join(json.dumps(item, sort_keys=True) + "\n" for item in records[-keep:]),
+            mode=PRIVATE_FILE_MODE,
+        )
+
+
+def read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read a JSON-lines state file oldest-first, skipping anything unreadable.
+
+    A ledger that raises is worse than a ledger with a hole in it.  One truncated
+    line -- a submit killed mid-write, or two that raced -- must not take
+    `fleetctl jobs` and `job status` down with it, so a line that is not a JSON
+    object is dropped and the rest of the file stays usable.
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    records: list[dict[str, Any]] = []
+    for line in text.splitlines():
+        try:
+            loaded = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(loaded, dict):
+            records.append(loaded)
+    return records
+
+
+def record_submitted_job(paths: FleetPaths, record: dict[str, Any]) -> None:
+    """Record one accepted submission, or warn and carry on.
+
+    Nothing here may raise.  This runs after the scheduler has accepted the
+    script, so the job already exists: an exception would orphan a real
+    allocation for the sake of a line of bookkeeping.  The failure is still worth
+    saying out loud -- an operator whose ledger silently stopped growing will
+    find out when `job status` asks for flags again -- so it degrades to a
+    warning on stderr and leaves the exit code alone.  The allocation is real
+    whether or not this file was writable.
+    """
+    try:
+        append_jsonl(jobs_ledger_file(paths), record)
+    except Exception as exc:
+        print(
+            f"warning: job {record.get('job_id') or '?'} was submitted but could not "
+            f"be recorded in {jobs_ledger_file(paths)} ({exc}); `fleetctl job status` "
+            "will need --target for it",
+            file=sys.stderr,
+        )
+
+
+def apply_job_ledger_defaults(args: argparse.Namespace, context: FleetContext) -> None:
+    """Fill in --target and --profile for a job id the ledger already knows.
+
+    `job status 812345` used to demand both flags every time, though the submit
+    that created the job knew both and threw them away.  An explicit flag still
+    wins: the ledger records where a job went, not where the next command should
+    go, and an operator holding a stale ledger needs a way past it.
+
+    An id two targets both claim is a refusal rather than a coin flip.  Two
+    clusters really do both have a job 12345, and `job cancel` guessing wrong
+    kills a live allocation that belongs to someone else while yours keeps
+    running.
+    """
+    if args.selector and args.profile:
+        return
+    selector = context.normalize_selector(args.selector)
+    matches = [
+        record
+        for record in read_jsonl(jobs_ledger_file(context.paths))
+        if str(record.get("job_id", "")) == args.job_id
+        and (selector is None or record.get("target") == selector)
+    ]
+    if not matches:
+        return
+    if selector is None:
+        claimed = sorted({str(item["target"]) for item in matches if item.get("target")})
+        if len(claimed) > 1:
+            raise FleetError(
+                f"job id {args.job_id!r} was submitted to more than one target "
+                f"({', '.join(claimed)}); pass --target to say which one you mean"
+            )
+    newest = matches[-1]
+    recorded_target = str(newest.get("target") or "")
+    if not args.selector and recorded_target:
+        if recorded_target not in context.targets:
+            # The ledger outlives the inventory, so this is a normal end state
+            # rather than a corrupt file.  Naming the ledger matters: the operator
+            # did not type this target, and "unknown target" about a name they
+            # never used reads as a bug in the tool.
+            raise FleetError(
+                f"the job ledger records job {args.job_id} on target "
+                f"{recorded_target!r}, which is no longer in the inventory. Pass "
+                "--target to name one that is, or run `fleetctl jobs` to see what "
+                "was recorded."
+            )
+        args.selector = recorded_target
+        # On stderr, because `job logs` output gets piped and this is a note about
+        # how the command was resolved rather than part of its answer.
+        print(
+            f"note: --target {recorded_target} resolved from the job ledger",
+            file=sys.stderr,
+        )
+    recorded_profile = str(newest.get("profile") or "")
+    # A profile since renamed out of the inventory falls back to normal
+    # resolution instead of failing.  That is what this command did before the
+    # ledger existed, and the profile is a detail the operator never asked about.
+    if not args.profile and recorded_profile in context.profiles:
+        args.profile = recorded_profile
+
+
+def record_invocation(
+    args: argparse.Namespace,
+    *,
+    head: list[str],
+    exit_code: int | None,
+) -> None:
+    """Record that a host was reached for: which verb, which host, what came of it.
+
+    No operator string is recorded, and that is the design rather than an
+    omission.  A fleetctl command line carries remote paths, script names and,
+    after `--`, whatever was pasted into the shell -- which is where a token ends
+    up.  A denylist of things to redact is a promise this file cannot keep,
+    because the leak is always the flag nobody thought of, and an audit log that
+    accumulates the contents of commands has stopped being a record and become a
+    secret store.  What lands here is fleetctl's own resolved facts plus the flag
+    *names* as typed: enough to answer what a shared cluster's admin asks -- when,
+    which host, which verb, did it run or was it refused -- and not enough to
+    reconstruct anything.  For `exec` that means knowing a command ran on a login
+    node at 14:02 and exited 1, and not what it was.  That is the trade.
+
+    Nothing here may raise and nothing here prints.  This runs from main()'s
+    `finally` while a SystemExit carrying the real exit code is already
+    propagating, so an exception would replace it with a traceback and the wrong
+    status; and a warning would fire on every command rather than once, for a
+    broken state directory `doctor` already reports.
+    """
+    try:
+        if not getattr(args, "audited", False):
+            return
+        plan = getattr(args, "audit_plan", None)
+        append_jsonl(
+            audit_log_file(
+                build_paths(
+                    config_home=args.config_home,
+                    state_home=args.state_home,
+                    cache_home=args.cache_home,
+                )
+            ),
+            {
+                "ts": utc_timestamp(),
+                "verb": " ".join(
+                    part
+                    for part in (args.command, getattr(args, "job_command", None))
+                    if part
+                ),
+                # Names only, split at `=` so `--cwd=/srv/customer-42` cannot
+                # smuggle its value in as part of one.  A value given as a
+                # separate word does not start with `--` and never arrives here.
+                "flags": sorted(
+                    {token.split("=", 1)[0] for token in head if token.startswith("--")}
+                ),
+                # Stamped by build_plan above its authorize() call, so a refusal
+                # still names the host it was refused on.
+                "target": getattr(args, "audit_target", "") or "",
+                "role": getattr(args, "audit_role", "") or "",
+                # ensure_route writes the route that came up back into the plan,
+                # so by the time main() unwinds this is the path traffic took --
+                # empty for a refusal, and the first candidate for a dry run,
+                # which `dry_run` below distinguishes.
+                "route": plan.route if plan is not None else "",
+                "admin": bool(getattr(args, "admin", False)),
+                "dry_run": bool(getattr(args, "dry_run", False)),
+                # None when fleetctl itself died, which is the honest record: we
+                # do not know what the remote did.
+                "exit": exit_code,
+            },
+        )
+    except Exception:
+        pass
+
+
 def ensure_route(plan: Plan) -> str:
     """Bring up a control master for the first of PLAN's routes that works.
 
@@ -3407,6 +3671,64 @@ def quote_remote_path(path: str) -> str:
     return shlex.quote(path)
 
 
+# A staging directory is named by exactly `secrets.token_hex(STAGE_TOKEN_BYTES)`,
+# and the collector below matches that shape rather than `*`.  Both constants live
+# here so the name a script is staged under and the glob that deletes it cannot
+# drift apart.
+STAGE_TOKEN_BYTES = 8
+STAGE_TOKEN_GLOB = "[0-9a-f]" * (STAGE_TOKEN_BYTES * 2)
+STAGE_RETENTION_DAYS = 14
+
+
+def stage_prune_command(remote_root: str, remote_dir: str) -> str:
+    """Build the one command that makes a staging directory and collects old ones.
+
+    Nothing has ever removed a staged script, and `submit` leaves two per job.
+    The collector therefore rides the `mkdir` staging already pays for: staging
+    is on the path of every single command, `submit` stages twice, and one host in
+    this fleet is reached through a Raspberry Pi, where a separate prune would be
+    two more round trips of real latency per submission.  What it actually costs
+    is one `find` over a single directory level.
+
+    Age comes from the remote `find`'s own view of mtime, because there is no
+    agent on the far side and a staging directory's mtime already *is* the moment
+    its script was written -- nothing touches it again.  The alternative, encoding
+    a timestamp in the name, would need an `ls` round trip to read the names back.
+
+    `mkdir` keeps its own failure, so the caller's "failed to create remote script
+    directory" still fires; everything the collector says or returns is discarded.
+    A stale directory nobody has permission to remove must never be the reason a
+    submit did not happen.
+
+    `-name` matches the exact shape of a fleet staging token rather than `*`: a
+    profile whose `remote_script_root` pointed somewhere shared would otherwise
+    hand `rm -rf` to whatever else lived there.  The cost is that directories
+    staged before this change are 8 characters of `[a-z0-9_]` and never match, so
+    they need one manual sweep -- which is the right trade against permanently
+    weakening the only thing keeping this honest.
+    """
+    collect = shlex.join(
+        [
+            "find",
+            remote_root,
+            "-mindepth", "1",
+            "-maxdepth", "1",
+            "-type", "d",
+            "-name", STAGE_TOKEN_GLOB,
+            "-mtime", f"+{STAGE_RETENTION_DAYS}",
+            "-exec", "rm", "-rf", "{}", "+",
+        ]
+    )
+    return shlex.join(
+        [
+            "/bin/sh",
+            "-c",
+            f"mkdir -p {quote_remote_path(remote_dir)} || exit 1; "
+            f"{collect} >/dev/null 2>&1; exit 0",
+        ]
+    )
+
+
 def remote_shell_path_command(argv: list[str], remote_path: str) -> str:
     """Build a remote command whose final argument is a fleet-resolved path."""
     return shlex.join(
@@ -3488,7 +3810,7 @@ def stage_remote_script(
 ) -> str:
     """Copy one local script into a remote scratch directory and return its path."""
     script_name = local_script.name
-    token = next(tempfile._get_candidate_names())
+    token = secrets.token_hex(STAGE_TOKEN_BYTES)
     ssh_runtime = ssh_runtime or {}
     remote_root = profile.remote_script_root
     if not remote_root.startswith("/"):
@@ -3503,7 +3825,7 @@ def stage_remote_script(
     mkdir = run_ssh_command(
         secret,
         allocate_tty=False,
-        remote_command=remote_shell_path_command(["mkdir", "-p"], remote_dir),
+        remote_command=stage_prune_command(remote_root, remote_dir),
         timeout=CONTROL_COMMAND_TIMEOUT,
         **ssh_runtime,
     )
@@ -3606,6 +3928,31 @@ def resolve_job_output_paths(
     output_path = resolve_one(output_override, "%j.out")
     error_path = resolve_one(error_override, "%j.err")
     return output_dir, output_path, error_path
+
+
+def job_ledger_record(plan: Plan, local_script: Path) -> dict[str, Any]:
+    """Describe one submission for the ledger, minus the id only the scheduler knows.
+
+    Every field comes off the frozen plan, so the ledger records the target,
+    protocol, profile and queue the submit actually used instead of a second
+    resolution of the same arguments.  `script` is the local path submitted, not
+    the staged remote one: the staged copy is a directory the collector removes.
+
+    Absent values are `""` and never null, so a record renders through
+    `format_table` without the word "None" appearing in a column.
+    """
+    return {
+        "ts": utc_timestamp(),
+        "target": plan.target.name,
+        "protocol": plan.protocol.name,
+        "profile": plan.profile.name,
+        "queue": plan.queue.name if plan.queue is not None else "",
+        "job_id": "",
+        "script": str(local_script),
+        "log_out": "",
+        "log_err": "",
+        "cwd": plan.cwd or "",
+    }
 
 
 def sanitize_job_name(value: str) -> str:
@@ -6039,6 +6386,7 @@ def command_submit(args: argparse.Namespace, context: FleetContext) -> int:
             remote_script=remote_script,
             cwd=cwd,
             ssh_runtime=ssh_runtime,
+            ledger=(context.paths, job_ledger_record(plan, local_script)),
         )
 
     if protocol.native_batch_required:
@@ -6128,7 +6476,41 @@ def command_submit(args: argparse.Namespace, context: FleetContext) -> int:
         ssh_runtime=ssh_runtime,
         output_path=output_path,
         error_path=error_path,
+        ledger=(context.paths, job_ledger_record(plan, local_script)),
     )
+
+
+# How many recorded submissions `fleetctl jobs` shows without being asked for
+# more.  Two thousand rows is not a listing.
+JOB_LIST_DEFAULT = 20
+
+JOB_LIST_COLUMNS = ["ts", "job_id", "target", "queue", "profile", "script"]
+
+
+def command_jobs(args: argparse.Namespace, context: FleetContext) -> int:
+    """List the submissions `fleetctl submit` recorded.
+
+    Newest first, because the job you are following is the one you just
+    submitted.  The table shows six of the ten fields; `--json` carries the whole
+    record, log paths included, since that is what a script piping this wants.
+    """
+    records = read_jsonl(jobs_ledger_file(context.paths))
+    if args.target:
+        selector = context.normalize_selector(args.target)
+        records = [record for record in records if record.get("target") == selector]
+    records.reverse()
+    if not args.all:
+        records = records[: max(args.limit, 0)]
+    emit_rows(
+        records,
+        JOB_LIST_COLUMNS,
+        as_json=bool(args.json),
+        when_empty=(
+            f"no submissions recorded in {jobs_ledger_file(context.paths)}; "
+            "`fleetctl submit` appends one line per job the scheduler accepted"
+        ),
+    )
+    return 0
 
 
 def run_job_command(
@@ -6160,18 +6542,21 @@ def run_job_command(
 
 def command_job_status(args: argparse.Namespace, context: FleetContext) -> int:
     """Check remote scheduler status."""
+    apply_job_ledger_defaults(args, context)
     plan = build_plan(context, args, "job")
     return run_job_command(plan, plan.profile.status_command, job_id=args.job_id)
 
 
 def command_job_logs(args: argparse.Namespace, context: FleetContext) -> int:
     """Fetch remote scheduler logs."""
+    apply_job_ledger_defaults(args, context)
     plan = build_plan(context, args, "job")
     return run_job_command(plan, plan.profile.logs_command, job_id=args.job_id)
 
 
 def command_job_cancel(args: argparse.Namespace, context: FleetContext) -> int:
     """Cancel one remote scheduler job."""
+    apply_job_ledger_defaults(args, context)
     plan = build_plan(context, args, "job")
     if args.dry_run:
         return report_plan(
@@ -6679,8 +7064,16 @@ ADMISSION VERBS
     so you can ask what an --admin run or a chosen route would do
     without doing it.
 
+    Those same nine append one line to
+    $FLEET_STATE_HOME/audit.jsonl: the time, the subcommand, the
+    resolved target and its role, the route taken, the flag names you
+    typed, and the exit code -- a refusal included, because a refused
+    `exec` on a login node is the line most worth having. No flag
+    value and nothing after `--` is recorded at all, because that is
+    where a pasted token would be.
+
 EVERYTHING ELSE
-    Inventory   list, show, explain, resolve, protocol show,
+    Inventory   jobs, list, show, explain, resolve, protocol show,
                 queue list, project bind|show|list
     Setup       init, import-ssh, migrate-config, migrate-env
     Secrets     seed-pass, deploy-config
@@ -6931,7 +7324,7 @@ SYNOPSIS
     $FLEET_CONFIG_HOME  (default ~/.config/fleet)
         config.toml  projects.toml
         targets.d/  pools.d/  protocols.d/  profiles.d/  secrets/
-    $FLEET_STATE_HOME   known_hosts
+    $FLEET_STATE_HOME   known_hosts  routes.json  jobs.jsonl  audit.jsonl
     $FLEET_CACHE_HOME   mux/  (ssh control sockets)
 
 DESCRIPTION
@@ -7032,6 +7425,7 @@ SYNOPSIS
         [--cpus-per-task <n>] [--mem <size>] [--output <path>]
         [--error <path>] [--native-batch] [--dry-run] [-- <args>]
     fleetctl job status|logs|cancel <job_id> [--target <target>]
+    fleetctl jobs [--target <target>] [--limit <n>] [--all] [--json]
 
 DESCRIPTION
     `submit` has two paths, and the profile decides which: a profile
@@ -7063,6 +7457,18 @@ JOB CONTROL
     quietly. Job output defaults to `%j.out` and `%j.err` under the
     protocol's `job_output_dir`, and the printed log paths have `%j`
     already replaced.
+
+THE LEDGER
+    Every submission the scheduler accepted appends one JSON line to
+    $FLEET_STATE_HOME/jobs.jsonl, and `fleetctl jobs` lists them,
+    newest first. `job status|logs|cancel` read it, so an id the ledger
+    knows needs neither --target nor --profile; an explicit flag still
+    wins, and an id two targets both claim is refused rather than
+    guessed. A line that cannot be parsed is skipped, never fatal, and
+    a ledger that cannot be written costs a warning and not the job.
+
+    The ledger keeps the newest 2000 submissions. Age would be the
+    wrong rule: a month-old array job is still one you want to follow.
 
 SEE ALSO
     fleetctl help verbs, fleetctl help config, fleetctl help examples
@@ -7100,9 +7506,11 @@ DESCRIPTION
     Run a local script with arguments; after `--` is verbatim:
         fleetctl script ./setup.sh --target <target> -- --flag value
 
-    Submit to a named queue, then follow the job:
+    Submit to a named queue, then follow the job; the ledger already
+    knows where it went:
         fleetctl submit train.sh --target <target> --queue <preset>
-        fleetctl job status <job_id> --target <target>
+        fleetctl jobs
+        fleetctl job status <job_id>
 
     Touch a login node's control plane on purpose:
         fleetctl exec <target> --admin -- squeue --me
@@ -7230,6 +7638,11 @@ def add_connection_flags(parser: argparse.ArgumentParser) -> None:
     Nine subparsers repeated the same five lines for `--admin`, which is exactly
     how a tenth verb ends up without it.  Admission and routing are both
     properties of connecting to a host, so they are declared together, once.
+
+    Reaching for a host is also what makes an invocation worth auditing, so the
+    audit's membership rule is declared here for the same reason.  It costs a
+    line for read-only `job status` and `job logs`, which is noise you can
+    filter; a missing line is not recoverable.
     """
     parser.add_argument(
         "--admin",
@@ -7238,6 +7651,7 @@ def add_connection_flags(parser: argparse.ArgumentParser) -> None:
     )
     add_route_flag(parser)
     add_capability_flags(parser)
+    parser.set_defaults(audited=True)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -7735,6 +8149,25 @@ def build_parser() -> argparse.ArgumentParser:
     )
     submit_parser.set_defaults(handler=command_submit)
 
+    jobs_parser = subparsers.add_parser(
+        "jobs",
+        help="List the jobs `fleetctl submit` recorded",
+    )
+    jobs_parser.add_argument("--target", help="Show only jobs submitted to one target")
+    jobs_parser.add_argument(
+        "--limit",
+        type=int,
+        default=JOB_LIST_DEFAULT,
+        help=f"Show at most this many, newest first (default {JOB_LIST_DEFAULT})",
+    )
+    jobs_parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Show every recorded job instead of the newest few",
+    )
+    jobs_parser.add_argument("--json", action="store_true", help="Emit JSON")
+    jobs_parser.set_defaults(handler=command_jobs)
+
     job_parser = subparsers.add_parser("job", help="Inspect or manage remote jobs")
     job_subparsers = job_parser.add_subparsers(dest="job_command", required=True)
 
@@ -7827,23 +8260,32 @@ def main() -> int:
             if hasattr(args, attribute):
                 setattr(args, attribute, payload)
 
+    # Set before the try, so an unhandled bug still writes a line: a null status
+    # records "fleetctl died and we do not know what the remote did".
+    exit_code: int | None = None
     try:
         # One load, one place.  There were twenty-four independent loads, which is
         # how `job status` came to resolve its target twice in one invocation.
         # The repair and diagnostic verbs opt out with `loads_own_config`: for
         # those a broken config is the input, not a precondition.
         if getattr(args, "loads_own_config", False):
-            return int(args.handler(args))
+            exit_code = int(args.handler(args))
+            return exit_code
         context = FleetContext.load(
             config_home=args.config_home,
             state_home=args.state_home,
             cache_home=args.cache_home,
         )
-        return int(args.handler(args, context))
+        exit_code = int(args.handler(args, context))
+        return exit_code
     except FleetError as exc:
-        parser.exit(exc.exit_code, f"error: {exc}\n")
+        exit_code = exc.exit_code
+        parser.exit(exit_code, f"error: {exc}\n")
     except KeyboardInterrupt:
+        exit_code = 130
         parser.exit(130, "error: interrupted\n")
+    finally:
+        record_invocation(args, head=head, exit_code=exit_code)
 
 
 if __name__ == "__main__":

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -2049,20 +2049,51 @@ def configured_machine_names(env: dict[str, str], prefix: str) -> list[str]:
     return names
 
 
+TOML_ESCAPES = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\b": "\\b",
+    "\t": "\\t",
+    "\n": "\\n",
+    "\f": "\\f",
+    "\r": "\\r",
+}
+
+
+def toml_string(value: str) -> str:
+    """Quote one value as a TOML basic string."""
+    out: list[str] = []
+    for char in value:
+        if char in TOML_ESCAPES:
+            out.append(TOML_ESCAPES[char])
+        elif char < " " or char == "\x7f":
+            out.append(f"\\u{ord(char):04X}")
+        else:
+            out.append(char)
+    return '"' + "".join(out) + '"'
+
+
+def toml_key(key: str) -> str:
+    """Quote one TOML key, leaving it bare when that is valid."""
+    if key and key.isascii() and all(c.isalnum() or c in "-_" for c in key):
+        return key
+    return toml_string(key)
+
+
 def secret_to_toml(secret: FleetSecret) -> str:
     """Serialize a secret file."""
     lines = [
-        f'host = "{secret.host}"',
-        f'user = "{secret.user}"',
+        f"host = {toml_string(secret.host)}",
+        f"user = {toml_string(secret.user)}",
         f"port = {secret.port}",
-        f'auth = "{secret.auth}"',
+        f"auth = {toml_string(secret.auth)}",
     ]
     if secret.identity_file:
-        lines.append(f'identity_file = "{secret.identity_file}"')
+        lines.append(f"identity_file = {toml_string(secret.identity_file)}")
     if secret.password:
-        lines.append(f'password = "{secret.password}"')
+        lines.append(f"password = {toml_string(secret.password)}")
     if secret.proxy_jump:
-        lines.append(f'proxy_jump = "{secret.proxy_jump}"')
+        lines.append(f"proxy_jump = {toml_string(secret.proxy_jump)}")
     lines.append(f"identities_only = {'true' if secret.identities_only else 'false'}")
     lines.append(f"forward_agent = {'true' if secret.forward_agent else 'false'}")
     lines.append(f"compression = {'true' if secret.compression else 'false'}")
@@ -2071,10 +2102,11 @@ def secret_to_toml(secret: FleetSecret) -> str:
     lines.append(f"server_alive_count_max = {secret.server_alive_count_max}")
     if secret.strict_host_key_checking:
         lines.append(
-            f'strict_host_key_checking = "{secret.strict_host_key_checking}"'
+            "strict_host_key_checking = "
+            f"{toml_string(secret.strict_host_key_checking)}"
         )
     for key, value in sorted(secret.extra_options.items()):
-        lines.append(f'ssh_option.{key} = "{value}"')
+        lines.append(f"ssh_option.{toml_key(key)} = {toml_string(value)}")
     return "\n".join(lines) + "\n"
 
 
@@ -2082,26 +2114,26 @@ def target_to_toml(target: TargetRecord) -> str:
     """Serialize a target file."""
     lines = [
         "version = 1",
-        f'name = "{target.name}"',
+        f"name = {toml_string(target.name)}",
         f"enabled = {'true' if target.enabled else 'false'}",
-        f'transport = "{target.transport}"',
+        f"transport = {toml_string(target.transport)}",
     ]
     if target.protocol:
-        lines.append(f'protocol = "{target.protocol}"')
+        lines.append(f"protocol = {toml_string(target.protocol)}")
     if target.workdir:
-        lines.append(f'workdir = "{target.workdir}"')
+        lines.append(f"workdir = {toml_string(target.workdir)}")
     if target.tags:
-        tags = ", ".join(f'"{tag}"' for tag in target.tags)
+        tags = ", ".join(toml_string(tag) for tag in target.tags)
         lines.append(f"tags = [{tags}]")
-    lines.append(f'secret_backend = "{target.secret_backend}"')
+    lines.append(f"secret_backend = {toml_string(target.secret_backend)}")
     if target.secret_ref:
-        lines.append(f'secret_ref = "{target.secret_ref}"')
+        lines.append(f"secret_ref = {toml_string(target.secret_ref)}")
     if target.ssh_host_alias:
-        lines.append(f'ssh_host_alias = "{target.ssh_host_alias}"')
+        lines.append(f"ssh_host_alias = {toml_string(target.ssh_host_alias)}")
     if target.default_profile:
-        lines.append(f'default_profile = "{target.default_profile}"')
+        lines.append(f"default_profile = {toml_string(target.default_profile)}")
     if target.scheduler:
-        lines.append(f'scheduler = "{target.scheduler}"')
+        lines.append(f"scheduler = {toml_string(target.scheduler)}")
     return "\n".join(lines) + "\n"
 
 

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import datetime
 import difflib
 import json
 import os
@@ -822,6 +823,7 @@ class Plan:
     admin: bool
     routes: tuple[str, ...] = DEFAULT_REACH
     _secret: FleetSecret | None = field(default=None, compare=False, repr=False)
+    _route: str | None = field(default=None, compare=False, repr=False)
 
     @property
     def secret(self) -> FleetSecret:
@@ -841,15 +843,27 @@ class Plan:
     def route(self) -> str:
         """The route this plan uses.
 
-        For a target that declares no bridge this is the only candidate; with a
-        fallback declared it is the one tried first, which is what the argv
-        builders need in order to be printable before any connection exists.
+        Before a connection exists this is the first candidate, which is what the
+        argv builders need in order to be printable; once `connect` has brought a
+        control master up it is the route that actually carries the traffic.
         """
+        if self._route is not None:
+            return self._route
         return self.routes[0] if self.routes else ROUTE_DIRECT
 
     def ssh_runtime(self) -> dict[str, Any]:
         """Return the fleet-managed SSH settings for this plan, hop included."""
         return ssh_runtime_kwargs(self.context, target=self.target, route=self.route)
+
+    def connect(self) -> dict[str, Any]:
+        """Bring up a route and return the SSH settings that use it.
+
+        The one boundary between describing a plan and acting on one: `explain`
+        and `--dry-run` call `ssh_runtime` and never touch a network, while every
+        host-touching verb calls this and gets the route that came up.
+        """
+        ensure_route(self)
+        return self.ssh_runtime()
 
     def ssh_connect_argv(self) -> list[str]:
         """The ssh invocation this plan will use, without the remote command."""
@@ -869,6 +883,7 @@ class Plan:
             "target": self.target.name,
             "role": resolve_role(self.target, self.protocol),
             "reach": list(self.target.reach),
+            "routes": list(self.routes),
             "route": self.route,
             "protocol": self.protocol.name,
             "protocol_kind": self.protocol.kind,
@@ -903,20 +918,31 @@ def build_plan(context: FleetContext, args: argparse.Namespace, verb: str) -> Pl
         selector=selector,
         pool=context.pools.get(selector) if selector else None,
         admin=admin,
-        routes=resolve_routes(target, getattr(args, "route", None)),
+        routes=resolve_routes(
+            target,
+            getattr(args, "route", None),
+            no_fallback=bool(getattr(args, "no_fallback", False)),
+        ),
     )
 
 
-def resolve_routes(target: TargetRecord, requested: str | None) -> tuple[str, ...]:
+def resolve_routes(
+    target: TargetRecord,
+    requested: str | None,
+    *,
+    no_fallback: bool = False,
+) -> tuple[str, ...]:
     """Return the routes to try for TARGET, in order.
 
     `--route` picks one of the declared routes rather than inventing one: a route
     fleetctl has never been told about is a guess about someone else's network,
     and the failure it produces is a timeout rather than an error.
+    `--no-fallback` keeps only the first, for when reaching a host the slow way is
+    worse than not reaching it at all.
     """
     declared = target.reach or DEFAULT_REACH
     if requested is None:
-        return declared
+        return declared[:1] if no_fallback else declared
     route = parse_route(requested, what=f"--route for target {target.name!r}")
     if route not in declared:
         raise FleetError(
@@ -1866,6 +1892,23 @@ def resolve_remote_root(
 SSH_TRANSPORT_FAILURE = 255
 
 CONTROL_COMMAND_TIMEOUT = 60.0
+
+# How long one route gets to bring up a control master before the next is tried.
+# Direct gets the shorter deadline because this is the entire cost of preferring
+# it: one timeout per ControlPersist window, paid only when direct is down.
+DIRECT_CONNECT_TIMEOUT = 5
+BRIDGE_CONNECT_TIMEOUT = 10
+
+# `ssh -O check` speaks only to a local unix socket, so anything slower than this
+# is a hung socket rather than a slow network.
+CONTROL_CHECK_TIMEOUT = 10.0
+
+# A unix domain socket path cannot exceed 104 bytes on macOS or 108 on Linux, and
+# ssh reports the overflow as a bare "ControlPath too long" from wherever in a
+# ProxyCommand chain it happened -- which is not where anyone looks. `%C` expands
+# to a 40-character hash, so the length is predictable enough to refuse up front.
+CONTROL_PATH_LIMIT = 100
+CONTROL_PATH_HASH_WIDTH = 40
 SUBMIT_COMMAND_TIMEOUT = 120.0
 PASS_COMMAND_TIMEOUT = 120.0
 
@@ -2216,6 +2259,47 @@ def escape_ssh_percent(text: str) -> str:
     return text.replace("%", "%%")
 
 
+def route_connect_timeout(route: str) -> int:
+    """Return how long ROUTE gets to bring up a control master."""
+    if route_bridge(route) is None:
+        return DIRECT_CONNECT_TIMEOUT
+    return BRIDGE_CONNECT_TIMEOUT
+
+
+def route_control_path(control_path: str, route: str) -> str:
+    """Return the control socket that belongs to ROUTE.
+
+    OpenSSH's `%C` hashes the local host, remote host, port and user -- not the
+    ProxyCommand -- so without this suffix both routes to one host share a
+    socket, and a warm direct master goes on serving a `--route via:` command
+    until ControlPersist expires.  The suffix is what makes the route part of a
+    connection's identity, and therefore what lets a fallback mean anything.
+    """
+    bridge = route_bridge(route)
+    token = ROUTE_DIRECT if bridge is None else f"via-{bridge}"
+    path = f"{control_path}-{token}"
+    expanded = len(path) + path.count("%C") * (CONTROL_PATH_HASH_WIDTH - 2)
+    if expanded > CONTROL_PATH_LIMIT:
+        raise FleetError(
+            f"the control socket for route {route!r} would be {expanded} bytes, "
+            f"over the {CONTROL_PATH_LIMIT} a unix socket allows: shorten "
+            '`control_path` under [ssh] in config.toml, e.g. "~/.cache/fleet/m/%C"'
+        )
+    return path
+
+
+def route_runtime(base: dict[str, Any], route: str) -> dict[str, Any]:
+    """Return BASE carrying the control socket that belongs to ROUTE.
+
+    An empty `control_path` turns multiplexing off, and then there is no socket to
+    suffix and no master to establish: the first route becomes the only route.
+    """
+    control_path = base.get("control_path")
+    if not control_path:
+        return dict(base)
+    return {**base, "control_path": route_control_path(str(control_path), route)}
+
+
 def build_proxy_command(
     context: FleetContext,
     route: str,
@@ -2252,6 +2336,9 @@ def build_proxy_command(
             "Give the bridge a key -- it is the host every other host is reached "
             "through."
         )
+    # The bridge is reached over its own first route and gets that route's
+    # socket: a bridge behind a bridge is the same problem one level down.
+    bridge_route = bridge.reach[0] if bridge.reach else ROUTE_DIRECT
     parts = ["ssh", "-W", "%h:%p", "-p", str(secret.port)]
     parts += [
         escape_ssh_percent(part)
@@ -2259,11 +2346,11 @@ def build_proxy_command(
             secret,
             proxy_command=build_proxy_command(
                 context,
-                bridge.reach[0] if bridge.reach else ROUTE_DIRECT,
+                bridge_route,
                 base,
                 chain=(*chain, bridge_name),
             ),
-            **base,
+            **route_runtime(base, bridge_route),
         )
     ]
     parts.append(secret.target)
@@ -2286,7 +2373,10 @@ def ssh_runtime_kwargs(
     if target is None:
         return base
     chosen = route or (target.reach[0] if target.reach else ROUTE_DIRECT)
-    return {**base, "proxy_command": build_proxy_command(context, chosen, base)}
+    return {
+        **route_runtime(base, chosen),
+        "proxy_command": build_proxy_command(context, chosen, base),
+    }
 
 
 def ssh_option_parts(
@@ -2517,6 +2607,197 @@ def run_ssh_command(
         env=ssh_env(secret),
         capture_output=capture_output,
         timeout=timeout,
+    )
+
+
+def build_control_request(
+    secret: FleetSecret, control_path: str, request: str
+) -> list[str]:
+    """Build `ssh -O REQUEST` against CONTROL_PATH.
+
+    No transport prefix and no ProxyCommand: `-O` speaks to the local socket only,
+    so a password helper would have nothing to answer and the bridge has no part
+    in the question of whether the master is up.  The port and `user@host` are
+    still passed, because `%C` hashes them.
+    """
+    return [
+        "ssh",
+        "-O",
+        request,
+        "-p",
+        str(secret.port),
+        "-o",
+        f"ControlPath={control_path}",
+        secret.target,
+    ]
+
+
+def control_master_alive(secret: FleetSecret, runtime: dict[str, Any]) -> bool:
+    """Report whether RUNTIME's control socket has a live master behind it.
+
+    A socket file left behind by a killed master answers this honestly: `-O
+    check` connects to the socket instead of trusting that it exists.
+    """
+    control_path = runtime.get("control_path")
+    if not control_path:
+        return False
+    completed = run_command(
+        build_control_request(secret, str(control_path), "check"),
+        env=ssh_env(secret),
+        capture_output=True,
+        timeout=CONTROL_CHECK_TIMEOUT,
+    )
+    return completed.returncode == 0
+
+
+def open_control_master(
+    secret: FleetSecret, runtime: dict[str, Any], route: str
+) -> str | None:
+    """Bring up a background control master over ROUTE; return None on success.
+
+    `-N -f` backgrounds after authentication rather than before, so a key
+    passphrase or a 2FA prompt is still answerable -- BatchMode stays unset here
+    for the same reason it is unset everywhere else in this file, which is why
+    the subprocess deadline is generous while ConnectTimeout is not.
+    ControlMaster is left at `auto` rather than forced to `yes`, so two fleetctl
+    processes racing for one socket share the winner instead of the loser failing
+    with "ControlSocket already exists".
+    """
+    command = build_ssh_command(
+        secret,
+        allocate_tty=False,
+        remote_command=None,
+        **runtime,
+    )
+    # Inserted ahead of the secret's own ConnectTimeout, because OpenSSH keeps the
+    # first value it is given for an option.
+    insert_at = len(ssh_transport_prefix(secret)) + 1
+    command[insert_at:insert_at] = [
+        "-N",
+        "-f",
+        "-o",
+        f"ConnectTimeout={route_connect_timeout(route)}",
+    ]
+    completed = run_command(
+        command,
+        env=ssh_env(secret),
+        capture_output=True,
+        timeout=route_connect_timeout(route) + CONTROL_COMMAND_TIMEOUT,
+    )
+    if completed.returncode == 0:
+        return None
+    detail = (completed.stderr or "").strip().splitlines()
+    return detail[-1] if detail else f"ssh exited {completed.returncode}"
+
+
+def utc_timestamp() -> str:
+    """Return the current time as ISO-8601 UTC.
+
+    One spelling for every timestamp fleetctl records, so a state file written on
+    a laptop in one timezone still sorts against one written on a login node in
+    another.
+    """
+    return (
+        datetime.datetime.now(datetime.timezone.utc)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def route_state_file(paths: FleetPaths) -> Path:
+    """Where the route each target was last reached over is recorded."""
+    return paths.state_home / "routes.json"
+
+
+def read_route_state(paths: FleetPaths) -> dict[str, Any]:
+    """Read the route each target was last reached over, for reporting only.
+
+    Never consulted when choosing a route.  A cache that remembered the bridge
+    had worked would quietly pin every later command to it, which is the exact
+    opposite of preferring the direct path.
+    """
+    try:
+        loaded = json.loads(route_state_file(paths).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def record_route_state(
+    paths: FleetPaths, target: str, route: str, control_path: str
+) -> None:
+    """Record the route TARGET was just reached over.
+
+    Bookkeeping never breaks a connection: a state directory that cannot be
+    written costs a line of reporting, not the command that was about to run.
+    """
+    state = read_route_state(paths)
+    state[target] = {
+        "route": route,
+        "socket": control_path,
+        "at": utc_timestamp(),
+    }
+    try:
+        ensure_private_dir(paths.state_home, mode=STATE_DIR_MODE)
+        write_text_file(
+            route_state_file(paths),
+            json.dumps(state, indent=2, sort_keys=True) + "\n",
+            mode=PRIVATE_FILE_MODE,
+        )
+    except OSError:
+        pass
+
+
+def ensure_route(plan: Plan) -> str:
+    """Bring up a control master for the first of PLAN's routes that works.
+
+    Selection happens once per socket, not once per command.  A warm master means
+    the route was chosen already and is still carrying traffic, so nothing is
+    re-probed and preferring the direct path costs nothing; when the socket is
+    cold each declared route is tried in order and the first master to come up
+    wins, which is what makes `reach` a fallback list rather than a wish.
+
+    Fallback lives here and nowhere else, deliberately.  Once a master exists a
+    failing command is a failing command -- never retried, never re-routed --
+    because `exec` and `submit` are at-most-once and a re-routed `sbatch` queues
+    the job twice.  A retry added anywhere outside this function takes that
+    guarantee away.
+    """
+    if plan._route is not None:
+        return plan._route
+    if not base_ssh_runtime_kwargs(plan.context)["control_path"]:
+        # Multiplexing is off, so there is no master to establish and no socket to
+        # check.  Fallback is a property of the master, not of the command.
+        return plan.route
+    secret = plan.secret
+    failures: list[str] = []
+    for route in plan.routes or DEFAULT_REACH:
+        runtime = ssh_runtime_kwargs(plan.context, target=plan.target, route=route)
+        failure = (
+            None
+            if control_master_alive(secret, runtime)
+            else open_control_master(secret, runtime, route)
+        )
+        if failure is None:
+            object.__setattr__(plan, "_route", route)
+            record_route_state(
+                plan.context.paths,
+                plan.target.name,
+                route,
+                str(runtime["control_path"]),
+            )
+            return route
+        failures.append(f"{route} ({failure})")
+    raise FleetError(
+        f"no route to {plan.target.name!r} came up; tried "
+        + ", ".join(failures)
+        + "."
+        + (
+            " Declare a `via:<bridge>` fallback in that target's `reach` if a "
+            "bridge can carry it."
+            if len(plan.target.reach) < 2
+            else ""
+        )
     )
 
 
@@ -4675,7 +4956,7 @@ def command_ssh(args: argparse.Namespace, context: FleetContext) -> int:
         plan.secret,
         allocate_tty=True,
         remote_command=None,
-        **plan.ssh_runtime(),
+        **plan.connect(),
     )
     return completed.returncode
 
@@ -4762,7 +5043,7 @@ def command_smoke(args: argparse.Namespace, context: FleetContext) -> int:
         remote_command=remote_shell_command(smoke_argv),
         capture_output=True,
         timeout=CONTROL_COMMAND_TIMEOUT,
-        **plan.ssh_runtime(),
+        **plan.connect(),
     )
     if completed.stdout:
         print(completed.stdout, end="")
@@ -4818,7 +5099,7 @@ def command_exec(args: argparse.Namespace, context: FleetContext) -> int:
         plan.secret,
         allocate_tty=bool(args.tty),
         remote_command=remote,
-        **plan.ssh_runtime(),
+        **plan.connect(),
     )
     return completed.returncode
 
@@ -4833,7 +5114,7 @@ def run_script_plan(
 ) -> int:
     """Stage LOCAL_SCRIPT on PLAN's target and run it there."""
     secret = plan.secret
-    ssh_runtime = plan.ssh_runtime()
+    ssh_runtime = plan.connect()
     remote_script = stage_remote_script(
         secret,
         plan.profile,
@@ -4884,7 +5165,7 @@ def command_sync(args: argparse.Namespace, context: FleetContext) -> int:
     plan = build_plan(context, args, "sync")
     target = plan.target
     secret = plan.secret
-    ssh_runtime = plan.ssh_runtime()
+    ssh_runtime = plan.connect()
     default_remote = (
         resolve_remote_path(args.remote_path, base=plan.cwd)
         if args.remote_path
@@ -4978,7 +5259,9 @@ def command_submit(args: argparse.Namespace, context: FleetContext) -> int:
     protocol = plan.protocol
     profile = plan.profile
     secret = plan.secret
-    ssh_runtime = plan.ssh_runtime()
+    # A dry run must not open a connection, so it describes the first route
+    # instead of establishing one; a real submit takes the route that comes up.
+    ssh_runtime = plan.ssh_runtime() if args.dry_run else plan.connect()
     cwd = plan.cwd
 
     # Two paths, and the profile itself says which: a profile submits if and only
@@ -5153,7 +5436,7 @@ def run_job_command(
         remote_command=remote_shell_command(argv, cwd=plan.cwd),
         capture_output=True,
         timeout=CONTROL_COMMAND_TIMEOUT,
-        **plan.ssh_runtime(),
+        **plan.connect(),
     )
     if completed.stdout:
         print(completed.stdout, end="")
@@ -5276,6 +5559,50 @@ def probe_remote_prerequisites(context: FleetContext) -> list[str]:
     return problems
 
 
+def probe_route_matrix(
+    context: FleetContext,
+) -> tuple[dict[str, dict[str, str]], list[str]]:
+    """Try every declared route of every target and report which ones carry.
+
+    "Direct is down, so you are on the bridge" should be something you are told
+    rather than a slowdown you eventually notice -- and a fallback that has
+    quietly become the only path is worth knowing before the bridge reboots.
+    Sockets this opens are left warm, which is most of the point of opening them.
+    """
+    matrix: dict[str, dict[str, str]] = {}
+    warnings: list[str] = []
+    for target in sorted(context.targets.values(), key=lambda item: item.name):
+        if not target.enabled:
+            continue
+        try:
+            secret = context.resolve_secret(target)
+        except FleetError:
+            continue  # already reported by the offline pass
+        results: dict[str, str] = {}
+        for route in target.reach or DEFAULT_REACH:
+            try:
+                runtime = ssh_runtime_kwargs(context, target=target, route=route)
+            except FleetError as exc:
+                results[route] = f"unusable: {exc}"
+                continue
+            if control_master_alive(secret, runtime):
+                results[route] = "live"
+                continue
+            failure = open_control_master(secret, runtime, route)
+            results[route] = "up" if failure is None else f"down: {failure}"
+        matrix[target.name] = results
+        working = [route for route, state in results.items() if state in ("live", "up")]
+        preferred = next(iter(results), None)
+        if not working:
+            warnings.append(f"no route to {target.name!r} came up")
+        elif preferred is not None and preferred not in working:
+            warnings.append(
+                f"{target.name!r} is reachable only over {working[0]!r}; its "
+                f"preferred route {preferred!r} is down"
+            )
+    return matrix, warnings
+
+
 def command_explain(args: argparse.Namespace, context: FleetContext) -> int:
     """Explain what a selector resolves to, and what each verb may do there.
 
@@ -5298,11 +5625,22 @@ def command_explain(args: argparse.Namespace, context: FleetContext) -> int:
         selector=selector,
         pool=context.pools.get(selector) if selector else None,
         admin=bool(args.admin),
-        routes=resolve_routes(target, getattr(args, "route", None)),
+        routes=resolve_routes(
+            target,
+            getattr(args, "route", None),
+            no_fallback=bool(getattr(args, "no_fallback", False)),
+        ),
     )
     role = resolve_role(target, protocol)
     payload = plan.describe()
     payload["ssh"] = shlex.join(plan.ssh_connect_argv())
+    payload["socket"] = plan.ssh_runtime().get("control_path")
+    # Reported, never consulted: this names the route that last worked, not the
+    # one the next command will take.
+    last_used = read_route_state(context.paths).get(target.name)
+    payload["route_last_used"] = (
+        last_used.get("route") if isinstance(last_used, dict) else None
+    )
     payload["queues"] = [queue.name for queue in protocol.queues]
     payload["admission"] = {
         verb: DECISION_LABELS[ROLE_MATRIX[role][VERBS.index(verb)]]
@@ -5327,6 +5665,7 @@ def command_doctor(args: argparse.Namespace) -> int:
     )
     problems: list[str] = []
     warnings: list[str] = []
+    route_matrix: dict[str, dict[str, str]] = {}
 
     for required_dir in [
         paths.config_home,
@@ -5488,6 +5827,8 @@ def command_doctor(args: argparse.Namespace) -> int:
 
         if getattr(args, "probe", False):
             problems.extend(probe_remote_prerequisites(context))
+            route_matrix, route_warnings = probe_route_matrix(context)
+            warnings.extend(route_warnings)
 
     payload = {
         "config_home": str(paths.config_home),
@@ -5495,6 +5836,7 @@ def command_doctor(args: argparse.Namespace) -> int:
         "pools": sorted(context.pools) if context else [],
         "protocols": sorted(context.protocols) if context else [],
         "profiles": sorted(context.profiles) if context else [],
+        "routes": route_matrix,
         "warnings": warnings,
         "problems": problems,
     }
@@ -5664,7 +6006,7 @@ NAME
 SYNOPSIS
     reach = ["direct"]
     reach = ["direct", "via:<bridge>"]
-    fleetctl <verb> <target> --route direct|via:<bridge>
+    fleetctl <verb> <target> [--route direct|via:<bridge>] [--no-fallback]
 
 DESCRIPTION
     How a host is reached is inventory, not a credential. `reach` is an
@@ -5673,10 +6015,11 @@ DESCRIPTION
     It defaults to ["direct"]. A repeated route is refused, and so is
     an empty list, which would mean nothing could ever reach the host.
 
-    The order is the point. Direct comes first and is the route taken;
-    a `via:` entry behind it is the declared fallback, because the one
-    machine that multiplexes every clustered connection is the last
-    thing you want in the path when you do not need it. `--route`
+    The order is the point. Direct comes first and is the route tried
+    first; a `via:` entry behind it is the fallback, taken only when
+    direct will not come up, because the one machine that multiplexes
+    every clustered connection is the last thing you want in the path
+    when you do not need it. `--route`
     selects a declared route and never invents one: a route fleetctl
     was never told about is a guess about someone else's network, and
     the failure it produces is a timeout rather than an error.
@@ -5695,15 +6038,32 @@ DESCRIPTION
     is still refused. A password-authenticated bridge is refused as a
     hop, because sshpass hands one password to the whole process tree.
 
-LIMITS
-    Nothing falls back on its own yet: the first declared route is the
-    one used, and a `via:` entry is a fallback you select. Both routes
-    to one host also share a control socket, because OpenSSH's %C hash
-    does not cover the ProxyCommand -- so a warm direct connection goes
-    on serving a `--route via:` command until it expires.
+FALLBACK
+    Selection happens once per control socket, not once per command. A
+    warm master means the route was chosen already and still carries
+    traffic, so nothing is re-probed; when the socket is cold each
+    route is tried in declared order and the first master to come up
+    wins. Direct gets a 5 second deadline and a bridge 10, so the whole
+    cost of preferring direct is one timeout per ControlPersist window,
+    paid only when direct is really down. `--no-fallback` refuses to
+    degrade.
 
-    `list --format topology` prints the graph: each target's routes,
-    and what each bridge carries.
+    Every route gets its own socket. OpenSSH's %C hash covers the host,
+    port and user but not the ProxyCommand, so without a suffix a warm
+    direct master would go on serving a `--route via:` command until it
+    expired. Setting an empty `control_path` turns multiplexing off,
+    and then there is no master to establish and the first route is the
+    only one.
+
+    Fallback lives in that one step and nowhere else. Once a master
+    exists a failing command is a failing command -- never retried,
+    never re-routed -- because `exec` and `submit` are at-most-once and
+    a re-routed `sbatch` would queue the job twice.
+
+    `explain` names the route chain, the socket and the route last
+    used; `doctor --probe` tries every route of every target and prints
+    the matrix. `list --format topology` prints the graph: each
+    target's routes, and what each bridge carries.
 
 DEPRECATED
     The secret key `proxy_jump` is accepted and ignored. Declare
@@ -5974,6 +6334,11 @@ def add_route_flag(parser: argparse.ArgumentParser) -> None:
         "--route",
         metavar="ROUTE",
         help='Use one declared route: "direct" or "via:<bridge>"',
+    )
+    parser.add_argument(
+        "--no-fallback",
+        action="store_true",
+        help="Refuse to degrade to a later route when the first one is down",
     )
 
 

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -2627,6 +2627,28 @@ def emit(payload: dict[str, Any], *, as_json: bool) -> None:
     print(render_text_payload(payload))
 
 
+def emit_rows(
+    rows: list[dict[str, Any]],
+    columns: list[str],
+    *,
+    as_json: bool,
+    when_empty: str | None = None,
+) -> None:
+    """Print a list of records: JSON when asked, one fixed-width table otherwise.
+
+    `when_empty` names the case where having nothing to show is itself the
+    problem.  It applies to the table only -- an empty JSON list is a complete
+    and correct answer, and a caller piping `--json` into another program should
+    not have to catch an error to learn that a protocol has no queues.
+    """
+    if as_json:
+        print(json.dumps(rows, indent=2, sort_keys=True))
+        return
+    if not rows and when_empty is not None:
+        raise FleetError(when_empty)
+    print(format_table(rows, columns))
+
+
 def render_text_payload(value: Any, *, indent: int = 0) -> str:
     """Render nested plain data as readable indented lines."""
     pad = "  " * indent
@@ -2646,12 +2668,14 @@ def render_text_payload(value: Any, *, indent: int = 0) -> str:
     if isinstance(value, (list, tuple)):
         if not value:
             return f"{pad}(none)"
-        return "\n".join(
+        parts = [
             render_text_payload(item, indent=indent)
             if isinstance(item, (dict, list, tuple))
             else f"{pad}- {render_scalar(item)}"
             for item in value
-        )
+        ]
+        separator = "\n\n" if any(isinstance(item, dict) for item in value) else "\n"
+        return separator.join(parts)
     return f"{pad}{render_scalar(value)}"
 
 
@@ -2661,6 +2685,8 @@ def render_scalar(value: Any) -> str:
         return "-"
     if isinstance(value, (dict, list, tuple)) and not value:
         return "(none)"
+    if value == "":
+        return "-"
     if value is True:
         return "yes"
     if value is False:
@@ -3226,7 +3252,7 @@ def command_project_show(args: argparse.Namespace, context: FleetContext) -> int
         "remote_roots_by_target": dict(sorted(binding.remote_roots_by_target.items())),
         "sync_excludes": list(binding.sync_excludes),
     }
-    print(json.dumps(payload, indent=2, sort_keys=True))
+    emit(payload, as_json=bool(args.json))
     return 0
 
 
@@ -3243,22 +3269,18 @@ def command_project_list(args: argparse.Namespace, context: FleetContext) -> int
         }
         for binding in sorted(context.projects, key=lambda item: str(item.path))
     ]
-    if args.json:
-        print(json.dumps(rows, indent=2, sort_keys=True))
-    else:
-        print(
-            format_table(
-                rows,
-                [
-                    "path",
-                    "default_target",
-                    "default_pool",
-                    "default_profile",
-                    "remote_root",
-                    "target_roots",
-                ],
-            )
-        )
+    emit_rows(
+        rows,
+        [
+            "path",
+            "default_target",
+            "default_pool",
+            "default_profile",
+            "remote_root",
+            "target_roots",
+        ],
+        as_json=bool(args.json),
+    )
     return 0
 
 
@@ -3342,24 +3364,20 @@ def command_list(args: argparse.Namespace, context: FleetContext) -> int:
                 pool_names=pool_index.get(target.name, []),
             )
         )
-    if args.json:
-        print(json.dumps(rows, indent=2, sort_keys=True))
-    else:
-        print(
-            format_table(
-                rows,
-                [
-                    "name",
-                    "enabled",
-                    "transport",
-                    "role",
-                    "protocol",
-                    "default_profile",
-                    "tags",
-                    "pools",
-                ],
-            )
-        )
+    emit_rows(
+        rows,
+        [
+            "name",
+            "enabled",
+            "transport",
+            "role",
+            "protocol",
+            "default_profile",
+            "tags",
+            "pools",
+        ],
+        as_json=bool(args.json),
+    )
     return 0
 
 
@@ -3408,7 +3426,7 @@ def command_show(args: argparse.Namespace, context: FleetContext) -> int:
     else:
         raise FleetError(f"unknown target or pool {args.selector!r}")
 
-    print(json.dumps(payload, indent=2, sort_keys=True))
+    emit(payload, as_json=bool(args.json))
     return 0
 
 
@@ -3426,7 +3444,7 @@ def command_protocol_show(args: argparse.Namespace, context: FleetContext) -> in
         payload = protocol_display(protocol)
         payload["selector_kind"] = "target"
         payload["target"] = target.name
-    print(json.dumps(payload, indent=2, sort_keys=True))
+    emit(payload, as_json=bool(args.json))
     return 0
 
 
@@ -3439,25 +3457,20 @@ def command_queue_list(args: argparse.Namespace, context: FleetContext) -> int:
         target, _binding = context.resolve_target(selector, cwd=Path.cwd())
         protocol = context.resolve_protocol(target)
     rows = [queue_display(queue) for queue in protocol.queues]
-    if args.json:
-        print(json.dumps(rows, indent=2, sort_keys=True))
-    else:
-        if not rows:
-            raise FleetError(f"protocol {protocol.name!r} does not define any queues")
-        print(
-            format_table(
-                rows,
-                [
-                    "name",
-                    "partition",
-                    "default",
-                    "gpus",
-                    "cpus_per_task",
-                    "mem",
-                    "time_limit",
-                ],
-            )
-        )
+    emit_rows(
+        rows,
+        [
+            "name",
+            "partition",
+            "default",
+            "gpus",
+            "cpus_per_task",
+            "mem",
+            "time_limit",
+        ],
+        as_json=bool(args.json),
+        when_empty=f"protocol {protocol.name!r} does not define any queues",
+    )
     return 0
 
 
@@ -3465,8 +3478,10 @@ def command_resolve(args: argparse.Namespace, context: FleetContext) -> int:
     """Resolve one pool or project binding to a concrete target name."""
     target, _binding = context.resolve_target(args.selector, cwd=Path.cwd())
     if args.json:
-        print(json.dumps({"target": target.name}, indent=2))
+        emit({"target": target.name}, as_json=True)
     else:
+        # The one command whose plain output is a value rather than a report:
+        # `resolve` exists to be substituted into another command line.
         print(target.name)
     return 0
 
@@ -4181,7 +4196,7 @@ def command_deploy_config(args: argparse.Namespace) -> int:
             "protocols": sorted(deployed.protocols),
             "profiles": sorted(deployed.profiles),
         }
-        print(json.dumps(payload, indent=2, sort_keys=True))
+        emit(payload, as_json=bool(args.json))
     else:
         print(live.config_home)
     return 0
@@ -5008,7 +5023,7 @@ def command_doctor(args: argparse.Namespace) -> int:
         "warnings": warnings,
         "problems": problems,
     }
-    print(json.dumps(payload, indent=2, sort_keys=True))
+    emit(payload, as_json=bool(args.json))
     if problems:
         return 1
     return 0
@@ -5140,6 +5155,7 @@ def build_parser() -> argparse.ArgumentParser:
         nargs="?",
         help="Project path to inspect (defaults to current directory)",
     )
+    project_show_parser.add_argument("--json", action="store_true", help="Emit JSON")
     project_show_parser.set_defaults(handler=command_project_show)
 
     project_list_parser = project_subparsers.add_parser(
@@ -5184,6 +5200,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print a short post-deploy summary after validation",
     )
+    deploy_config_parser.add_argument("--json", action="store_true", help="Emit JSON")
     deploy_config_parser.set_defaults(handler=command_deploy_config, loads_own_config=True)
 
     migrate_config_parser = subparsers.add_parser(

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -317,7 +317,7 @@ class FleetContext:
         normalized = self.normalize_selector(selector)
         if normalized:
             if normalized in self.targets:
-                return self.targets[normalized], binding
+                return ensure_target_enabled(self.targets[normalized]), binding
             if normalized in self.pools:
                 return self.select_pool(self.pools[normalized]), binding
             raise FleetError(
@@ -330,7 +330,7 @@ class FleetContext:
                     f"project binding for {binding.path} refers to missing target "
                     f"{binding.default_target!r}"
                 )
-            return self.targets[binding.default_target], binding
+            return ensure_target_enabled(self.targets[binding.default_target]), binding
         if binding and binding.default_pool:
             if binding.default_pool not in self.pools:
                 raise FleetError(
@@ -851,6 +851,128 @@ def resolve_remote_root(
     return target.workdir
 
 
+CONTROL_COMMAND_TIMEOUT = 60.0
+SUBMIT_COMMAND_TIMEOUT = 120.0
+
+SUBMIT_RESOURCE_FLAGS = (
+    ("queue", "--queue"),
+    ("gpus", "--gpus"),
+    ("time", "--time"),
+    ("mem", "--mem"),
+    ("cpus_per_task", "--cpus-per-task"),
+)
+
+
+def ensure_no_resource_flags(args: argparse.Namespace, *, because: str) -> None:
+    """Refuse resource flags on a submit path that cannot honour them."""
+    supplied = [
+        flag
+        for attr, flag in SUBMIT_RESOURCE_FLAGS
+        if getattr(args, attr, None) not in (None, "")
+    ]
+    if supplied:
+        raise FleetError(
+            f"{', '.join(supplied)} cannot be applied here: {because}"
+        )
+
+
+def ensure_job_id_pattern(profile: ProfileRecord) -> None:
+    """Catch a profile that could never report a job id, before anything is submitted."""
+    if not profile.job_id_pattern:
+        raise FleetError(
+            f"profile {profile.name!r} defines `submit_command` but no "
+            "`job_id_pattern`, so a submitted job's id could never be reported back. "
+            f"Add `job_id_pattern` to profiles.d/{profile.name}.toml"
+        )
+
+
+def report_submitted_job(
+    completed: subprocess.CompletedProcess[str],
+    profile: ProfileRecord,
+    *,
+    output_path: str | None = None,
+    error_path: str | None = None,
+) -> int:
+    """Echo scheduler output and report the job id without ever losing a queued job.
+
+    Once the scheduler accepts the script the job exists, so nothing here may raise:
+    a traceback at this point would orphan a real allocation whose only identifier
+    was in output we had not printed yet.
+    """
+    if completed.stdout:
+        print(completed.stdout, end="")
+    if completed.stderr:
+        print(completed.stderr, end="", file=sys.stderr)
+    if completed.returncode != 0:
+        return completed.returncode
+
+    match = (
+        re.search(profile.job_id_pattern, completed.stdout)
+        if profile.job_id_pattern
+        else None
+    )
+    if match is None:
+        print(
+            "warning: the scheduler accepted the script but its job id could not be "
+            f"parsed (job_id_pattern={profile.job_id_pattern!r}). The job IS most "
+            "likely queued: read the scheduler output above and confirm with "
+            "`squeue --me` before submitting again.",
+            file=sys.stderr,
+        )
+        return completed.returncode
+
+    job_id = match.groupdict().get("job_id")
+    if not job_id:
+        job_id = match.group(1) if match.groups() else match.group(0)
+    print(f"job_id={job_id}")
+    if output_path:
+        print(f"log_out={output_path.replace('%j', job_id)}")
+    if error_path:
+        print(f"log_err={error_path.replace('%j', job_id)}")
+    return completed.returncode
+
+
+def ensure_target_enabled(target: TargetRecord) -> TargetRecord:
+    """Refuse to act on a target the operator has explicitly disabled."""
+    if not target.enabled:
+        raise FleetError(
+            f"target {target.name!r} is disabled (`enabled = false`); re-enable it in "
+            f"~/.config/fleet/targets.d/{target.name}.toml if it is back in service"
+        )
+    return target
+
+
+UNSAFE_SYNC_DELETE_ROOTS = frozenset({"", ".", "..", "~", "/", "*", "$HOME"})
+
+
+def ensure_sync_delete_allowed(
+    remote_path: str,
+    target: TargetRecord,
+    *,
+    direction: str,
+    force: bool,
+) -> None:
+    """Refuse `--delete` where a mistake would erase a whole home directory."""
+    normalized = remote_path.rstrip("/")
+    if normalized in UNSAFE_SYNC_DELETE_ROOTS:
+        raise FleetError(
+            f"refusing `--delete` against remote path {remote_path!r} on "
+            f"{target.name!r}: that is a home directory, not a project directory"
+        )
+    if target.workdir and normalized == target.workdir.rstrip("/") and not force:
+        raise FleetError(
+            f"refusing `--delete` against the host-level workdir {target.workdir!r} "
+            f"on {target.name!r}; sync a project path instead, or pass --force if you "
+            "really mean the entire workdir"
+        )
+    if direction == "pull" and not force:
+        raise FleetError(
+            "`sync pull --delete` removes local files that are missing on the remote, "
+            "including everything `sync push` refused to upload (.git/, .venv/, .env, "
+            "artifacts/); re-run with --force if that is what you want"
+        )
+
+
 def ensure_private_dir(path: Path, *, mode: int) -> None:
     """Create PATH and enforce private directory permissions."""
     path.mkdir(parents=True, exist_ok=True)
@@ -1137,8 +1259,9 @@ def run_command(
     *,
     env: dict[str, str] | None = None,
     capture_output: bool = False,
+    timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
-    """Run one local command with optional capture."""
+    """Run one local command with optional capture and an optional deadline."""
     try:
         return subprocess.run(
             command,
@@ -1146,9 +1269,15 @@ def run_command(
             env=env,
             capture_output=capture_output,
             text=True,
+            timeout=timeout,
         )
     except FileNotFoundError as exc:
         raise FleetError(f"missing required command: {command[0]}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise FleetError(
+            f"{command[0]} timed out after {timeout:g}s; the remote host may be "
+            "unreachable or hung"
+        ) from exc
 
 
 def run_ssh_command(
@@ -1161,6 +1290,7 @@ def run_ssh_command(
     control_path: str | None = None,
     strict_host_key_checking: str | None = None,
     update_host_keys: bool = True,
+    timeout: float | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run one ssh command with fleet defaults."""
     command = build_ssh_command(
@@ -1172,7 +1302,12 @@ def run_ssh_command(
         strict_host_key_checking=strict_host_key_checking,
         update_host_keys=update_host_keys,
     )
-    return run_command(command, env=ssh_env(secret), capture_output=capture_output)
+    return run_command(
+        command,
+        env=ssh_env(secret),
+        capture_output=capture_output,
+        timeout=timeout,
+    )
 
 
 def render_template_values(
@@ -1201,7 +1336,7 @@ def remote_shell_command(command: list[str], *, cwd: str | None = None) -> str:
         quoted_cwd = shlex.quote(cwd)
         inner = (
             f"if [ -d {quoted_cwd} ]; then cd {quoted_cwd};"
-            f" else printf '%s\\n' 'error: remote cwd not found: {cwd}' >&2;"
+            f" else printf 'error: remote cwd not found: %s\\n' {quoted_cwd} >&2;"
             " exit 1; fi;"
             f" {inner}"
         )
@@ -2872,11 +3007,21 @@ def command_sync(args: argparse.Namespace) -> int:
     target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
     secret = context.resolve_secret(target)
     ssh_runtime = ssh_runtime_kwargs(context)
-    default_remote = (
-        args.remote_path
-        or resolve_remote_root(target, binding)
-        or "."
-    )
+    default_remote = args.remote_path or resolve_remote_root(target, binding)
+    if not default_remote:
+        raise FleetError(
+            f"no remote path for {target.name!r}: the target defines no `workdir` and "
+            "the current directory has no project binding. Pass an explicit remote "
+            "path, set `workdir` on the target, or run `fleetctl project bind`."
+        )
+    if args.delete:
+        ensure_sync_delete_allowed(
+            default_remote,
+            target,
+            direction=args.direction,
+            force=bool(args.force),
+        )
+
     excludes = list(DEFAULT_SYNC_EXCLUDES)
     if binding is not None:
         excludes.extend(binding.sync_excludes)
@@ -2884,10 +3029,10 @@ def command_sync(args: argparse.Namespace) -> int:
     command = ["rsync", "-az"]
     if args.delete:
         command.append("--delete")
+    for pattern in excludes:
+        command += ["--exclude", pattern]
     if args.direction == "push":
         remote_parent = posixpath.dirname(default_remote.rstrip("/")) or "."
-        for pattern in excludes:
-            command += ["--exclude", pattern]
         mkdir = run_ssh_command(
             secret,
             allocate_tty=False,
@@ -2936,6 +3081,13 @@ def command_submit(args: argparse.Namespace) -> int:
     if profile.kind == "direct":
         if args.native_batch:
             raise FleetError("`--native-batch` only applies to scheduler profiles")
+        ensure_no_resource_flags(
+            args,
+            because=(
+                f"profile {profile.name!r} runs the script directly over SSH on "
+                f"{target.name!r}; there is no scheduler to allocate resources"
+            ),
+        )
         namespace = argparse.Namespace(
             config_home=args.config_home,
             state_home=args.state_home,
@@ -2956,6 +3108,14 @@ def command_submit(args: argparse.Namespace) -> int:
             raise FleetError(
                 "`fleetctl submit --native-batch` does not accept extra script arguments"
             )
+        ensure_no_resource_flags(
+            args,
+            because=(
+                "`--native-batch` submits your script unchanged, so its own #SBATCH "
+                "directives decide resources; edit the script instead"
+            ),
+        )
+        ensure_job_id_pattern(profile)
         remote_script = stage_remote_script(
             secret,
             profile,
@@ -2976,20 +3136,10 @@ def command_submit(args: argparse.Namespace) -> int:
             allocate_tty=False,
             remote_command=remote_shell_command(submit_argv, cwd=cwd),
             capture_output=True,
+            timeout=SUBMIT_COMMAND_TIMEOUT,
             **ssh_runtime,
         )
-        if completed.stdout:
-            print(completed.stdout, end="")
-        if completed.stderr:
-            print(completed.stderr, end="", file=sys.stderr)
-        if completed.returncode != 0:
-            return completed.returncode
-        if profile.job_id_pattern:
-            match = re.search(profile.job_id_pattern, completed.stdout)
-            if match:
-                job_id = match.groupdict().get("job_id") or match.group(1)
-                print(f"job_id={job_id}")
-        return completed.returncode
+        return report_submitted_job(completed, profile)
 
     if protocol.kind == "slurm":
         if protocol.native_batch_required:
@@ -2997,6 +3147,7 @@ def command_submit(args: argparse.Namespace) -> int:
                 f"protocol {protocol.name!r} requires `fleetctl submit --native-batch` "
                 "so the scheduler receives the site-native batch script unchanged"
             )
+        ensure_job_id_pattern(profile)
         queue = resolve_queue(protocol, args.queue)
         remote_script = stage_remote_script(
             secret,
@@ -3056,25 +3207,25 @@ def command_submit(args: argparse.Namespace) -> int:
             allocate_tty=False,
             remote_command=remote_shell_command(submit_argv, cwd=cwd),
             capture_output=True,
+            timeout=SUBMIT_COMMAND_TIMEOUT,
             **ssh_runtime,
         )
-        if completed.stdout:
-            print(completed.stdout, end="")
-        if completed.stderr:
-            print(completed.stderr, end="", file=sys.stderr)
-        if completed.returncode != 0:
-            return completed.returncode
-        if profile.job_id_pattern:
-            match = re.search(profile.job_id_pattern, completed.stdout)
-            if match:
-                job_id = match.groupdict().get("job_id") or match.group(1)
-                print(f"job_id={job_id}")
-                if output_path:
-                    print(f"log_out={output_path.replace('%j', job_id)}")
-                if error_path:
-                    print(f"log_err={error_path.replace('%j', job_id)}")
-        return completed.returncode
+        return report_submitted_job(
+            completed,
+            profile,
+            output_path=output_path,
+            error_path=error_path,
+        )
 
+    ensure_no_resource_flags(
+        args,
+        because=(
+            f"protocol {protocol.name!r} has kind={protocol.kind!r}, for which fleetctl "
+            f"renders no batch wrapper; profile {profile.name!r} submits your script "
+            "unchanged, so put the scheduler directives in the script itself"
+        ),
+    )
+    ensure_job_id_pattern(profile)
     remote_script = stage_remote_script(
         secret,
         profile,
@@ -3095,20 +3246,10 @@ def command_submit(args: argparse.Namespace) -> int:
         allocate_tty=False,
         remote_command=remote_shell_command(submit_argv, cwd=cwd),
         capture_output=True,
+        timeout=SUBMIT_COMMAND_TIMEOUT,
         **ssh_runtime,
     )
-    if completed.stdout:
-        print(completed.stdout, end="")
-    if completed.stderr:
-        print(completed.stderr, end="", file=sys.stderr)
-    if completed.returncode != 0:
-        return completed.returncode
-    if profile.job_id_pattern:
-        match = re.search(profile.job_id_pattern, completed.stdout)
-        if match:
-            job_id = match.groupdict().get("job_id") or match.group(1)
-            print(job_id)
-    return completed.returncode
+    return report_submitted_job(completed, profile)
 
 
 def run_job_command(
@@ -3609,7 +3750,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="Remote source or destination path (defaults to target/project root)",
     )
     sync_parser.add_argument("--target", dest="selector", help="Target or pool name")
-    sync_parser.add_argument("--delete", action="store_true", help="Pass --delete")
+    sync_parser.add_argument(
+        "--delete",
+        action="store_true",
+        help="Pass --delete to rsync (destructive; guarded)",
+    )
+    sync_parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Override a --delete safety refusal",
+    )
     sync_parser.set_defaults(handler=command_sync)
 
     submit_parser = subparsers.add_parser(

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -53,6 +53,90 @@ DEFAULT_SYNC_EXCLUDES = [
     "*.pyc",
 ]
 
+# ---- SECTION: admission policy ---------------------------------------------
+#
+# What may be done to a machine is decided by its `role`, and by nothing else.
+# The whole policy is the table below, so it can be read in one screen.
+#
+# A role is a taint, in the Kubernetes sense: it *repels* work rather than
+# attracting it, and `--admin` is a toleration -- permission, never a
+# recommendation.  There is deliberately no role meaning "scheduler node where
+# direct execution is fine", so the state this tool exists to prevent cannot be
+# spelled in the config at all.
+#
+#   bridge       an SSH waypoint.  Its job is to be jumped through.
+#   login        a scheduler submission surface.  Compute goes through `submit`.
+#   compute      a node you hold directly and may run work on.
+#   workstation  a machine you own outright.  No scheduler.
+#   storage      a data mover.  Not a place to run anything.
+
+ALLOW = "allow"
+ADMIN = "admin"
+DENY = "deny"
+
+ROLES = ("bridge", "login", "compute", "workstation", "storage")
+VERBS = ("ssh", "exec", "script", "sync", "submit", "job")
+
+ROLE_MATRIX: dict[str, tuple[str, ...]] = {
+    #               ssh    exec   script sync   submit job
+    "bridge":      (ALLOW, ADMIN, DENY,  ADMIN, DENY,  DENY),
+    "login":       (ALLOW, ADMIN, ADMIN, ALLOW, ALLOW, ALLOW),
+    "compute":     (ALLOW, ALLOW, ALLOW, ALLOW, ALLOW, ALLOW),
+    "workstation": (ALLOW, ALLOW, ALLOW, ALLOW, ALLOW, DENY),
+    "storage":     (ALLOW, ADMIN, DENY,  ALLOW, DENY,  DENY),
+}
+
+# Why a verb is refused outright, so the error names the alternative instead of
+# just restating the rule.
+DENY_REASON = {
+    "exec": "run compute through `fleetctl submit`",
+    "script": "run compute through `fleetctl submit`",
+    "sync": "this role does not host project trees",
+    "submit": "this role is not a compute surface",
+    "job": "there is no scheduler here",
+}
+
+
+def resolve_role(target: "TargetRecord", protocol: "ProtocolRecord") -> str:
+    """Return TARGET's role, inferring one only while configs are unmigrated.
+
+    An explicit `role` always wins.  Without one, infer the safety level the
+    protocol already implied -- so an unmigrated fleet is never *less* guarded
+    than it was before roles existed -- and let `doctor` ask for a migration.
+    """
+    if target.role:
+        return target.role
+    return "login" if protocol.kind != "direct" else "workstation"
+
+
+def authorize(
+    verb: str,
+    target: "TargetRecord",
+    protocol: "ProtocolRecord",
+    *,
+    admin: bool = False,
+) -> str:
+    """Single admission chokepoint.  Every verb calls this before touching a host."""
+    if verb not in VERBS:  # pragma: no cover - guards against a typo in a caller
+        raise FleetError(f"internal error: {verb!r} is not an admission verb")
+    role = resolve_role(target, protocol)
+    decision = ROLE_MATRIX[role][VERBS.index(verb)]
+    if decision == ALLOW:
+        return role
+    if decision == ADMIN:
+        if admin:
+            return role
+        raise FleetError(
+            f"`fleetctl {verb}` on {target.name!r} reaches the control plane of a "
+            f"{role} node. Re-run with --admin if that is genuinely what you want; "
+            "it is permission, not a recommendation."
+        )
+    raise FleetError(
+        f"`fleetctl {verb}` is refused on {target.name!r}: it is a {role} node -- "
+        f"{DENY_REASON.get(verb, 'this verb does not apply to that role')}."
+    )
+
+
 EXEC_REMOTE_STUB = """\
 import base64
 import json
@@ -118,6 +202,7 @@ class TargetRecord:
     name: str
     enabled: bool = True
     transport: str = "ssh"
+    role: str | None = None
     protocol: str | None = None
     workdir: str | None = None
     tags: tuple[str, ...] = ()
@@ -528,6 +613,7 @@ TARGET_KEYS = frozenset(
         "name",
         "enabled",
         "transport",
+        "role",
         "protocol",
         "workdir",
         "tags",
@@ -815,6 +901,13 @@ def load_targets(path: Path) -> dict[str, TargetRecord]:
                 what=what,
                 key="transport",
                 source=source,
+            ),
+            role=(
+                check_vocabulary(
+                    str(raw["role"]), ROLES, what=what, key="role", source=source
+                )
+                if raw.get("role") is not None
+                else None
             ),
             protocol=optional_str(raw.get("protocol")),
             workdir=optional_str(raw.get("workdir")),
@@ -2042,22 +2135,6 @@ def sanitize_job_name(value: str) -> str:
     return cleaned[:128] or "fleet-job"
 
 
-def ensure_login_exec_allowed(
-    target: TargetRecord,
-    protocol: ProtocolRecord,
-    *,
-    allow_login: bool,
-) -> None:
-    """Require an explicit acknowledgment on scheduler-backed login surfaces."""
-    if protocol.allow_login_exec or allow_login:
-        return
-    raise FleetError(
-        f"target {target.name!r} uses protocol {protocol.name!r}; "
-        "direct login-surface execution requires `--login`, while compute jobs "
-        "should go through `fleetctl submit`"
-    )
-
-
 def resolve_queue(
     protocol: ProtocolRecord,
     requested: str | None,
@@ -2570,6 +2647,8 @@ def target_to_toml(target: TargetRecord) -> str:
         f"enabled = {'true' if target.enabled else 'false'}",
         f"transport = {toml_string(target.transport)}",
     ]
+    if target.role:
+        lines.append(f"role = {toml_string(target.role)}")
     if target.protocol:
         lines.append(f"protocol = {toml_string(target.protocol)}")
     if target.workdir:
@@ -3405,6 +3484,7 @@ def command_ssh(args: argparse.Namespace) -> int:
         cache_home=args.cache_home,
     )
     target, _binding = context.resolve_target(args.selector, cwd=Path.cwd())
+    authorize("ssh", target, context.resolve_protocol(target), admin=bool(args.admin))
     secret = context.resolve_secret(target)
     completed = run_ssh_command(
         secret,
@@ -3423,9 +3503,11 @@ def command_smoke(args: argparse.Namespace) -> int:
         cache_home=args.cache_home,
     )
     target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
+    protocol = context.resolve_protocol(target)
+    # `smoke` only reports on the host, so it rides the same rule as `ssh`.
+    authorize("ssh", target, protocol, admin=bool(args.admin))
     secret = context.resolve_secret(target)
     profile = context.resolve_profile(target, binding, args.profile)
-    protocol = context.resolve_protocol(target)
     workdir = target.workdir
     project_root = resolve_remote_root(target, binding, args.cwd)
     prelude = ""
@@ -3544,7 +3626,7 @@ def command_exec(args: argparse.Namespace) -> int:
         raise FleetError("`fleetctl exec` requires a command after `--`")
     target, binding = context.resolve_target(selector, cwd=Path.cwd())
     protocol = context.resolve_protocol(target)
-    ensure_login_exec_allowed(target, protocol, allow_login=bool(args.login))
+    authorize("exec", target, protocol, admin=bool(args.admin))
     secret = context.resolve_secret(target)
     profile = context.resolve_profile(target, binding, args.profile)
     cwd = resolve_remote_root(target, binding, args.cwd)
@@ -3583,7 +3665,7 @@ def command_script(args: argparse.Namespace) -> int:
     )
     target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
     protocol = context.resolve_protocol(target)
-    ensure_login_exec_allowed(target, protocol, allow_login=bool(args.login))
+    authorize("script", target, protocol, admin=bool(args.admin))
     secret = context.resolve_secret(target)
     profile = context.resolve_profile(target, binding, args.profile)
     ssh_runtime = ssh_runtime_kwargs(context)
@@ -3618,6 +3700,7 @@ def command_sync(args: argparse.Namespace) -> int:
         cache_home=args.cache_home,
     )
     target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
+    authorize("sync", target, context.resolve_protocol(target), admin=bool(args.admin))
     secret = context.resolve_secret(target)
     ssh_runtime = ssh_runtime_kwargs(context)
     default_remote = args.remote_path or resolve_remote_root(target, binding)
@@ -3690,6 +3773,7 @@ def command_submit(args: argparse.Namespace) -> int:
     )
     target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
     protocol = context.resolve_protocol(target)
+    authorize("submit", target, protocol, admin=bool(args.admin))
     secret = context.resolve_secret(target)
     profile = context.resolve_profile(target, binding, args.profile)
     ssh_runtime = ssh_runtime_kwargs(context)
@@ -3715,7 +3799,7 @@ def command_submit(args: argparse.Namespace) -> int:
             local_script=str(local_script),
             interpreter=args.interpreter,
             script_args=args.script_args,
-            login=False,
+            admin=bool(args.admin),
             tty=False,
         )
         return command_script(namespace)
@@ -3880,6 +3964,7 @@ def run_job_command(
         cache_home=args.cache_home,
     )
     target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
+    authorize("job", target, context.resolve_protocol(target), admin=bool(args.admin))
     secret = context.resolve_secret(target)
     profile = context.resolve_profile(target, binding, args.profile)
     cwd = resolve_remote_root(target, binding, args.cwd)
@@ -4472,12 +4557,22 @@ def build_parser() -> argparse.ArgumentParser:
 
     ssh_parser = subparsers.add_parser("ssh", help="Open an interactive SSH session")
     ssh_parser.add_argument("selector", nargs="?", help="Target or pool name")
+    ssh_parser.add_argument(
+        "--admin",
+        action="store_true",
+        help="Acknowledge a control-plane action on a role that repels this verb",
+    )
     ssh_parser.set_defaults(handler=command_ssh)
 
     smoke_parser = subparsers.add_parser("smoke", help="Run a remote smoke check")
     smoke_parser.add_argument("selector", nargs="?", help="Target or pool name")
     smoke_parser.add_argument("--profile", help="Execution profile override")
     smoke_parser.add_argument("--cwd", help="Remote working directory override")
+    smoke_parser.add_argument(
+        "--admin",
+        action="store_true",
+        help="Acknowledge a control-plane action on a role that repels this verb",
+    )
     smoke_parser.set_defaults(handler=command_smoke)
 
     exec_parser = subparsers.add_parser(
@@ -4489,9 +4584,9 @@ def build_parser() -> argparse.ArgumentParser:
     exec_parser.add_argument("--profile", help="Execution profile override")
     exec_parser.add_argument("--cwd", help="Remote working directory override")
     exec_parser.add_argument(
-        "--login",
+        "--admin",
         action="store_true",
-        help="Acknowledge login-surface execution on scheduler-backed targets",
+        help="Acknowledge a control-plane action on a role that repels this verb",
     )
     exec_parser.add_argument("--tty", action="store_true", help="Allocate a TTY")
     exec_parser.add_argument(
@@ -4510,9 +4605,9 @@ def build_parser() -> argparse.ArgumentParser:
     script_parser.add_argument("--profile", help="Execution profile override")
     script_parser.add_argument("--cwd", help="Remote working directory override")
     script_parser.add_argument(
-        "--login",
+        "--admin",
         action="store_true",
-        help="Acknowledge direct script execution on a scheduler login surface",
+        help="Acknowledge a control-plane action on a role that repels this verb",
     )
     script_parser.add_argument("--interpreter", help="Interpreter to prepend")
     script_parser.add_argument("--tty", action="store_true", help="Allocate a TTY")
@@ -4541,6 +4636,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--force",
         action="store_true",
         help="Override a --delete safety refusal",
+    )
+    sync_parser.add_argument(
+        "--admin",
+        action="store_true",
+        help="Acknowledge a control-plane action on a role that repels this verb",
     )
     sync_parser.set_defaults(handler=command_sync)
 
@@ -4585,6 +4685,11 @@ def build_parser() -> argparse.ArgumentParser:
         nargs="*",
         help="Arguments for direct-profile submissions after `--`",
     )
+    submit_parser.add_argument(
+        "--admin",
+        action="store_true",
+        help="Acknowledge a control-plane action on a role that repels this verb",
+    )
     submit_parser.set_defaults(handler=command_submit)
 
     job_parser = subparsers.add_parser("job", help="Inspect or manage remote jobs")
@@ -4595,6 +4700,11 @@ def build_parser() -> argparse.ArgumentParser:
     status_parser.add_argument("--target", dest="selector", help="Target or pool name")
     status_parser.add_argument("--profile", help="Execution profile override")
     status_parser.add_argument("--cwd", help="Remote working directory override")
+    status_parser.add_argument(
+        "--admin",
+        action="store_true",
+        help="Acknowledge a control-plane action on a role that repels this verb",
+    )
     status_parser.set_defaults(handler=command_job_status)
 
     logs_parser = job_subparsers.add_parser("logs", help="Fetch scheduler logs")
@@ -4602,6 +4712,11 @@ def build_parser() -> argparse.ArgumentParser:
     logs_parser.add_argument("--target", dest="selector", help="Target or pool name")
     logs_parser.add_argument("--profile", help="Execution profile override")
     logs_parser.add_argument("--cwd", help="Remote working directory override")
+    logs_parser.add_argument(
+        "--admin",
+        action="store_true",
+        help="Acknowledge a control-plane action on a role that repels this verb",
+    )
     logs_parser.set_defaults(handler=command_job_logs)
 
     cancel_parser = job_subparsers.add_parser("cancel", help="Cancel scheduler jobs")
@@ -4609,6 +4724,11 @@ def build_parser() -> argparse.ArgumentParser:
     cancel_parser.add_argument("--target", dest="selector", help="Target or pool name")
     cancel_parser.add_argument("--profile", help="Execution profile override")
     cancel_parser.add_argument("--cwd", help="Remote working directory override")
+    cancel_parser.add_argument(
+        "--admin",
+        action="store_true",
+        help="Acknowledge a control-plane action on a role that repels this verb",
+    )
     cancel_parser.set_defaults(handler=command_job_cancel)
 
     doctor_parser = subparsers.add_parser("doctor", help="Validate local fleet setup")

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -6501,15 +6501,17 @@ def command_jobs(args: argparse.Namespace, context: FleetContext) -> int:
     records.reverse()
     if not args.all:
         records = records[: max(args.limit, 0)]
-    emit_rows(
-        records,
-        JOB_LIST_COLUMNS,
-        as_json=bool(args.json),
-        when_empty=(
-            f"no submissions recorded in {jobs_ledger_file(context.paths)}; "
+    if not records and not args.json:
+        # Not `when_empty`: that is for emptiness which is itself a fault, and a
+        # fleet that has not submitted anything yet is working correctly. Exiting
+        # non-zero here would also disagree with the `--json` arm, which already
+        # answers `[]` and succeeds.
+        print(
+            f"no submissions recorded yet in {jobs_ledger_file(context.paths)}\n"
             "`fleetctl submit` appends one line per job the scheduler accepted"
-        ),
-    )
+        )
+        return 0
+    emit_rows(records, JOB_LIST_COLUMNS, as_json=bool(args.json))
     return 0
 
 

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -1351,6 +1351,9 @@ def run_ssh_command(
     )
 
 
+TEMPLATE_PLACEHOLDER = re.compile(r"\{(script|job_id|workdir)\}")
+
+
 def render_template_values(
     values: Iterable[str],
     *,
@@ -1358,16 +1361,21 @@ def render_template_values(
     job_id: str | None = None,
     workdir: str | None = None,
 ) -> list[str]:
-    """Render simple `{name}` placeholders in argv templates."""
-    rendered: list[str] = []
+    """Render `{script}`, `{job_id}` and `{workdir}` placeholders in argv templates.
+
+    Deliberately not `str.format`: these templates come from config, and a literal
+    brace -- an awk program, a `${VAR}`, a JSON fragment -- raised at render time,
+    while an unrecognised `{name}` raised KeyError instead of being left alone.
+    """
     substitutions = {
         "script": script_path or "",
         "job_id": job_id or "",
         "workdir": workdir or "",
     }
-    for value in values:
-        rendered.append(value.format(**substitutions))
-    return rendered
+    return [
+        TEMPLATE_PLACEHOLDER.sub(lambda match: substitutions[match.group(1)], value)
+        for value in values
+    ]
 
 
 def quote_remote_path(path: str) -> str:

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -853,6 +853,7 @@ def resolve_remote_root(
 
 CONTROL_COMMAND_TIMEOUT = 60.0
 SUBMIT_COMMAND_TIMEOUT = 120.0
+PASS_COMMAND_TIMEOUT = 120.0
 
 SUBMIT_RESOURCE_FLAGS = (
     ("queue", "--queue"),
@@ -1016,9 +1017,15 @@ def run_pass_show(secret_ref: str) -> str:
             check=False,
             capture_output=True,
             text=True,
+            timeout=PASS_COMMAND_TIMEOUT,
         )
     except FileNotFoundError as exc:
         raise FleetError("`pass` is required for pass-backed secrets") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise FleetError(
+            f"`pass show {secret_ref}` timed out after {PASS_COMMAND_TIMEOUT:g}s; "
+            "gpg-agent is probably waiting on a passphrase or a smartcard"
+        ) from exc
     if completed.returncode != 0:
         message = completed.stderr.strip() or completed.stdout.strip()
         raise FleetError(
@@ -1074,9 +1081,15 @@ def run_pass_insert(secret_ref: str, content: str, *, force: bool) -> None:
             capture_output=True,
             text=True,
             env=env,
+            timeout=PASS_COMMAND_TIMEOUT,
         )
     except FileNotFoundError as exc:
         raise FleetError("`pass` is required for pass-backed fleet config") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise FleetError(
+            f"`pass` timed out after {PASS_COMMAND_TIMEOUT:g}s writing {secret_ref}; "
+            "gpg-agent is probably waiting on a passphrase or a smartcard"
+        ) from exc
     if completed.returncode != 0:
         message = completed.stderr.strip() or completed.stdout.strip()
         raise FleetError(
@@ -1368,6 +1381,7 @@ def resolve_remote_home(
         allocate_tty=False,
         remote_command=shlex.join(["/bin/sh", "-c", 'printf "%s" "$HOME"']),
         capture_output=True,
+        timeout=CONTROL_COMMAND_TIMEOUT,
         **(ssh_runtime or {}),
     )
     home = completed.stdout.strip()
@@ -1401,6 +1415,7 @@ def stage_remote_script(
         secret,
         allocate_tty=False,
         remote_command=remote_shell_command(["mkdir", "-p", remote_dir]),
+        timeout=CONTROL_COMMAND_TIMEOUT,
         **ssh_runtime,
     )
     if mkdir.returncode != 0:
@@ -1417,6 +1432,7 @@ def stage_remote_script(
             **ssh_runtime,
         ),
         env=ssh_env(secret),
+        timeout=CONTROL_COMMAND_TIMEOUT,
     )
     if scp.returncode != 0:
         raise FleetError(
@@ -1427,6 +1443,7 @@ def stage_remote_script(
         secret,
         allocate_tty=False,
         remote_command=remote_shell_command(["chmod", "700", remote_path]),
+        timeout=CONTROL_COMMAND_TIMEOUT,
         **ssh_runtime,
     )
     if chmod.returncode != 0:
@@ -1458,6 +1475,7 @@ def ensure_remote_directory(
         secret,
         allocate_tty=False,
         remote_command=remote_shell_command(["mkdir", "-p", remote_path]),
+        timeout=CONTROL_COMMAND_TIMEOUT,
         **(ssh_runtime or {}),
     )
     if mkdir.returncode != 0:
@@ -1890,7 +1908,11 @@ def int_setting(raw: dict[str, str], key: str, default: int) -> int:
 
 def infer_secret_from_ssh_alias(alias: str) -> FleetSecret:
     """Resolve one existing SSH alias from the local SSH client."""
-    completed = run_command(["ssh", "-G", alias], capture_output=True)
+    completed = run_command(
+        ["ssh", "-G", alias],
+        capture_output=True,
+        timeout=CONTROL_COMMAND_TIMEOUT,
+    )
     if completed.returncode != 0:
         message = completed.stderr.strip() or completed.stdout.strip()
         raise FleetError(
@@ -2889,6 +2911,7 @@ def command_smoke(args: argparse.Namespace) -> int:
         allocate_tty=False,
         remote_command=remote_shell_command(smoke_argv),
         capture_output=True,
+        timeout=CONTROL_COMMAND_TIMEOUT,
         **ssh_runtime_kwargs(context),
     )
     if completed.stdout:
@@ -3037,6 +3060,7 @@ def command_sync(args: argparse.Namespace) -> int:
             secret,
             allocate_tty=False,
             remote_command=remote_shell_command(["mkdir", "-p", remote_parent]),
+            timeout=CONTROL_COMMAND_TIMEOUT,
             **ssh_runtime,
         )
         if mkdir.returncode != 0:
@@ -3276,6 +3300,7 @@ def run_job_command(
         allocate_tty=False,
         remote_command=remote_shell_command(argv, cwd=cwd),
         capture_output=True,
+        timeout=CONTROL_COMMAND_TIMEOUT,
         **ssh_runtime_kwargs(context),
     )
     if completed.stdout:

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -1009,6 +1009,32 @@ def load_protocols(path: Path) -> dict[str, ProtocolRecord]:
     return protocols
 
 
+def validate_job_id_pattern(
+    pattern: str | None,
+    *,
+    what: str,
+    source: Path | None = None,
+) -> str | None:
+    """Compile a profile's job-id regex now rather than after a job is queued.
+
+    The pattern is only applied to scheduler output, which happens *after*
+    `sbatch` has already accepted the job.  An invalid regex there raises
+    `re.error` at the one moment a traceback is unrecoverable: the allocation is
+    running and its ID has just been discarded.  Compiling at load time makes
+    that state unreachable.
+    """
+    if pattern is None:
+        return None
+    try:
+        re.compile(pattern)
+    except re.error as exc:
+        where = f" in {source}" if source is not None else ""
+        raise FleetError(
+            f"invalid `job_id_pattern` for {what}{where}: {exc}"
+        ) from exc
+    return pattern
+
+
 def load_profiles(path: Path) -> dict[str, ProfileRecord]:
     """Load execution profile files."""
     profiles: dict[str, ProfileRecord] = {}
@@ -1055,7 +1081,9 @@ def load_profiles(path: Path) -> dict[str, ProfileRecord]:
             status_command=status,
             cancel_command=cancel,
             logs_command=logs,
-            job_id_pattern=optional_str(raw.get("job_id_pattern")),
+            job_id_pattern=validate_job_id_pattern(
+                optional_str(raw.get("job_id_pattern")), what=what, source=source
+            ),
         )
     if "plain-ssh" not in profiles:
         profiles["plain-ssh"] = ProfileRecord(name="plain-ssh")

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -93,6 +93,17 @@ DECISION_LABELS = {
     DENY: "refused",
 }
 
+# One line per admission verb, keyed on VERBS so `fleetctl help verbs` renders
+# from the vocabulary rather than from a list that can quietly fall behind it.
+VERB_SUMMARY = {
+    "ssh": "open an interactive session",
+    "exec": "run one command, your argv preserved",
+    "script": "stage a local script and run it there",
+    "sync": "push or pull a directory with rsync",
+    "submit": "hand a script to the site's scheduler",
+    "job": "status, logs and cancel for a submitted job",
+}
+
 # Why a verb is refused outright, so the error names the alternative instead of
 # just restating the rule.
 DENY_REASON = {
@@ -5492,6 +5503,471 @@ def command_doctor(args: argparse.Namespace) -> int:
         return 1
     return 0
 
+# ---- SECTION: manual -------------------------------------------------------
+#
+# The manual lives in the file for the same reason the policy does: fleetctl is
+# one file you copy to a new machine, and documentation that ships separately is
+# documentation that will not be there when you need it.  `fleetctl help` is the
+# whole thing; there is no man page to install and nothing to keep in sync.
+#
+# The two tables are rendered from ROLE_MATRIX and VERB_SUMMARY at print time,
+# so the manual cannot disagree with the policy it describes.
+
+MANUAL: dict[str, str] = {
+    "overview": """\
+NAME
+    fleetctl - drive your own machines under one admission policy
+
+SYNOPSIS
+    fleetctl [--config-home <dir>] [--state-home <dir>]
+             [--cache-home <dir>] <subcommand> [options] [-- <payload>]
+    fleetctl help [<topic>]
+
+DESCRIPTION
+    One file of Python 3 and the standard library, driving ssh, scp and
+    rsync against a private TOML inventory. It is a policy layer, not a
+    transport: most of its value is in what it refuses.
+
+    What may be done to a machine is decided by its `role` and by
+    nothing else, through one table read in one place. Nothing touches
+    a host without a resolved plan, and building that plan performs the
+    admission check, so a new verb cannot forget it.
+
+    The config loads once per run. The repair and diagnostic
+    subcommands opt out, because for those a broken config is the input
+    rather than a precondition.
+
+OPTIONS
+    --config-home, --state-home and --cache-home override the three
+    roots; see `fleetctl help config`. There are no short options.
+
+    Everything after the first bare `--` is a verbatim payload, split
+    off before the argument parser sees it, so it can never be read as
+    a fleetctl flag -- or swallow one.
+
+EXIT STATUS
+    0    success
+    1    `doctor` found problems
+    2    any refusal, and any usage error
+    130  interrupted
+
+    Any other status is the remote command's own: ssh, exec, script,
+    sync, submit and job return what ran there.
+
+TOPICS
+    {TOPIC_LIST}
+
+SEE ALSO
+    fleetctl help verbs, fleetctl help roles, fleetctl help reach
+""",
+    "verbs": """\
+NAME
+    fleetctl verbs - what each subcommand does, and what it refuses
+
+SYNOPSIS
+    fleetctl <verb> [<target>|<pool>] [--admin] [--route <route>]
+    fleetctl exec <target> [--tty] [--dry-run] -- <argv>...
+    fleetctl script <file> --target <target> [--interpreter <cmd>]
+    fleetctl sync push|pull <local> [<remote>] [--delete] [--force]
+    fleetctl submit <file> [--queue <preset>] [--native-batch]
+
+ADMISSION VERBS
+    Six subcommands are the columns of the role matrix:
+
+{VERB_TABLE}
+
+    `smoke` is not one of them: it only reports on the host, so it is
+    admitted as `ssh`. Nine subcommands open a connection and so carry
+    --admin and --route together -- ssh, smoke, exec, script, sync,
+    submit, and the three `job` operations. `explain` takes both too,
+    so you can ask what an --admin run or a chosen route would do
+    without doing it.
+
+EVERYTHING ELSE
+    Inventory   list, show, explain, resolve, protocol show,
+                queue list, project bind|show|list
+    Setup       init, import-ssh, migrate-config, migrate-env
+    Secrets     seed-pass, deploy-config
+    Diagnosis   doctor, help
+
+    --json is on the inspection and diagnostic subcommands only. A verb
+    that runs remote work prints what the remote printed.
+
+REFUSALS WORTH KNOWING
+    `exec` takes its command after `--` and nowhere else. Naming a
+    target both positionally and with --target is an error, and an
+    empty payload is an error rather than a login shell.
+
+    `sync --delete` refuses a home or root directory outright, and
+    refuses the target's own workdir, or any pull, without --force.
+
+    `--dry-run` prints the resolved plan and exits 0, claiming nothing
+    about remote state. `sync` is the exception that earns it: it runs
+    `rsync --dry-run --itemize-changes` and returns rsync's own code.
+
+SEE ALSO
+    fleetctl help roles, fleetctl help jobs, fleetctl help examples
+""",
+    "roles": """\
+NAME
+    fleetctl roles - what a machine is, and what that permits
+
+SYNOPSIS
+    role = "bridge"|"login"|"compute"|"workstation"|"storage"
+    fleetctl <verb> <target> [--admin]
+    fleetctl explain <target> [<verb>]
+
+DESCRIPTION
+    A role is a taint in the Kubernetes sense: it repels work rather
+    than attracting it, and --admin is a toleration -- permission,
+    never a recommendation.
+
+    bridge       an SSH waypoint. Its job is to be jumped through.
+    login        a submission surface. Compute goes through `submit`.
+    compute      a node you hold directly and may run work on.
+    workstation  a machine you own outright. No scheduler.
+    storage      a data mover. Not a place to run anything.
+
+    There is deliberately no role meaning "scheduler node where direct
+    execution is fine", so the state this tool exists to prevent cannot
+    be spelled in the config at all.
+
+ADMISSION
+    One table decides, and one function reads it:
+
+{ADMISSION_TABLE}
+
+    A refusal names the alternative rather than restating the rule --
+    "run compute through `fleetctl submit`" -- and no flag lifts it.
+    `fleetctl explain <target>` reports every cell for one host, where
+    a refusal is the answer rather than an error.
+
+INFERENCE
+    A target with no `role` gets the conservative reading of its
+    protocol: "login" when the protocol schedules, "workstation" when
+    it runs work directly. An unmigrated fleet is therefore never less
+    guarded than it was before roles existed, and `doctor` names every
+    target still relying on the guess.
+
+    Role and protocol must agree. `role = "login"` on a protocol that
+    runs work directly is refused at load time, and so is any other
+    role on a scheduler-backed one: either combination is a machine
+    whose safety rules and execution path disagree.
+
+SEE ALSO
+    fleetctl help verbs, fleetctl help reach, fleetctl help config
+""",
+    "reach": """\
+NAME
+    fleetctl reach - how a connection gets to a host
+
+SYNOPSIS
+    reach = ["direct"]
+    reach = ["direct", "via:<bridge>"]
+    fleetctl <verb> <target> --route direct|via:<bridge>
+
+DESCRIPTION
+    How a host is reached is inventory, not a credential. `reach` is an
+    ordered list of routes on the target: "direct" for a host you dial
+    yourself, "via:<target>" for one carried by another fleet target.
+    It defaults to ["direct"]. A repeated route is refused, and so is
+    an empty list, which would mean nothing could ever reach the host.
+
+    The order is the point. Direct comes first and is the route taken;
+    a `via:` entry behind it is the declared fallback, because the one
+    machine that multiplexes every clustered connection is the last
+    thing you want in the path when you do not need it. `--route`
+    selects a declared route and never invents one: a route fleetctl
+    was never told about is a guess about someone else's network, and
+    the failure it produces is a timeout rather than an error.
+
+    Carrying other connections is a declared job. Every `via:` must
+    name a real, enabled target whose role is "bridge"; self-bridges
+    and cycles are refused. The graph is checked once per load, so a
+    missing bridge is one fault rather than one per host behind it.
+
+    A hop is a full fleetctl connection to the bridge -- its own
+    secret, and the same private known_hosts, IdentitiesOnly, timeouts
+    and control socket the destination gets -- rendered as `ssh -W
+    %h:%p` in a ProxyCommand, and it chains. `-W` forwards a stream and
+    runs nothing, which is why using a bridge is transport rather than
+    execution and takes no admission check: `exec` on that same bridge
+    is still refused. A password-authenticated bridge is refused as a
+    hop, because sshpass hands one password to the whole process tree.
+
+LIMITS
+    Nothing falls back on its own yet: the first declared route is the
+    one used, and a `via:` entry is a fallback you select. Both routes
+    to one host also share a control socket, because OpenSSH's %C hash
+    does not cover the ProxyCommand -- so a warm direct connection goes
+    on serving a `--route via:` command until it expires.
+
+    `list --format topology` prints the graph: each target's routes,
+    and what each bridge carries.
+
+DEPRECATED
+    The secret key `proxy_jump` is accepted and ignored. Declare
+    `reach` instead; `migrate-config` lifts an old hop out for you. A
+    waypoint that is not itself a fleet target stays expressible as an
+    `[ssh_option]` ProxyJump entry.
+
+SEE ALSO
+    fleetctl help roles, fleetctl help secrets, fleetctl help config
+""",
+    "config": """\
+NAME
+    fleetctl config - the inventory, and why a typo is fatal
+
+SYNOPSIS
+    $FLEET_CONFIG_HOME  (default ~/.config/fleet)
+        config.toml  projects.toml
+        targets.d/  pools.d/  protocols.d/  profiles.d/  secrets/
+    $FLEET_STATE_HOME   known_hosts
+    $FLEET_CACHE_HOME   mux/  (ssh control sockets)
+
+DESCRIPTION
+    Those three variables, or the defaults above, decide every path;
+    --config-home, --state-home and --cache-home override them for one
+    run.
+
+    A target is a machine: `role`, `protocol`, `reach`, `workdir`,
+    `tags`, and a pointer to its secret. A pool is an ordered set,
+    named either by `targets` or by `match_tags`, and selection takes
+    its first enabled member. A protocol describes a site: whether
+    compute is scheduled there, and the queue presets. A profile
+    describes how work runs: `submit_command`, `status_command`,
+    `cancel_command`, `logs_command`, `job_id_pattern` and `[script]`.
+    A project binding maps a local directory onto a target and a
+    remote root, so a bound directory needs no --target.
+
+    A record's name is its `name` key or the file stem, and two files
+    claiming one name is an error rather than a silent last-one-wins.
+    `protocol` is mandatory: guessing it once turned a scheduler site
+    into a box you could run training on. `direct` and `slurm` are
+    built in, and protocols.d overrides them. For profiles, --profile
+    beats the project binding, which beats the target, which beats the
+    protocol.
+
+VALIDATION
+    An unknown key is fatal, and the error names the file, the key and
+    a likely correction -- because the default that fills in for a
+    misspelling is always the permissive one. A `version` other than 1
+    is refused. Every role, protocol and profile disagreement is
+    reported in one pass rather than one per run.
+
+    `[defaults]` has no valid keys left: `redact_sensitive_output` is
+    accepted and ignored. `fleetctl doctor` names every file still
+    carrying a deprecated key, and never prints its value.
+
+SEE ALSO
+    fleetctl help secrets, fleetctl help reach, fleetctl help verbs
+""",
+    "secrets": """\
+NAME
+    fleetctl secrets - connection material, kept out of the inventory
+
+SYNOPSIS
+    secret_backend = "file" | "pass" | "inline"
+    secret_ref = "<config-home>/secrets/<target>.toml"
+    fleetctl show <target> --secret [--sensitive]
+
+DESCRIPTION
+    A secret record carries only what should stay out of version
+    control: `host`, `user`, `port`, `auth`, `identity_file`,
+    `password`, `identities_only`, `forward_agent`, `compression`,
+    `connect_timeout`, `server_alive_interval`,
+    `server_alive_count_max`, `strict_host_key_checking`, `batch_mode`
+    and an `[ssh_option]` table. `host` and `user` are required; `port`
+    defaults to 22, `auth` to "key", `identities_only` to true, and the
+    connect and keepalive timeouts to 30 seconds. Each `[ssh_option]`
+    entry becomes one `-o key=value`, which is the escape hatch for
+    everything fleetctl does not model.
+
+    Three backends: a private TOML file, a `pass` entry, or a
+    `secret = { ... }` table inline in the target. Resolution is lazy,
+    on first use, so only the code that opens a connection pays for it.
+
+    A `host`, `user`, `port`, `password` or `identity_file` key in a
+    target file is refused with that explanation, not a spelling hint:
+    it belongs in the secret.
+
+WHAT IS PRINTED
+    `show --secret` redacts host and user together and reports the
+    port, the auth mode, whether an identity is configured and whether
+    a password is on file. A username beside a redacted host is half a
+    credential. `--sensitive` asks for the real values, one command at
+    a time, rather than a setting that changes what everything prints.
+
+    Files are written 0600 and directories 0700, and `doctor` treats a
+    group- or world-readable secret as a problem rather than a warning.
+    `seed-pass` copies live config into `pass`; `deploy-config` renders
+    a fresh tree beside the live one, validates it, and only then swaps
+    -- keeping one previous generation, and never clearing `secrets/`
+    unless it can refill it.
+
+    auth = "password" runs ssh under sshpass with pubkey auth off, and
+    is refused on a bridge. BatchMode is never forced, so a
+    passphrase-protected key or a 2FA prompt can still be answered when
+    there is a terminal to answer on.
+
+SEE ALSO
+    fleetctl help config, fleetctl help reach
+""",
+    "jobs": """\
+NAME
+    fleetctl jobs - submitting compute, and following it
+
+SYNOPSIS
+    fleetctl submit <file> [--target <target>] [--queue <preset>]
+        [--job-name <name>] [--time <limit>] [--gpus <n>]
+        [--cpus-per-task <n>] [--mem <size>] [--output <path>]
+        [--error <path>] [--native-batch] [--dry-run] [-- <args>]
+    fleetctl job status|logs|cancel <job_id> [--target <target>]
+
+DESCRIPTION
+    `submit` has two paths, and the profile decides which: a profile
+    submits if and only if it defines `submit_command`. Without one the
+    script is staged and run directly over SSH, and resource flags are
+    refused, because nothing there could honour them. With one, the
+    staged script is wrapped in a small scheduler preamble built from
+    the queue preset and your overrides. --native-batch sends your file
+    unchanged instead, refusing script arguments and resource flags
+    alike; a protocol can require it.
+
+    Resources come from a named queue preset on the protocol. Without
+    --queue the protocol's default is used; a missing default or an
+    unknown name is an error rather than a guess. A GPU request renders
+    as --gpus or --gres according to the protocol's `gpu_request_mode`.
+
+    Nothing is submitted until a job id could be reported back: a
+    submitting profile with no `job_id_pattern` is refused up front.
+    After the scheduler has accepted the script nothing may raise -- a
+    traceback there would orphan a real allocation -- so the output is
+    echoed, and an id that cannot be parsed becomes a warning telling
+    you to confirm before you resubmit.
+
+JOB CONTROL
+    `job status`, `job logs` and `job cancel` run the profile's own
+    `status_command`, `logs_command` and `cancel_command` with the job
+    id substituted, and return the remote exit code. A profile that
+    defines none refuses the operation rather than doing nothing
+    quietly. Job output defaults to `%j.out` and `%j.err` under the
+    protocol's `job_output_dir`, and the printed log paths have `%j`
+    already replaced.
+
+SEE ALSO
+    fleetctl help verbs, fleetctl help config, fleetctl help examples
+""",
+    "examples": """\
+NAME
+    fleetctl examples - worked invocations
+
+DESCRIPTION
+    <target> is a target name, <bridge> a target whose role is
+    "bridge", <project> a local directory, <alias> an entry in your own
+    SSH config, <preset> a queue name from the protocol.
+
+    Import an existing SSH alias, naming what the machine is:
+        fleetctl import-ssh <alias> --name <target> --role workstation
+
+    Declare a fallback route, then pin one connection to it:
+        # targets.d/<target>.toml
+        reach = ["direct", "via:<bridge>"]
+        fleetctl exec <target> --route via:<bridge> -- uptime
+
+    See the fleet as a graph, with what each bridge carries:
+        fleetctl list --format topology
+
+    Ask what a selector resolves to, and what it admits, without
+    running anything:
+        fleetctl explain <target>
+        fleetctl explain <target> submit --json
+
+    Bind a directory once, so later commands need no target:
+        cd <project> && fleetctl project bind --target <target>
+        fleetctl sync push .
+        fleetctl exec -- python3 --version
+
+    Run a local script with arguments; after `--` is verbatim:
+        fleetctl script ./setup.sh --target <target> -- --flag value
+
+    Submit to a named queue, then follow the job:
+        fleetctl submit train.sh --target <target> --queue <preset>
+        fleetctl job status <job_id> --target <target>
+
+    Touch a login node's control plane on purpose:
+        fleetctl exec <target> --admin -- squeue --me
+
+    Check the local setup, then the one remote prerequisite:
+        fleetctl doctor
+        fleetctl doctor --probe
+
+SEE ALSO
+    fleetctl help verbs, fleetctl help reach, fleetctl help jobs
+""",
+}
+
+MANUAL_TOPICS = tuple(MANUAL)
+
+
+def render_admission_table() -> str:
+    """Render ROLE_MATRIX as a grid, so the manual cannot contradict the policy."""
+    glyphs = {ALLOW: "yes", ADMIN: "admin", DENY: "no"}
+    widths = [max(len(verb), 5) + 1 for verb in VERBS]
+    role_column = max(len(role) for role in ROLES) + 2
+    rows = [
+        "    "
+        + "role".ljust(role_column)
+        + "".join(verb.ljust(width) for verb, width in zip(VERBS, widths))
+    ]
+    for role in ROLES:
+        rows.append(
+            "    "
+            + role.ljust(role_column)
+            + "".join(
+                glyphs[decision].ljust(width)
+                for decision, width in zip(ROLE_MATRIX[role], widths)
+            )
+        )
+    rows.append("")
+    rows.append("    yes = allowed    admin = needs --admin    no = refused")
+    return "\n".join(row.rstrip() for row in rows)
+
+
+def render_verb_table() -> str:
+    """Render one line per admission verb, keyed on the closed vocabulary.
+
+    A verb added to VERBS without a summary shows up as undocumented rather than
+    silently vanishing from the manual.
+    """
+    column = max(len(verb) for verb in VERBS) + 4
+    return "\n".join(
+        "    " + verb.ljust(column) + VERB_SUMMARY.get(verb, "(undocumented)")
+        for verb in VERBS
+    )
+
+
+def render_manual(topic: str) -> str:
+    """Return one manual topic with its generated tables substituted."""
+    if topic not in MANUAL:
+        raise FleetError(
+            f"no manual topic {topic!r}; try one of: {', '.join(MANUAL_TOPICS)}"
+        )
+    return (
+        MANUAL[topic]
+        .replace("{ADMISSION_TABLE}", render_admission_table())
+        .replace("{VERB_TABLE}", render_verb_table())
+        .replace("{TOPIC_LIST}", "  ".join(MANUAL_TOPICS))
+        .rstrip()
+    )
+
+
+def command_help(args: argparse.Namespace) -> int:
+    """Print one manual topic."""
+    print(render_manual(args.topic or "overview"))
+    return 0
+
+
 def add_route_flag(parser: argparse.ArgumentParser) -> None:
     """Register `--route`, which pins one of a target's declared routes."""
     parser.add_argument(
@@ -5518,12 +5994,32 @@ def add_connection_flags(parser: argparse.ArgumentParser) -> None:
 
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI parser."""
-    parser = argparse.ArgumentParser(prog="fleetctl")
+    parser = argparse.ArgumentParser(
+        prog="fleetctl",
+        epilog=(
+            "`fleetctl help` prints the manual; `fleetctl help <topic>` one "
+            "section of it. Topics: " + "  ".join(MANUAL_TOPICS) + "."
+        ),
+    )
     parser.add_argument("--config-home", type=Path, help="Override FLEET_CONFIG_HOME")
     parser.add_argument("--state-home", type=Path, help="Override FLEET_STATE_HOME")
     parser.add_argument("--cache-home", type=Path, help="Override FLEET_CACHE_HOME")
 
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    help_parser = subparsers.add_parser(
+        "help",
+        help="Show the manual: overview, or one topic",
+    )
+    help_parser.add_argument(
+        "topic",
+        nargs="?",
+        choices=MANUAL_TOPICS,
+        help="Manual topic; omit for the overview",
+    )
+    # Loads no config on purpose: the manual has to be readable on a machine
+    # where nothing is set up yet, which is exactly when it is wanted.
+    help_parser.set_defaults(handler=command_help, loads_own_config=True)
 
     init_parser = subparsers.add_parser("init", help="Initialize local fleet directories")
     init_parser.add_argument(

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -1243,6 +1243,10 @@ def resolve_remote_root(
     return target.workdir
 
 
+# ssh reserves this exit status for its own failures, so a command exiting 255
+# means the connection died rather than the remote command failing.
+SSH_TRANSPORT_FAILURE = 255
+
 CONTROL_COMMAND_TIMEOUT = 60.0
 SUBMIT_COMMAND_TIMEOUT = 120.0
 PASS_COMMAND_TIMEOUT = 120.0
@@ -3967,7 +3971,15 @@ def probe_remote_prerequisites(context: FleetContext) -> list[str]:
         except FleetError as exc:
             problems.append(f"target {target.name!r} is not reachable: {exc}")
             continue
-        if completed.returncode != 0:
+        if completed.returncode == SSH_TRANSPORT_FAILURE:
+            # ssh reserves 255 for its own failures, so this is a transport
+            # problem, not a missing interpreter -- do not blame python3 for it.
+            detail = (completed.stderr or "").strip().splitlines()
+            problems.append(
+                f"target {target.name!r} is not reachable: "
+                + (detail[-1] if detail else "ssh failed with no diagnostic")
+            )
+        elif completed.returncode != 0:
             problems.append(
                 f"target {target.name!r} has no `python3` on PATH; `fleetctl exec` "
                 "runs its payload through a remote Python stub and will fail there"

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -1001,13 +1001,40 @@ def write_text_if_missing(path: Path, content: str, *, mode: int) -> None:
     write_text_file(path, content, mode=mode, force=False)
 
 
-def clear_toml_dir(path: Path) -> None:
-    """Remove managed TOML files from PATH."""
-    if not path.exists():
-        return
-    for entry in path.glob("*.toml"):
-        entry.unlink()
+def carry_secret_files(source_dir: Path, dest_dir: Path) -> list[str]:
+    """Copy existing secret files into a staging tree so a deploy cannot lose them."""
+    if not source_dir.is_dir():
+        return []
+    carried: list[str] = []
+    for entry in sorted(source_dir.glob("*.toml")):
+        destination = dest_dir / entry.name
+        shutil.copy2(entry, destination)
+        os.chmod(destination, PRIVATE_FILE_MODE)
+        carried.append(entry.name)
+    return carried
 
+
+def swap_config_tree(staging: Path, live: Path) -> Path | None:
+    """Replace `live` with `staging` by rename, keeping one previous generation.
+
+    Both paths share a parent, so each rename is atomic: no reader ever sees a
+    half-written config tree, and a failure part-way through puts the old tree
+    back where it was.
+    """
+    previous = live.with_name(live.name + ".prev")
+    rotated = False
+    if live.exists():
+        if previous.exists():
+            shutil.rmtree(previous)
+        os.replace(live, previous)
+        rotated = True
+    try:
+        os.replace(staging, live)
+    except OSError:
+        if rotated and not live.exists():
+            os.replace(previous, live)
+        raise
+    return previous if rotated else None
 
 def run_pass_show(secret_ref: str) -> str:
     """Fetch one pass entry."""
@@ -2730,8 +2757,15 @@ def command_seed_pass(args: argparse.Namespace) -> int:
 
 
 def command_deploy_config(args: argparse.Namespace) -> int:
-    """Render ~/.config/fleet from public templates and pass-backed private state."""
-    paths = build_paths(
+    """Render ~/.config/fleet from public templates and pass-backed private state.
+
+    The new tree is rendered and validated in a sibling staging directory, and the
+    live config is only ever replaced by a rename once the new tree is known to
+    load.  A failed fetch -- locked gpg-agent, expired card, missing `pass`, a
+    mistyped `--pass-prefix` -- therefore leaves the working config untouched
+    instead of deleting it first and reporting the error afterwards.
+    """
+    live = build_paths(
         config_home=args.config_home,
         state_home=args.state_home,
         cache_home=args.cache_home,
@@ -2740,62 +2774,102 @@ def command_deploy_config(args: argparse.Namespace) -> int:
     if not prefix:
         raise FleetError("`--pass-prefix` must not be empty")
 
-    ensure_private_dir(paths.config_home, mode=PRIVATE_DIR_MODE)
-    ensure_private_dir(paths.targets_dir, mode=PRIVATE_DIR_MODE)
-    ensure_private_dir(paths.pools_dir, mode=PRIVATE_DIR_MODE)
-    ensure_private_dir(paths.protocols_dir, mode=PRIVATE_DIR_MODE)
-    ensure_private_dir(paths.profiles_dir, mode=PRIVATE_DIR_MODE)
-    ensure_private_dir(paths.secrets_dir, mode=PRIVATE_DIR_MODE)
-
-    clear_toml_dir(paths.targets_dir)
-    clear_toml_dir(paths.pools_dir)
-    clear_toml_dir(paths.protocols_dir)
-    clear_toml_dir(paths.profiles_dir)
-    clear_toml_dir(paths.secrets_dir)
-
-    config_entry = pass_entry_name(prefix, "config")
-    config_text = run_pass_show(config_entry) if pass_entry_exists(config_entry) else default_config_template()
-    write_text_file(paths.config_file, config_text, mode=PRIVATE_FILE_MODE)
-
-    projects_entry = pass_entry_name(prefix, "projects")
-    projects_text = run_pass_show(projects_entry) if pass_entry_exists(projects_entry) else default_projects_template()
-    write_text_file(paths.projects_file, projects_text, mode=PRIVATE_FILE_MODE)
-
-    write_text_file(
-        paths.profiles_dir / "plain-ssh.toml",
-        default_plain_profile_template(),
-        mode=PRIVATE_FILE_MODE,
+    staging_root = live.config_home.with_name(live.config_home.name + ".new")
+    if staging_root.exists():
+        shutil.rmtree(staging_root)
+    paths = build_paths(
+        config_home=staging_root,
+        state_home=args.state_home,
+        cache_home=args.cache_home,
     )
-    write_text_file(
-        paths.profiles_dir / "slurm-batch.toml",
-        default_slurm_profile_template(),
-        mode=PRIVATE_FILE_MODE,
-    )
-    write_pass_tree_to_dir(pass_entry_name(prefix, "profiles"), paths.profiles_dir)
-    targets_written = write_pass_tree_to_dir(pass_entry_name(prefix, "targets"), paths.targets_dir)
-    write_pass_tree_to_dir(pass_entry_name(prefix, "pools"), paths.pools_dir)
-    write_pass_tree_to_dir(pass_entry_name(prefix, "protocols"), paths.protocols_dir)
 
-    if not targets_written:
-        raise FleetError(
-            f"no target entries found under pass prefix {pass_entry_name(prefix, 'targets')!r}"
+    try:
+        ensure_private_dir(paths.config_home, mode=PRIVATE_DIR_MODE)
+        ensure_private_dir(paths.targets_dir, mode=PRIVATE_DIR_MODE)
+        ensure_private_dir(paths.pools_dir, mode=PRIVATE_DIR_MODE)
+        ensure_private_dir(paths.protocols_dir, mode=PRIVATE_DIR_MODE)
+        ensure_private_dir(paths.profiles_dir, mode=PRIVATE_DIR_MODE)
+        ensure_private_dir(paths.secrets_dir, mode=PRIVATE_DIR_MODE)
+
+        # Secret files are the one thing here that cannot be regenerated from
+        # templates plus `pass`, so they are carried forward rather than dropped.
+        carried = carry_secret_files(live.secrets_dir, paths.secrets_dir)
+
+        config_entry = pass_entry_name(prefix, "config")
+        config_text = (
+            run_pass_show(config_entry)
+            if pass_entry_exists(config_entry)
+            else default_config_template()
+        )
+        write_text_file(paths.config_file, config_text, mode=PRIVATE_FILE_MODE)
+
+        projects_entry = pass_entry_name(prefix, "projects")
+        projects_text = (
+            run_pass_show(projects_entry)
+            if pass_entry_exists(projects_entry)
+            else default_projects_template()
+        )
+        write_text_file(paths.projects_file, projects_text, mode=PRIVATE_FILE_MODE)
+
+        write_text_file(
+            paths.profiles_dir / "plain-ssh.toml",
+            default_plain_profile_template(),
+            mode=PRIVATE_FILE_MODE,
+        )
+        write_text_file(
+            paths.profiles_dir / "slurm-batch.toml",
+            default_slurm_profile_template(),
+            mode=PRIVATE_FILE_MODE,
+        )
+        write_pass_tree_to_dir(pass_entry_name(prefix, "profiles"), paths.profiles_dir)
+        targets_written = write_pass_tree_to_dir(
+            pass_entry_name(prefix, "targets"), paths.targets_dir
+        )
+        write_pass_tree_to_dir(pass_entry_name(prefix, "pools"), paths.pools_dir)
+        write_pass_tree_to_dir(
+            pass_entry_name(prefix, "protocols"), paths.protocols_dir
         )
 
-    deployed = FleetContext.load(
-        config_home=paths.config_home,
-        state_home=paths.state_home,
-        cache_home=paths.cache_home,
-    )
-    for target in deployed.targets.values():
-        if target.secret_backend != "pass":
+        if not targets_written:
             raise FleetError(
-                f"deployed target {target.name!r} does not use pass-backed secrets"
+                "no target entries found under pass prefix "
+                f"{pass_entry_name(prefix, 'targets')!r}; the existing config at "
+                f"{live.config_home} has been left alone"
             )
-        deployed.resolve_secret(target)
+
+        deployed = FleetContext.load(
+            config_home=paths.config_home,
+            state_home=paths.state_home,
+            cache_home=paths.cache_home,
+        )
+        for target in deployed.targets.values():
+            if target.secret_backend != "pass":
+                raise FleetError(
+                    f"deployed target {target.name!r} does not use pass-backed "
+                    "secrets; `deploy-config` can only render a fleet whose secrets "
+                    "all live in `pass` (run `fleetctl seed-pass` first)"
+                )
+            deployed.resolve_secret(target)
+
+        previous = swap_config_tree(staging_root, live.config_home)
+    finally:
+        if staging_root.exists():
+            shutil.rmtree(staging_root, ignore_errors=True)
+
+    if carried:
+        print(
+            f"note: carried {len(carried)} plaintext secret file(s) forward into "
+            f"{live.secrets_dir} ({', '.join(carried)}). Every deployed target is "
+            "pass-backed, so these are no longer read; remove them once you are "
+            "satisfied the pass entries are complete.",
+            file=sys.stderr,
+        )
+    if previous is not None:
+        print(f"note: previous config kept at {previous}", file=sys.stderr)
 
     if args.doctor:
         payload = {
-            "config_home": str(paths.config_home),
+            "config_home": str(live.config_home),
             "targets": sorted(deployed.targets),
             "pools": sorted(deployed.pools),
             "protocols": sorted(deployed.protocols),
@@ -2803,9 +2877,8 @@ def command_deploy_config(args: argparse.Namespace) -> int:
         }
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        print(paths.config_home)
+        print(live.config_home)
     return 0
-
 
 def command_ssh(args: argparse.Namespace) -> int:
     """Open one interactive SSH session."""

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -754,14 +754,31 @@ def load_toml_file(path: Path, *, default: Any | None = None) -> dict[str, Any]:
     return data
 
 
-def load_records_from_dir(path: Path) -> list[tuple[str, dict[str, Any], Path]]:
+def load_records_from_dir(
+    path: Path,
+    *,
+    kind: str = "record",
+) -> list[tuple[str, dict[str, Any], Path]]:
     """Read every TOML file in PATH and return (name, raw, source_path)."""
     if not path.exists():
         return []
     records: list[tuple[str, dict[str, Any], Path]] = []
+    seen: dict[str, Path] = {}
     for entry in sorted(path.glob("*.toml")):
         raw = load_toml_file(entry)
         name = str(raw.get("name") or entry.stem)
+        # The record name, not the filename, is the key every loader builds its
+        # dict on, so two files claiming one name used to mean the
+        # alphabetically later file silently won.  That is how a target gets
+        # edited in one file and resolved from another.
+        if name in seen:
+            raise FleetError(
+                f"duplicate {kind} name {name!r}: declared in both "
+                f"{seen[name].name} and {entry.name} under {path}. Names are "
+                "how fleetctl identifies records, so exactly one file may "
+                "claim each one."
+            )
+        seen[name] = entry
         records.append((name, raw, entry))
     return records
 
@@ -779,7 +796,7 @@ TARGET_FILE_WARNINGS: dict[str, str] = {
 def load_targets(path: Path) -> dict[str, TargetRecord]:
     """Load target metadata files."""
     targets: dict[str, TargetRecord] = {}
-    for name, raw, source in load_records_from_dir(path):
+    for name, raw, source in load_records_from_dir(path, kind="target"):
         what = f"target {name!r}"
         check_version(raw, what=what, source=source)
         reject_unknown_keys(
@@ -833,7 +850,7 @@ def load_targets(path: Path) -> dict[str, TargetRecord]:
 def load_pools(path: Path) -> dict[str, PoolRecord]:
     """Load pool metadata files."""
     pools: dict[str, PoolRecord] = {}
-    for name, raw, source in load_records_from_dir(path):
+    for name, raw, source in load_records_from_dir(path, kind="pool"):
         what = f"pool {name!r}"
         check_version(raw, what=what, source=source)
         reject_unknown_keys(raw, POOL_KEYS, what=what, source=source)
@@ -899,7 +916,7 @@ def built_in_protocols() -> dict[str, ProtocolRecord]:
 def load_protocols(path: Path) -> dict[str, ProtocolRecord]:
     """Load protocol definitions and merge them over the built-ins."""
     protocols = built_in_protocols()
-    for name, raw, source in load_records_from_dir(path):
+    for name, raw, source in load_records_from_dir(path, kind="protocol"):
         what = f"protocol {name!r}"
         check_version(raw, what=what, source=source)
         reject_unknown_keys(raw, PROTOCOL_KEYS, what=what, source=source)
@@ -995,7 +1012,7 @@ def load_protocols(path: Path) -> dict[str, ProtocolRecord]:
 def load_profiles(path: Path) -> dict[str, ProfileRecord]:
     """Load execution profile files."""
     profiles: dict[str, ProfileRecord] = {}
-    for name, raw, source in load_records_from_dir(path):
+    for name, raw, source in load_records_from_dir(path, kind="profile"):
         what = f"profile {name!r}"
         check_version(raw, what=what, source=source)
         reject_unknown_keys(raw, PROFILE_KEYS, what=what, source=source)

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -363,6 +363,7 @@ class TargetRecord:
     secret_backend: str = "file"
     secret_ref: str | None = None
     secret_inline: dict[str, Any] = field(default_factory=dict)
+    capabilities: dict[str, Any] = field(default_factory=dict)
     ssh_host_alias: str | None = None
     default_profile: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -410,6 +411,11 @@ class QueueRecord:
     constraint: str | None = None
     extra_directives: tuple[str, ...] = ()
     notes: tuple[str, ...] = ()
+    # What the scheduler allocates here, as opposed to what the login node has.
+    # A site's GPUs live on compute nodes behind the surface you SSH to, so
+    # without this `--require vram_gb>=64` would refuse the one target in the
+    # fleet whose partitions have 64 GB cards.
+    capabilities: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -420,7 +426,6 @@ class ProtocolRecord:
     kind: str = "direct"
     description: str | None = None
     default_profile: str | None = None
-    smoke_gpu_probe: bool = True
     gpu_request_mode: str = "gres"
     job_runtime: str = "host"
     native_batch_required: bool = False
@@ -645,20 +650,151 @@ class FleetContext:
             return selector[len("fleet:") :]
         return selector
 
+    def selectable_capabilities(
+        self, target: TargetRecord
+    ) -> list[tuple[str | None, dict[str, Any]]]:
+        """Every surface TARGET can offer, as (queue name or None, capabilities).
+
+        A login node's own hardware is not what a job gets: the GPUs live on
+        compute nodes behind it, described by the partitions.  So a scheduler
+        target offers one surface per queue -- the target's capabilities with the
+        queue's layered over them -- and satisfies a requirement when *any* of
+        them does.  Without this, `--require vram_gb>=64` would refuse the one
+        target in the fleet whose partitions have 64 GB cards.
+        """
+        protocol = self.resolve_protocol(target)
+        if not protocol.queues:
+            return [(None, dict(target.capabilities))]
+        surfaces = []
+        for queue in protocol.queues:
+            merged = dict(target.capabilities)
+            merged.update(queue.capabilities)
+            surfaces.append((queue.name, merged))
+        return surfaces
+
+    def capability_refusal(
+        self, target: TargetRecord, requirements: tuple[Requirement, ...]
+    ) -> str | None:
+        """Why TARGET cannot satisfy REQUIREMENTS, or None when it can."""
+        if not requirements:
+            return None
+        reports = []
+        for queue_name, capabilities in self.selectable_capabilities(target):
+            mismatches = capability_mismatches(requirements, capabilities)
+            if not mismatches:
+                return None
+            prefix = f"queue {queue_name!r} " if queue_name is not None else ""
+            reports.append(prefix + "; ".join(mismatches))
+        return " / ".join(reports)
+
+    def fit_cost(
+        self, target: TargetRecord, requirements: tuple[Requirement, ...] = ()
+    ) -> tuple[float, ...]:
+        """TARGET's cost as the cheapest surface on it that fits REQUIREMENTS."""
+        costs = [
+            capability_cost(capabilities)
+            for _, capabilities in self.selectable_capabilities(target)
+            if not capability_mismatches(requirements, capabilities)
+        ]
+        return min(costs) if costs else capability_cost({})
+
+    def require_target(
+        self, target: TargetRecord, requirements: tuple[Requirement, ...]
+    ) -> TargetRecord:
+        """Assert TARGET meets REQUIREMENTS, since something already named it.
+
+        A requirement against a named target is a check, not a search.  Silently
+        moving the work to a host that does fit would be the worst possible
+        reading: you asked for that machine.
+        """
+        refusal = self.capability_refusal(target, requirements)
+        if refusal is None:
+            return target
+        wanted = " ".join(str(item) for item in requirements)
+        raise FleetError(
+            f"{target.name!r} does not satisfy {wanted}: {refusal}. A requirement "
+            "checks the target you named; it never moves the work. Run "
+            f"`fleetctl resolve --require {wanted!r} --fit` to see what does."
+        )
+
+    def matching_targets(
+        self, requirements: tuple[Requirement, ...]
+    ) -> list[TargetRecord]:
+        """Every enabled target that satisfies REQUIREMENTS, by name."""
+        return [
+            target
+            for target in sorted(self.targets.values(), key=lambda item: item.name)
+            if target.enabled
+            and self.capability_refusal(target, requirements) is None
+        ]
+
+    def select_fleet(
+        self, requirements: tuple[Requirement, ...], *, fit: bool
+    ) -> TargetRecord:
+        """Pick one target out of the whole fleet by requirement alone.
+
+        Reached only when no selector and no project binding named anything.
+        Ambiguity is refused rather than resolved alphabetically: picking the
+        first of four sufficient machines is a coin toss wearing a rule.
+        """
+        wanted = " ".join(str(item) for item in requirements)
+        matches = self.matching_targets(requirements)
+        if not matches:
+            near = [
+                f"  {target.name}: {self.capability_refusal(target, requirements)}"
+                for target in sorted(
+                    self.targets.values(), key=lambda item: item.name
+                )
+                if target.enabled
+            ]
+            listing = "\n".join(near) if near else "  (no enabled targets)"
+            raise FleetError(f"no enabled target satisfies {wanted}:\n{listing}")
+        if fit:
+            return min(
+                matches,
+                key=lambda target: (self.fit_cost(target, requirements), target.name),
+            )
+        if len(matches) > 1:
+            names = ", ".join(target.name for target in matches)
+            raise FleetError(
+                f"{wanted} matches {len(matches)} targets ({names}). Pass --fit to "
+                "take the smallest sufficient one, or name the target you want."
+            )
+        return matches[0]
+
     def resolve_target(
         self,
         selector: str | None,
         *,
         cwd: Path | None = None,
+        requirements: tuple[Requirement, ...] = (),
+        fit: bool = False,
     ) -> tuple[TargetRecord, ProjectBinding | None]:
-        """Resolve a user selector or project default to one concrete target."""
+        """Resolve a user selector or project default to one concrete target.
+
+        Precedence is selector, then project binding, then a fleet-wide search --
+        and requirements never change it.  Against a name they are a check that
+        refuses; against a set (a pool, or the fleet) they are a filter.  The
+        alternative, letting `--require` retarget a named host, would mean a typo
+        in a capability silently ran your job somewhere else.
+        """
         binding = self.project_binding_for(cwd)
         normalized = self.normalize_selector(selector)
         if normalized:
             if normalized in self.targets:
-                return ensure_target_enabled(self.targets[normalized]), binding
+                return (
+                    self.require_target(
+                        ensure_target_enabled(self.targets[normalized]), requirements
+                    ),
+                    binding,
+                )
             if normalized in self.pools:
-                return self.select_pool(self.pools[normalized]), binding
+                return (
+                    self.select_pool(
+                        self.pools[normalized], requirements=requirements, fit=fit
+                    ),
+                    binding,
+                )
             raise FleetError(
                 f"unknown target or pool {normalized!r}; run `fleetctl list`"
             )
@@ -669,18 +805,33 @@ class FleetContext:
                     f"project binding for {binding.path} refers to missing target "
                     f"{binding.default_target!r}"
                 )
-            return ensure_target_enabled(self.targets[binding.default_target]), binding
+            return (
+                self.require_target(
+                    ensure_target_enabled(self.targets[binding.default_target]),
+                    requirements,
+                ),
+                binding,
+            )
         if binding and binding.default_pool:
             if binding.default_pool not in self.pools:
                 raise FleetError(
                     f"project binding for {binding.path} refers to missing pool "
                     f"{binding.default_pool!r}"
                 )
-            return self.select_pool(self.pools[binding.default_pool]), binding
+            return (
+                self.select_pool(
+                    self.pools[binding.default_pool],
+                    requirements=requirements,
+                    fit=fit,
+                ),
+                binding,
+            )
+        if requirements:
+            return self.select_fleet(requirements, fit=fit), binding
 
         raise FleetError(
             "no target specified and no project default available; "
-            "pass a target or pool explicitly"
+            "pass a target, a pool, or `--require` explicitly"
         )
 
     def pool_members(self, pool: PoolRecord) -> list[TargetRecord]:
@@ -709,11 +860,39 @@ class FleetContext:
             ]
         return [target for target in members if target.enabled]
 
-    def select_pool(self, pool: PoolRecord) -> TargetRecord:
+    def select_pool(
+        self,
+        pool: PoolRecord,
+        *,
+        requirements: tuple[Requirement, ...] = (),
+        fit: bool = False,
+    ) -> TargetRecord:
         """Select one target from a logical pool."""
         members = self.pool_members(pool)
         if not members:
             raise FleetError(f"pool {pool.name!r} has no eligible targets")
+        if requirements:
+            wanted = " ".join(str(item) for item in requirements)
+            eligible = [
+                target
+                for target in members
+                if self.capability_refusal(target, requirements) is None
+            ]
+            if not eligible:
+                detail = "\n".join(
+                    f"  {target.name}: "
+                    f"{self.capability_refusal(target, requirements)}"
+                    for target in members
+                )
+                raise FleetError(
+                    f"no member of pool {pool.name!r} satisfies {wanted}:\n{detail}"
+                )
+            members = eligible
+        if fit:
+            return min(
+                members,
+                key=lambda target: (self.fit_cost(target, requirements), target.name),
+            )
         return members[0]
 
     def resolve_profile(
@@ -801,6 +980,258 @@ class FleetContext:
         return parse_secret_dict(raw, source=source)
 
 
+# ---- SECTION: capabilities -------------------------------------------------
+#
+# `role` is a hard admission boundary; capabilities are the soft layer above it,
+# and the split is deliberate.  Nomad added node pools precisely because
+# affinities and constraints "do not easily prevent other jobs from placing
+# allocations in a set of nodes": attribute matching is the wrong tool for a
+# boundary, and a boundary is the wrong tool for "which of these will fit".
+#
+# Declared values are authoritative and nothing here is measured.  Salt's own
+# documentation calls minion-supplied grains "less secure than other
+# identifiers" for the reason that applies here too -- what a machine has is a
+# fact its owner writes down, not something discovered at selection time and
+# possibly stale by the time the job lands.
+#
+# The vocabulary is open on purpose, and this is the one place in the file where
+# an unrecognised key is not fatal.  A fleet growing in variety wants `nvlink`,
+# `rocm_version`, `infiniband` next month, and a closed list would make the tool
+# the obstacle.  It is safe here for a reason that holds nowhere else: elsewhere
+# an unknown key fails *open*, because the default that quietly fills in is the
+# permissive one, whereas a misspelled capability fails *closed* --
+# `--require vram_bg>=24` matches nothing and says exactly that.
+#
+# What is still enforced is the part a mistake would hide.  A value must be a
+# scalar, because a list would silently satisfy no comparison, and the four keys
+# compared as numbers must really be numbers -- checked at load time rather than
+# at the point a comparison would raise.
+
+# The keys `--fit` costs, in the order it minimises them.  Written down because
+# a hidden cost function is an unpredictable one: fewest GPUs, then least VRAM,
+# then fewest CPUs, then least memory -- the smallest sufficient machine, so the
+# big box stays free for the job that needs it.  Ties break on the target name,
+# since a tie broken any other way is one you cannot script against.
+FIT_ORDER = ("gpu_count", "vram_gb", "cpus", "mem_gb")
+
+CAPABILITY_NUMBER_KEYS = frozenset(FIT_ORDER)
+
+# Keys common enough that a near-miss is worth reporting.  Not a closed list --
+# nothing rejects a key outside it -- just the seed of the vocabulary `doctor`
+# spell-checks against.
+CAPABILITY_COMMON_KEYS = ("arch", "gpu_model", *FIT_ORDER)
+
+# Two-character operators first, so `>=` is never read as `>` with a stray `=`.
+REQUIREMENT_OPERATORS = (">=", "<=", "!=", "==", ">", "<", "=")
+REQUIREMENT_ORDERINGS = (">=", "<=", ">", "<")
+
+
+@dataclass(frozen=True)
+class Requirement:
+    """One `key<op>value` clause from `--require`."""
+
+    key: str
+    operator: str
+    text: str
+
+    def __str__(self) -> str:
+        return f"{self.key}{self.operator}{self.text}"
+
+
+def parse_requirements(values: Iterable[str]) -> tuple["Requirement", ...]:
+    """Parse `--require` clauses like `vram_gb>=24,gpu_count>=1`.
+
+    Every clause carries an operator, and there is deliberately no bare-key
+    form.  A bare key would have to mean either "declares this" or "is called
+    this", and `--fit lab-gpu` reading as a target name is exactly the ambiguity
+    that makes a selection flag dangerous.
+    """
+    requirements: list[Requirement] = []
+    for value in values or ():
+        for raw in str(value).split(","):
+            clause = raw.strip()
+            if not clause:
+                continue
+            for operator in REQUIREMENT_OPERATORS:
+                key, found, text = clause.partition(operator)
+                if not found:
+                    continue
+                if not key.strip() or not text.strip():
+                    raise FleetError(
+                        f"malformed requirement {clause!r}: expected "
+                        "`key<op>value`, as in `vram_gb>=24`"
+                    )
+                requirements.append(
+                    Requirement(key.strip(), operator, text.strip())
+                )
+                break
+            else:
+                raise FleetError(
+                    f"requirement {clause!r} has no comparison in it. Write "
+                    f"`{clause}>=<value>` or `{clause}=<value>`; a bare key would "
+                    "be ambiguous with a target name."
+                )
+    return tuple(requirements)
+
+
+def capability_number(value: Any) -> float | None:
+    """Return VALUE as a number, or None when it is not one.
+
+    `bool` is excluded deliberately: TOML's `true` is an int in Python, and
+    `gpu_count = true` comparing greater than zero is not a fact about a machine.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def capability_text(value: Any) -> str:
+    """Render one capability value the way a requirement compares it."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def requirement_mismatch(
+    requirement: "Requirement", capabilities: dict[str, Any]
+) -> str | None:
+    """Return why CAPABILITIES fail REQUIREMENT, or None when they satisfy it.
+
+    Absence is a mismatch, never a pass.  An undeclared capability is an
+    unknown, and reading an unknown as sufficient is how a job lands on a
+    machine that cannot run it.
+    """
+    if requirement.key not in capabilities:
+        close = difflib.get_close_matches(
+            requirement.key, sorted(capabilities), n=1, cutoff=0.7
+        )
+        hint = f", though it declares {close[0]!r}" if close else ""
+        return f"declares no {requirement.key!r}{hint}"
+    have = capabilities[requirement.key]
+    wanted_number = capability_number(requirement.text)
+    have_number = capability_number(have)
+    if requirement.operator in ("=", "==", "!="):
+        equal = capability_text(have) == requirement.text
+        if not equal and wanted_number is not None and have_number is not None:
+            equal = have_number == wanted_number
+        if (requirement.operator == "!=") is equal:
+            return f"{requirement.key} is {capability_text(have)!r}"
+        return None
+    if wanted_number is None:
+        raise FleetError(
+            f"requirement {requirement} orders its values, so {requirement.text!r} "
+            "has to be a number"
+        )
+    if have_number is None:
+        return (
+            f"{requirement.key} is {capability_text(have)!r}, which "
+            f"`{requirement.operator}` cannot order"
+        )
+    satisfied = {
+        ">=": have_number >= wanted_number,
+        "<=": have_number <= wanted_number,
+        ">": have_number > wanted_number,
+        "<": have_number < wanted_number,
+    }[requirement.operator]
+    if satisfied:
+        return None
+    return f"{requirement.key} is {capability_text(have)}"
+
+
+def capability_mismatches(
+    requirements: Iterable["Requirement"], capabilities: dict[str, Any]
+) -> list[str]:
+    """Every reason CAPABILITIES fail REQUIREMENTS, not just the first one."""
+    reasons: list[str] = []
+    for requirement in requirements:
+        reason = requirement_mismatch(requirement, capabilities)
+        if reason is not None:
+            reasons.append(f"{requirement}: {reason}")
+    return reasons
+
+
+def capability_cost(capabilities: dict[str, Any]) -> tuple[float, ...]:
+    """Return the FIT_ORDER cost vector for CAPABILITIES.
+
+    An undeclared key sorts last rather than first: `--fit` takes the smallest
+    machine *known* to be sufficient, and an unknown is not smaller than a
+    number.
+    """
+    return tuple(
+        float("inf") if number is None else number
+        for number in (
+            capability_number(capabilities.get(key)) for key in FIT_ORDER
+        )
+    )
+
+
+def capability_key_warnings(what: str, capabilities: dict[str, Any]) -> list[str]:
+    """Report capability keys that look like a common key misspelled.
+
+    The vocabulary stays open -- nothing here rejects anything, and a genuinely
+    new key like `nvlink` or `rocm_version` is silent.  But a misspelled
+    capability is invisible in the one way that matters: `--require vram_bg>=24`
+    matches nothing, and a filter that matches nothing looks exactly like a fleet
+    with nothing big enough in it.  `doctor` is where that gets caught.
+    """
+    warnings = []
+    for key in sorted(capabilities):
+        if key in CAPABILITY_COMMON_KEYS:
+            continue
+        close = difflib.get_close_matches(
+            key, CAPABILITY_COMMON_KEYS, n=1, cutoff=0.8
+        )
+        if close:
+            warnings.append(
+                f"{what} declares capability {key!r}, which looks like {close[0]!r}. "
+                "Capability keys are open on purpose, so this is not an error -- but "
+                "`--require` matches the exact spelling, so nothing would ever "
+                "select it."
+            )
+    return warnings
+
+
+def declares_no_gpu(target: "TargetRecord") -> bool:
+    """True only when TARGET says outright that it has no GPU.
+
+    Silence is not a claim.  This replaced `protocol.smoke_gpu_probe`, which
+    defaulted to on, so a target that declares nothing keeps being probed and
+    only an explicit `gpu_count = 0` turns the check off.
+    """
+    return capability_number(target.capabilities.get("gpu_count")) == 0
+
+
+def parse_capabilities(
+    value: Any, *, what: str, source: Path | None = None
+) -> dict[str, Any]:
+    """Validate one `[capabilities]` table.  See this section's note on keys."""
+    table = check_table(value, what=what, source=source)
+    where = f" in {source}" if source is not None else ""
+    capabilities: dict[str, Any] = {}
+    for key, item in table.items():
+        if isinstance(item, (dict, list, tuple)):
+            raise FleetError(
+                f"`{key}` in {what}{where} must be a single value, not "
+                f"{type(item).__name__}: a requirement compares one value, so a "
+                "list here would match nothing and explain nothing"
+            )
+        if key in CAPABILITY_NUMBER_KEYS:
+            number = capability_number(item)
+            if number is None or number < 0:
+                raise FleetError(
+                    f"`{key}` in {what}{where} must be a non-negative number, not "
+                    f"{item!r}: `--require {key}>=n` compares it numerically"
+                )
+            item = int(number) if number.is_integer() else number
+        capabilities[key] = item
+    return capabilities
+
+
 # ---- SECTION: resolution (config + args -> Plan, no remote I/O) ------------
 
 
@@ -828,6 +1259,11 @@ class Plan:
     pool: PoolRecord | None
     admin: bool
     routes: tuple[str, ...] = DEFAULT_REACH
+    # Resolved here rather than in the handler, so `--dry-run` and `explain`
+    # report the queue the submit will really use instead of guessing at it
+    # again.  None for every verb that has no queue.
+    queue: QueueRecord | None = None
+    requirements: tuple[Requirement, ...] = ()
     _secret: FleetSecret | None = field(default=None, compare=False, repr=False)
     _route: str | None = field(default=None, compare=False, repr=False)
 
@@ -895,10 +1331,100 @@ class Plan:
             "protocol_kind": self.protocol.kind,
             "profile": self.profile.name,
             "submits": bool(self.profile.submit_command),
+            "queue": self.queue.name if self.queue is not None else None,
+            "requirements": [str(item) for item in self.requirements],
             "remote_cwd": self.cwd,
             "admin": self.admin,
             "project": str(self.binding.path) if self.binding is not None else None,
         }
+
+
+# Requested-versus-declared pairs, checked before a connection is opened.
+# Deliberately not `queue.gpus`/`queue.cpus_per_task`: those are what the preset
+# *asks the scheduler for*, not what the partition has, so comparing against
+# them would refuse a job for exceeding a default.  Memory is left out on
+# purpose -- `--mem` units are scheduler-specific, and a wrong parse would
+# refuse a valid job, which is worse than not checking.
+PREFLIGHT_CAPABILITY_FLAGS = (
+    ("gpus", "--gpus", "gpu_count"),
+    ("cpus_per_task", "--cpus-per-task", "cpus"),
+)
+
+
+def plan_queue(
+    args: argparse.Namespace,
+    *,
+    verb: str,
+    target: TargetRecord,
+    protocol: ProtocolRecord,
+    profile: ProfileRecord,
+    requirements: tuple[Requirement, ...] = (),
+    fit: bool = False,
+) -> QueueRecord | None:
+    """The queue VERB will use on TARGET, or None when it uses none.
+
+    The guards mirror command_submit's branch order exactly, so every error it
+    already raised still fires in the same order and from the same place.  A
+    queue is only a thing when a profile submits, the caller did not ask for the
+    site's own batch script, and the protocol does not insist on one.
+    """
+    if verb != "submit" or not profile.submit_command:
+        return None
+    if getattr(args, "native_batch", False) or protocol.native_batch_required:
+        return None
+    return resolve_queue(
+        protocol,
+        getattr(args, "queue", None),
+        target_capabilities=target.capabilities,
+        requirements=requirements,
+        fit=fit,
+    )
+
+
+def plan_capabilities(plan: "Plan") -> dict[str, Any]:
+    """The capabilities of the surface PLAN actually lands on."""
+    capabilities = dict(plan.target.capabilities)
+    if plan.queue is not None:
+        capabilities.update(plan.queue.capabilities)
+    return capabilities
+
+
+def capability_preflight(plan: "Plan", args: argparse.Namespace) -> None:
+    """Refuse a request larger than the declared hardware, at zero network cost.
+
+    Only on a path that has a queue, which is the only path where these flags
+    mean anything: everywhere else `ensure_no_resource_flags` already refuses
+    them outright, and answering "your machine only has one GPU" would be
+    answering the wrong question about a flag that could never have been honoured.
+
+    An undeclared capability is not a refusal here, which is the opposite of how
+    `--require` reads absence -- and the asymmetry is the point.  `--require` is
+    a question, so an unknown cannot answer it; `--gpus 4` names a machine and
+    states a need, and refusing that because nobody has written down a
+    `gpu_count` yet would make declaring capabilities mandatory rather than
+    useful.
+    """
+    if plan.queue is None:
+        return
+    capabilities = plan_capabilities(plan)
+    for attr, flag, key in PREFLIGHT_CAPABILITY_FLAGS:
+        requested = capability_number(getattr(args, attr, None))
+        if requested is None:
+            continue
+        declared = capability_number(capabilities.get(key))
+        if declared is None or requested <= declared:
+            continue
+        where = (
+            f"{plan.target.name!r} queue {plan.queue.name!r}"
+            if plan.queue is not None
+            else repr(plan.target.name)
+        )
+        raise FleetError(
+            f"{flag} {capability_text(getattr(args, attr))} exceeds {where}, which "
+            f"declares {key} = {capability_text(capabilities[key])}. Fix the "
+            "request, pick another target, or correct the declaration if the "
+            "hardware changed."
+        )
 
 
 def build_plan(context: FleetContext, args: argparse.Namespace, verb: str) -> Plan:
@@ -909,17 +1435,22 @@ def build_plan(context: FleetContext, args: argparse.Namespace, verb: str) -> Pl
     first, and no way to act on a host without a Plan.
     """
     selector = context.normalize_selector(getattr(args, "selector", None))
-    target, binding = context.resolve_target(selector, cwd=Path.cwd())
+    requirements = parse_requirements(getattr(args, "require", None) or ())
+    fit = bool(getattr(args, "fit", False))
+    target, binding = context.resolve_target(
+        selector, cwd=Path.cwd(), requirements=requirements, fit=fit
+    )
     protocol = context.resolve_protocol(target)
     admin = bool(getattr(args, "admin", False))
     authorize(verb, target, protocol, admin=admin)
-    return Plan(
+    profile = context.resolve_profile(target, binding, getattr(args, "profile", None))
+    plan = Plan(
         verb=verb,
         context=context,
         target=target,
         binding=binding,
         protocol=protocol,
-        profile=context.resolve_profile(target, binding, getattr(args, "profile", None)),
+        profile=profile,
         cwd=resolve_remote_root(target, binding, getattr(args, "cwd", None)),
         selector=selector,
         pool=context.pools.get(selector) if selector else None,
@@ -929,7 +1460,19 @@ def build_plan(context: FleetContext, args: argparse.Namespace, verb: str) -> Pl
             getattr(args, "route", None),
             no_fallback=bool(getattr(args, "no_fallback", False)),
         ),
+        queue=plan_queue(
+            args,
+            verb=verb,
+            target=target,
+            protocol=protocol,
+            profile=profile,
+            requirements=requirements,
+            fit=fit,
+        ),
+        requirements=requirements,
     )
+    capability_preflight(plan, args)
+    return plan
 
 
 def resolve_routes(
@@ -1062,6 +1605,7 @@ TARGET_KEYS = frozenset(
         "secret_backend",
         "secret_ref",
         "secret",
+        "capabilities",
         "ssh_host_alias",
         "default_profile",
         "metadata",
@@ -1075,7 +1619,6 @@ PROTOCOL_KEYS = frozenset(
         "kind",
         "description",
         "default_profile",
-        "smoke_gpu_probe",
         "gpu_request_mode",
         "job_runtime",
         "native_batch_required",
@@ -1101,6 +1644,7 @@ QUEUE_KEYS = frozenset(
         "directive",
         "directives",
         "notes",
+        "capabilities",
     }
 )
 PROFILE_KEYS = frozenset(
@@ -1170,6 +1714,11 @@ DEPRECATED_TARGET_KEYS: dict[str, str] = {
 DEPRECATED_PROTOCOL_KEYS: dict[str, str] = {
     "scheduler_required": "the role matrix decides this for every verb",
     "allow_login_exec": "the role matrix decides this; pass --admin per command",
+    "smoke_gpu_probe": (
+        "whether a host has a GPU is a fact about the host, not about the site "
+        'protocol shared by all of them; declare `gpu_count` under the target\'s '
+        "`[capabilities]` and `smoke` follows it"
+    ),
 }
 DEPRECATED_POOL_KEYS: dict[str, str] = {
     "default_profile": (
@@ -1419,6 +1968,11 @@ def load_targets(path: Path) -> dict[str, TargetRecord]:
             secret_inline=check_table(
                 raw.get("secret", {}), what=f"`secret` for {what}", source=source
             ),
+            capabilities=parse_capabilities(
+                raw.get("capabilities", {}),
+                what=f"`[capabilities]` for {what}",
+                source=source,
+            ),
             ssh_host_alias=optional_str(raw.get("ssh_host_alias")),
             default_profile=optional_str(raw.get("default_profile")),
             metadata=check_table(
@@ -1475,7 +2029,6 @@ def built_in_protocols() -> dict[str, ProtocolRecord]:
         kind="direct",
         description="Direct SSH execution on a host-level workdir.",
         default_profile="plain-ssh",
-        smoke_gpu_probe=True,
         gpu_request_mode="gres",
         job_runtime="host",
         native_batch_required=False,
@@ -1485,7 +2038,6 @@ def built_in_protocols() -> dict[str, ProtocolRecord]:
         kind="slurm",
         description="Scheduler-backed login surface that submits compute via Slurm.",
         default_profile="slurm-batch",
-        smoke_gpu_probe=False,
         gpu_request_mode="gres",
         job_runtime="host",
         native_batch_required=False,
@@ -1551,6 +2103,11 @@ def load_protocols(path: Path) -> dict[str, ProtocolRecord]:
                     constraint=optional_str(item.get("constraint")),
                     extra_directives=directive_values,
                     notes=note_values,
+                    capabilities=parse_capabilities(
+                        item.get("capabilities", {}),
+                        what=f"`[queue.capabilities]` for {queue_name!r} in {what}",
+                        source=source,
+                    ),
                 )
             )
         docs = raw.get("docs", [])
@@ -1576,7 +2133,6 @@ def load_protocols(path: Path) -> dict[str, ProtocolRecord]:
             description=optional_str(raw.get("description")),
             default_profile=optional_str(raw.get("default_profile"))
             or ("slurm-batch" if kind == "slurm" else "plain-ssh"),
-            smoke_gpu_probe=bool(raw.get("smoke_gpu_probe", kind != "slurm")),
             gpu_request_mode=check_vocabulary(
                 str(raw.get("gpu_request_mode", "gres")),
                 GPU_REQUEST_MODES,
@@ -3061,21 +3617,66 @@ def sanitize_job_name(value: str) -> str:
 def resolve_queue(
     protocol: ProtocolRecord,
     requested: str | None,
+    *,
+    target_capabilities: dict[str, Any] | None = None,
+    requirements: tuple[Requirement, ...] = (),
+    fit: bool = False,
 ) -> QueueRecord:
-    """Resolve one queue preset from a protocol."""
+    """Resolve one queue preset from a protocol.
+
+    Requirements filter the partitions, because on a scheduler the hardware a job
+    gets is the partition's rather than the login node's.  `--fit` then takes the
+    smallest sufficient one, so a single-GPU job stops booking the eight-GPU
+    partition.  With neither flag this is exactly the old rule: the declared
+    default, else the first declared.
+    """
+    base = dict(target_capabilities or {})
+
+    def surface(queue: QueueRecord) -> dict[str, Any]:
+        merged = dict(base)
+        merged.update(queue.capabilities)
+        return merged
+
+    wanted = " ".join(str(item) for item in requirements)
     if requested:
         queue = protocol.queue_named(requested)
         if queue is None:
             raise FleetError(
                 f"protocol {protocol.name!r} does not define queue {requested!r}"
             )
+        mismatches = capability_mismatches(requirements, surface(queue))
+        if mismatches:
+            raise FleetError(
+                f"queue {queue.name!r} does not satisfy {wanted}: "
+                f"{'; '.join(mismatches)}"
+            )
         return queue
-    queue = protocol.default_queue()
-    if queue is None:
-        raise FleetError(
-            f"protocol {protocol.name!r} does not define a default queue"
+    candidates = [
+        queue
+        for queue in protocol.queues
+        if not capability_mismatches(requirements, surface(queue))
+    ]
+    if not candidates:
+        if not protocol.queues:
+            raise FleetError(
+                f"protocol {protocol.name!r} does not define a default queue"
+            )
+        detail = "\n".join(
+            f"  {queue.name}: "
+            f"{'; '.join(capability_mismatches(requirements, surface(queue)))}"
+            for queue in protocol.queues
         )
-    return queue
+        raise FleetError(
+            f"no queue on protocol {protocol.name!r} satisfies {wanted}:\n{detail}"
+        )
+    if fit:
+        return min(
+            candidates, key=lambda queue: (capability_cost(surface(queue)), queue.name)
+        )
+    for queue in candidates:
+        if queue.default:
+            return queue
+    return candidates[0]
 
 
 def slurm_gpu_directive(
@@ -3190,6 +3791,7 @@ def target_display(
         "default_profile": target.default_profile or "",
         "role": role,
         "pools": sorted(pool_names),
+        "capabilities": dict(target.capabilities),
     }
 
 
@@ -3202,7 +3804,6 @@ def protocol_display(protocol: ProtocolRecord) -> dict[str, Any]:
         "description": protocol.description or "",
         "default_profile": protocol.default_profile or "",
         "default_queue": default_queue.name if default_queue is not None else "",
-        "smoke_gpu_probe": protocol.smoke_gpu_probe,
         "gpu_request_mode": protocol.gpu_request_mode,
         "job_runtime": protocol.job_runtime,
         "native_batch_required": protocol.native_batch_required,
@@ -3231,6 +3832,7 @@ def queue_display(queue: QueueRecord) -> dict[str, Any]:
         "constraint": queue.constraint or "",
         "extra_directives": list(queue.extra_directives),
         "notes": list(queue.notes),
+        "capabilities": dict(queue.capabilities),
     }
 
 
@@ -3520,6 +4122,14 @@ tags = ["example"]
 secret_backend = "file"
 secret_ref = "~/.config/fleet/secrets/{name}.toml"
 default_profile = "plain-ssh"
+
+# What the machine has, for `--require` and `--fit`. Any key you like; these
+# four are compared as numbers. `gpu_count = 0` also silences the GPU probe.
+[capabilities]
+arch = "x86_64"
+gpu_count = 0
+cpus = 8
+mem_gb = 16
 """
 
 
@@ -3690,6 +4300,15 @@ def toml_key(key: str) -> str:
     return toml_string(key)
 
 
+def toml_scalar(value: Any) -> str:
+    """Serialize one scalar as TOML."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    return toml_string(str(value))
+
+
 def secret_to_toml(secret: FleetSecret) -> str:
     """Serialize a secret file."""
     lines = [
@@ -3747,6 +4366,13 @@ def target_to_toml(target: TargetRecord) -> str:
         lines.append(f"ssh_host_alias = {toml_string(target.ssh_host_alias)}")
     if target.default_profile:
         lines.append(f"default_profile = {toml_string(target.default_profile)}")
+    if target.capabilities:
+        # Last, and it has to be: a table header ends the bare-key section, so
+        # anything emitted after this would be read as part of it.
+        lines.append("")
+        lines.append("[capabilities]")
+        for key, value in sorted(target.capabilities.items()):
+            lines.append(f"{toml_key(key)} = {toml_scalar(value)}")
     return "\n".join(lines) + "\n"
 
 
@@ -4001,11 +4627,64 @@ def reach_dependents(context: FleetContext) -> dict[str, list[str]]:
 
 def command_list(args: argparse.Namespace, context: FleetContext) -> int:
     """List configured targets."""
+    requirements = parse_requirements(getattr(args, "require", None) or ())
+    # Filtered on capability alone, deliberately including disabled targets: this
+    # is a report, not a selection, and "it would fit but it is switched off" is
+    # the single most useful thing it can tell you.
+    fits = (
+        {
+            target.name
+            for target in context.targets.values()
+            if context.capability_refusal(target, requirements) is None
+        }
+        if requirements
+        else None
+    )
+
+    def shown(target: TargetRecord) -> bool:
+        if args.tag and args.tag not in target.tags:
+            return False
+        return fits is None or target.name in fits
+
+    if args.format == "capabilities":
+        rows = []
+        for target in sorted(context.targets.values(), key=lambda item: item.name):
+            if not shown(target):
+                continue
+            for queue_name, capabilities in context.selectable_capabilities(target):
+                row = {
+                    "name": target.name,
+                    "queue": queue_name or "",
+                    "enabled": target.enabled,
+                }
+                row.update(
+                    {
+                        key: capability_text(value)
+                        for key, value in capabilities.items()
+                    }
+                )
+                rows.append(row)
+        declared = {key for row in rows for key in row} - {"name", "queue", "enabled"}
+        # FIT_ORDER first because that is the order `--fit` costs them in, then
+        # whatever else the fleet declares, alphabetically.
+        columns = [key for key in FIT_ORDER if key in declared] + sorted(
+            declared - set(FIT_ORDER)
+        )
+        for row in rows:
+            for key in columns:
+                row.setdefault(key, "")
+        emit_rows(
+            rows,
+            ["name", "queue", "enabled", *columns],
+            as_json=bool(args.json),
+        )
+        return 0
+
     if args.format == "ssh-hosts":
         for target in sorted(context.targets.values(), key=lambda item: item.name):
             if not target.enabled:
                 continue
-            if args.tag and args.tag not in target.tags:
+            if not shown(target):
                 continue
             print(f"fleet:{target.name}")
         return 0
@@ -4014,7 +4693,7 @@ def command_list(args: argparse.Namespace, context: FleetContext) -> int:
         carried = reach_dependents(context)
         rows = []
         for target in sorted(context.targets.values(), key=lambda item: item.name):
-            if args.tag and args.tag not in target.tags:
+            if not shown(target):
                 continue
             rows.append(
                 {
@@ -4039,7 +4718,7 @@ def command_list(args: argparse.Namespace, context: FleetContext) -> int:
 
     rows = []
     for target in sorted(context.targets.values(), key=lambda item: item.name):
-        if args.tag and args.tag not in target.tags:
+        if not shown(target):
             continue
         protocol = context.resolve_protocol(target)
         rows.append(
@@ -4161,7 +4840,12 @@ def command_queue_list(args: argparse.Namespace, context: FleetContext) -> int:
 
 def command_resolve(args: argparse.Namespace, context: FleetContext) -> int:
     """Resolve one pool or project binding to a concrete target name."""
-    target, _binding = context.resolve_target(args.selector, cwd=Path.cwd())
+    target, _binding = context.resolve_target(
+        args.selector,
+        cwd=Path.cwd(),
+        requirements=parse_requirements(getattr(args, "require", None) or ()),
+        fit=bool(getattr(args, "fit", False)),
+    )
     if args.json:
         emit({"target": target.name}, as_json=True)
     else:
@@ -4205,6 +4889,13 @@ def command_import_ssh(args: argparse.Namespace, context: FleetContext) -> int:
         secret_backend="file",
         secret_ref=str(secret_path),
         default_profile=args.profile or "plain-ssh",
+        capabilities=parse_capabilities(
+            dict(
+                parse_assignment(item, flag="--capability")
+                for item in args.capability
+            ),
+            what=f"--capability for target {name!r}",
+        ),
     )
     write_text_file(target_path, target_to_toml(target), mode=PRIVATE_FILE_MODE)
     write_text_file(secret_path, secret_to_toml(secret), mode=PRIVATE_FILE_MODE)
@@ -5031,7 +5722,7 @@ def command_smoke(args: argparse.Namespace, context: FleetContext) -> int:
             " queues=\"$(sinfo -h -o '%P' | paste -sd, -)\";"
             " if [ -n \"$queues\" ]; then printf 'queues=%s\\n' \"$queues\"; fi;"
         )
-    elif protocol.smoke_gpu_probe:
+    elif not declares_no_gpu(target):
         smoke_body += (
             " if command -v nvidia-smi >/dev/null 2>&1; then"
             " nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader;"
@@ -5356,7 +6047,13 @@ def command_submit(args: argparse.Namespace, context: FleetContext) -> int:
             "so the scheduler receives the site-native batch script unchanged"
         )
     ensure_job_id_pattern(profile)
-    queue = resolve_queue(protocol, args.queue)
+    queue = plan.queue
+    if queue is None:
+        raise FleetError(
+            f"internal error: no queue resolved for {target.name!r}. plan_queue() "
+            "and this branch disagree about which submit path this is; they are "
+            "meant to test the same three conditions in the same order."
+        )
     remote_script = (
         planned_script_path(profile, local_script)
         if args.dry_run
@@ -5628,15 +6325,35 @@ def command_explain(args: argparse.Namespace, context: FleetContext) -> int:
     use, so this is also the debugging story for "why did it pick that?".
     """
     selector = context.normalize_selector(args.selector)
-    target, binding = context.resolve_target(selector, cwd=Path.cwd())
+    requirements = parse_requirements(getattr(args, "require", None) or ())
+    fit = bool(getattr(args, "fit", False))
+    target, binding = context.resolve_target(
+        selector, cwd=Path.cwd(), requirements=requirements, fit=fit
+    )
     protocol = context.resolve_protocol(target)
+    profile = context.resolve_profile(target, binding, args.profile)
+    plan_verb = args.verb or "explain"
+    queue: QueueRecord | None = None
+    queue_problem: str | None = None
+    try:
+        queue = plan_queue(
+            args,
+            verb=plan_verb,
+            target=target,
+            protocol=protocol,
+            profile=profile,
+            requirements=requirements,
+            fit=fit,
+        )
+    except FleetError as error:
+        queue_problem = str(error)
     plan = Plan(
-        verb=args.verb or "explain",
+        verb=plan_verb,
         context=context,
         target=target,
         binding=binding,
         protocol=protocol,
-        profile=context.resolve_profile(target, binding, args.profile),
+        profile=profile,
         cwd=resolve_remote_root(target, binding, args.cwd),
         selector=selector,
         pool=context.pools.get(selector) if selector else None,
@@ -5646,6 +6363,8 @@ def command_explain(args: argparse.Namespace, context: FleetContext) -> int:
             getattr(args, "route", None),
             no_fallback=bool(getattr(args, "no_fallback", False)),
         ),
+        queue=queue,
+        requirements=requirements,
     )
     role = resolve_role(target, protocol)
     payload = plan.describe()
@@ -5657,7 +6376,14 @@ def command_explain(args: argparse.Namespace, context: FleetContext) -> int:
     payload["route_last_used"] = (
         last_used.get("route") if isinstance(last_used, dict) else None
     )
-    payload["queues"] = [queue.name for queue in protocol.queues]
+    payload["queues"] = [item.name for item in protocol.queues]
+    payload["queue_problem"] = queue_problem
+    # Every surface a requirement could match here, which is one per partition on
+    # a scheduler and exactly one otherwise.
+    payload["capabilities"] = [
+        {"queue": name, "capabilities": capabilities}
+        for name, capabilities in context.selectable_capabilities(target)
+    ]
     payload["admission"] = {
         verb: DECISION_LABELS[ROLE_MATRIX[role][VERBS.index(verb)]]
         for verb in (VERBS if args.verb is None else (args.verb,))
@@ -5782,6 +6508,18 @@ def command_doctor(args: argparse.Namespace) -> int:
                 warnings.append(
                     f"target {target.name!r} uses Slurm protocol {protocol.name!r} "
                     "without any queue presets"
+                )
+            warnings.extend(
+                capability_key_warnings(
+                    f"target {target.name!r}", target.capabilities
+                )
+            )
+            for queue in protocol.queues:
+                warnings.extend(
+                    capability_key_warnings(
+                        f"protocol {protocol.name!r} queue {queue.name!r}",
+                        queue.capabilities,
+                    )
                 )
 
         # A pool that cannot be selected from is a pool that aborts the first
@@ -6094,7 +6832,96 @@ DEPRECATED
     `[ssh_option]` ProxyJump entry.
 
 SEE ALSO
-    fleetctl help roles, fleetctl help secrets, fleetctl help config
+    fleetctl help roles, fleetctl help capabilities, fleetctl help config
+""",
+    "capabilities": """\
+NAME
+    fleetctl capabilities - what a machine has, and how to ask for it
+
+SYNOPSIS
+    # targets.d/<target>.toml
+    [capabilities]
+    arch      = "x86_64"
+    gpu_model = "RTX 3090"
+    gpu_count = 1
+    vram_gb   = 24
+    cpus      = 16
+    mem_gb    = 64
+
+    fleetctl list --format capabilities
+    fleetctl <verb> --require 'vram_gb>=24,gpu_count>=1' [--fit]
+
+DESCRIPTION
+    `role` is a boundary: it says what may be done at all. Capabilities
+    are the layer above it, and they only ever choose between hosts
+    that the boundary already allows. Keeping them apart is deliberate
+    -- attribute matching cannot express a boundary, and a boundary
+    cannot express "which of these will fit".
+
+    Any key you like. `{FIT_KEYS}` are compared as
+    numbers and must be non-negative; everything else is compared as
+    text. The vocabulary is open because a fleet grows in variety, and
+    this is the one place in the config where an unknown key is not an
+    error -- a misspelled capability fails closed, so
+    `--require vram_bg>=24` simply matches nothing and says so.
+    `fleetctl doctor` still names a key that looks like a typo.
+
+REQUIREMENTS
+    `--require key<op>value`, repeatable and comma-separated within one
+    flag. Operators: >= <= > < = == !=. Every clause carries one; there
+    is no bare-key form, because `--fit lab-gpu` would be ambiguous
+    with a target name.
+
+    An undeclared capability never satisfies a requirement. An unknown
+    is not a yes, and reading it as one is how a job lands on a machine
+    that cannot run it.
+
+    A requirement narrows a choice; it never moves work. Against a name
+    -- a target you passed, or one a project binding supplied -- it is
+    a check that refuses with the exact mismatch. Against a set -- a
+    pool, or the whole fleet when nothing else named anything -- it is
+    a filter. So a typo in a capability can stop a command, but it can
+    never redirect one.
+
+    `--fit` breaks a tie by taking the smallest sufficient candidate:
+    fewest {FIT_KEYS}, then by name. An
+    undeclared key sorts last, so `--fit` prefers a machine known to be
+    big enough over one that might be. Without `--fit`, an ambiguous
+    fleet-wide match is refused rather than resolved alphabetically.
+
+SCHEDULERS
+    On a Slurm site the hardware a job gets belongs to the partition,
+    not to the login node you SSH into. So a queue carries its own
+    block:
+
+        [[queue]]
+        name = "mi210"
+        partition = "GPU"
+          [queue.capabilities]
+          gpu_model = "MI210"
+          vram_gb = 64
+
+    A queue's capabilities layer over the target's, and the target
+    satisfies a requirement when any of its queues does. `--require`
+    then filters the partitions too, and `--fit` picks the smallest
+    sufficient one, so a one-GPU job stops booking the eight-GPU
+    partition.
+
+PREFLIGHT
+    `--gpus` is checked against declared `gpu_count` and
+    `--cpus-per-task` against `cpus` before anything connects. Nothing
+    declared is not a refusal here -- you named the machine, and
+    requiring a declaration first would make capabilities a migration
+    rather than a feature. `--mem` is deliberately not checked: its
+    units are scheduler-specific, and a wrong parse would refuse a
+    valid job.
+
+    Declared values are authoritative and nothing is measured. What a
+    machine has is a fact its owner writes down, not something probed
+    at selection time and already stale.
+
+SEE ALSO
+    fleetctl help roles, fleetctl help jobs, fleetctl help config
 """,
     "config": """\
 NAME
@@ -6142,7 +6969,7 @@ VALIDATION
     carrying a deprecated key, and never prints its value.
 
 SEE ALSO
-    fleetctl help secrets, fleetctl help reach, fleetctl help verbs
+    fleetctl help secrets, fleetctl help reach, fleetctl help capabilities
 """,
     "secrets": """\
 NAME
@@ -6284,8 +7111,14 @@ DESCRIPTION
         fleetctl doctor
         fleetctl doctor --probe
 
+    Pick a machine by what it has rather than by name, smallest
+    sufficient one first:
+        fleetctl list --format capabilities
+        fleetctl resolve --require 'vram_gb>=24,gpu_count>=1' --fit
+        fleetctl submit train.sh --require 'vram_gb>=40' --fit
+
 SEE ALSO
-    fleetctl help verbs, fleetctl help reach, fleetctl help jobs
+    fleetctl help verbs, fleetctl help capabilities, fleetctl help jobs
 """,
 }
 
@@ -6340,6 +7173,7 @@ def render_manual(topic: str) -> str:
         .replace("{ADMISSION_TABLE}", render_admission_table())
         .replace("{VERB_TABLE}", render_verb_table())
         .replace("{TOPIC_LIST}", "  ".join(MANUAL_TOPICS))
+        .replace("{FIT_KEYS}", ", ".join(FIT_ORDER))
         .rstrip()
     )
 
@@ -6364,6 +7198,32 @@ def add_route_flag(parser: argparse.ArgumentParser) -> None:
     )
 
 
+def add_capability_flags(parser: argparse.ArgumentParser) -> None:
+    """Register `--require` and `--fit`, the soft layer above `role`.
+
+    Attached to every verb that opens a connection, plus `list`, `resolve` and
+    `explain`, so the question and the answer use the same words.
+    """
+    parser.add_argument(
+        "--require",
+        action="append",
+        metavar="KEY<OP>VALUE",
+        help=(
+            "Only accept a declared capability, e.g. `vram_gb>=24`. Repeatable, "
+            "and comma-separated within one flag. Absence never satisfies."
+        ),
+    )
+    parser.add_argument(
+        "--fit",
+        action="store_true",
+        help=(
+            "Take the smallest sufficient candidate: fewest "
+            + ", then ".join(FIT_ORDER)
+            + ", then by name"
+        ),
+    )
+
+
 def add_connection_flags(parser: argparse.ArgumentParser) -> None:
     """Register the flags every verb that opens a connection carries.
 
@@ -6377,6 +7237,7 @@ def add_connection_flags(parser: argparse.ArgumentParser) -> None:
         help="Acknowledge a control-plane action on a role that repels this verb",
     )
     add_route_flag(parser)
+    add_capability_flags(parser)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -6420,11 +7281,15 @@ def build_parser() -> argparse.ArgumentParser:
     list_parser.add_argument("--json", action="store_true", help="Emit JSON")
     list_parser.add_argument(
         "--format",
-        choices=["table", "ssh-hosts", "topology"],
+        choices=["table", "ssh-hosts", "topology", "capabilities"],
         default="table",
-        help="Output format; `topology` reports routes and what each bridge carries",
+        help=(
+            "Output format; `topology` reports routes and what each bridge "
+            "carries, `capabilities` one row per selectable surface"
+        ),
     )
     list_parser.add_argument("--tag", help="Filter by one target tag")
+    add_capability_flags(list_parser)
     list_parser.set_defaults(handler=command_list)
 
     show_parser = subparsers.add_parser("show", help="Show one target or pool")
@@ -6480,6 +7345,7 @@ def build_parser() -> argparse.ArgumentParser:
     resolve_parser = subparsers.add_parser("resolve", help="Resolve a selector to a target")
     resolve_parser.add_argument("selector", nargs="?", help="Target or pool name")
     resolve_parser.add_argument("--json", action="store_true", help="Emit JSON")
+    add_capability_flags(resolve_parser)
     resolve_parser.set_defaults(handler=command_resolve)
 
     project_parser = subparsers.add_parser("project", help="Manage project bindings")
@@ -6628,6 +7494,17 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         default=[],
         help="Tag to attach to the imported target",
+    )
+    import_ssh_parser.add_argument(
+        "--capability",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help=(
+            "Declare one capability, e.g. `vram_gb=24`. Repeatable. "
+            + ", ".join(FIT_ORDER)
+            + " must be non-negative numbers; any other key is yours to name."
+        ),
     )
     import_ssh_parser.add_argument(
         "--profile",
@@ -6909,6 +7786,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Show the plan as it would resolve with --admin",
     )
     add_route_flag(explain_parser)
+    add_capability_flags(explain_parser)
     explain_parser.add_argument("--json", action="store_true", help="Emit JSON")
     explain_parser.set_defaults(handler=command_explain)
 

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -609,6 +609,96 @@ class FleetContext:
         )
 
 
+# ---- SECTION: resolution (config + args -> Plan, no remote I/O) ------------
+
+
+@dataclass(frozen=True)
+class Plan:
+    """Everything one verb needs to know about one host, resolved once.
+
+    Every host-touching verb used to walk this chain itself, in its own order,
+    with its own omissions: `sync` never resolved a profile, `ssh` never resolved
+    a remote cwd, and `job status` walked the whole chain twice -- once in the
+    handler and again inside run_job_command -- so one command could resolve two
+    different machines.  There is now one value, built once, which is also what
+    makes `--dry-run` honest: it prints the plan the verb is about to use rather
+    than a second guess at it.
+    """
+
+    verb: str
+    context: FleetContext
+    target: TargetRecord
+    binding: ProjectBinding | None
+    protocol: ProtocolRecord
+    profile: ProfileRecord
+    cwd: str | None
+    selector: str | None
+    pool: PoolRecord | None
+    admin: bool
+    _secret: FleetSecret | None = field(default=None, compare=False, repr=False)
+
+    @property
+    def secret(self) -> FleetSecret:
+        """TARGET's connection details, loaded on first use.
+
+        Resolution stays out of the secret store so that `explain` and
+        `--dry-run` can describe a `pass`-backed target without unlocking a gpg
+        agent; only code that actually opens a connection pays for it.
+        """
+        if self._secret is None:
+            object.__setattr__(
+                self, "_secret", self.context.resolve_secret(self.target)
+            )
+        return self._secret
+
+    def ssh_runtime(self) -> dict[str, Any]:
+        """Return the fleet-managed SSH settings for this plan."""
+        return ssh_runtime_kwargs(self.context)
+
+    def describe(self) -> dict[str, Any]:
+        """Report the plan as data, for `--dry-run`, `explain` and `--json`."""
+        return {
+            "verb": self.verb,
+            "selector": self.selector,
+            "pool": self.pool.name if self.pool is not None else None,
+            "target": self.target.name,
+            "role": self.target.role,
+            "protocol": self.protocol.name,
+            "protocol_kind": self.protocol.kind,
+            "profile": self.profile.name,
+            "submits": bool(self.profile.submit_command),
+            "remote_cwd": self.cwd,
+            "admin": self.admin,
+            "project": str(self.binding.path) if self.binding is not None else None,
+        }
+
+
+def build_plan(context: FleetContext, args: argparse.Namespace, verb: str) -> Plan:
+    """Resolve VERB against ARGS once, admission included, before anything runs.
+
+    The role matrix is consulted here rather than in each handler, so a new verb
+    cannot forget it: there is no way to obtain a Plan without passing admission
+    first, and no way to act on a host without a Plan.
+    """
+    selector = context.normalize_selector(getattr(args, "selector", None))
+    target, binding = context.resolve_target(selector, cwd=Path.cwd())
+    protocol = context.resolve_protocol(target)
+    admin = bool(getattr(args, "admin", False))
+    authorize(verb, target, protocol, admin=admin)
+    return Plan(
+        verb=verb,
+        context=context,
+        target=target,
+        binding=binding,
+        protocol=protocol,
+        profile=context.resolve_profile(target, binding, getattr(args, "profile", None)),
+        cwd=resolve_remote_root(target, binding, getattr(args, "cwd", None)),
+        selector=selector,
+        pool=context.pools.get(selector) if selector else None,
+        admin=admin,
+    )
+
+
 def build_paths(
     *,
     config_home: Path | None = None,
@@ -2140,6 +2230,23 @@ def remote_posix_join(base: str, name: str) -> str:
     return posixpath.join(base, name)
 
 
+def resolve_remote_path(value: str, *, base: str | None) -> str:
+    """Resolve one operator-supplied remote path against BASE.
+
+    Absolute stays absolute, `~/...` stays home-relative, and anything else
+    hangs off the target's remote root.  The call sites used to disagree: `sync`
+    read a relative remote path as remote-$HOME-relative while job output paths
+    read the same spelling as project-relative, so `--remote-path logs` and
+    `--output logs/run.out` named two different directories on one host in one
+    command.
+    """
+    if value.startswith("/") or value == "~" or value.startswith("~/"):
+        return value
+    if base is None:
+        return value
+    return remote_posix_join(base, value)
+
+
 def scp_remote_path(path: str) -> str:
     """Normalize a remote path for scp/sftp transports."""
     if path.startswith("~/"):
@@ -2282,21 +2389,14 @@ def resolve_job_output_paths(
         return None, None, None
     output_dir: str | None = None
     if base_root is not None:
-        if protocol.job_output_dir.startswith("/"):
-            output_dir = protocol.job_output_dir
-        else:
-            output_dir = remote_posix_join(base_root, protocol.job_output_dir)
+        output_dir = resolve_remote_path(protocol.job_output_dir, base=base_root)
 
     def resolve_one(value: str | None, fallback_name: str) -> str | None:
         if value is None:
             if output_dir is None:
                 return None
             return remote_posix_join(output_dir, fallback_name)
-        if value.startswith("/"):
-            return value
-        if base_root is None:
-            return value
-        return remote_posix_join(base_root, value)
+        return resolve_remote_path(value, base=base_root)
 
     output_path = resolve_one(output_override, "%j.out")
     error_path = resolve_one(error_override, "%j.err")
@@ -2916,15 +3016,10 @@ def update_project_binding(
     write_text_file(path, serialize_projects(filtered), mode=PRIVATE_FILE_MODE)
 
 
-def command_project_bind(args: argparse.Namespace) -> int:
+def command_project_bind(args: argparse.Namespace, context: FleetContext) -> int:
     """Bind one project path to a default target or pool."""
     if bool(args.target) == bool(args.pool):
         raise FleetError("pass exactly one of --target or --pool")
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
     ensure_private_dir(context.paths.config_home, mode=PRIVATE_DIR_MODE)
     write_text_if_missing(
         context.paths.projects_file,
@@ -2975,13 +3070,8 @@ def command_project_bind(args: argparse.Namespace) -> int:
     return 0
 
 
-def command_project_show(args: argparse.Namespace) -> int:
+def command_project_show(args: argparse.Namespace, context: FleetContext) -> int:
     """Show the effective project binding for one path."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
     project_path = expand_local_path(args.path or str(Path.cwd()))
     binding = context.project_binding_for(project_path)
     if binding is None:
@@ -2999,13 +3089,8 @@ def command_project_show(args: argparse.Namespace) -> int:
     return 0
 
 
-def command_project_list(args: argparse.Namespace) -> int:
+def command_project_list(args: argparse.Namespace, context: FleetContext) -> int:
     """List all configured project bindings."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
     rows = [
         {
             "path": str(binding.path),
@@ -3038,12 +3123,11 @@ def command_project_list(args: argparse.Namespace) -> int:
 
 def command_init(args: argparse.Namespace) -> int:
     """Create the local private fleet directory layout."""
-    context = FleetContext.load(
+    paths = build_paths(
         config_home=args.config_home,
         state_home=args.state_home,
         cache_home=args.cache_home,
     )
-    paths = context.paths
     ensure_private_dir(paths.config_home, mode=PRIVATE_DIR_MODE)
     ensure_private_dir(paths.targets_dir, mode=PRIVATE_DIR_MODE)
     ensure_private_dir(paths.pools_dir, mode=PRIVATE_DIR_MODE)
@@ -3088,13 +3172,8 @@ def command_init(args: argparse.Namespace) -> int:
     return 0
 
 
-def command_list(args: argparse.Namespace) -> int:
+def command_list(args: argparse.Namespace, context: FleetContext) -> int:
     """List configured targets."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
     if args.format == "ssh-hosts":
         for target in sorted(context.targets.values(), key=lambda item: item.name):
             if not target.enabled:
@@ -3143,13 +3222,8 @@ def command_list(args: argparse.Namespace) -> int:
     return 0
 
 
-def command_show(args: argparse.Namespace) -> int:
+def command_show(args: argparse.Namespace, context: FleetContext) -> int:
     """Show one target or pool with optional secret preview."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
     selector = context.normalize_selector(args.selector)
     payload: dict[str, Any]
 
@@ -3197,13 +3271,8 @@ def command_show(args: argparse.Namespace) -> int:
     return 0
 
 
-def command_protocol_show(args: argparse.Namespace) -> int:
+def command_protocol_show(args: argparse.Namespace, context: FleetContext) -> int:
     """Show the resolved protocol for one target, pool, or protocol name."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
     selector = context.normalize_selector(args.selector)
     payload: dict[str, Any]
     if selector in context.protocols:
@@ -3220,13 +3289,8 @@ def command_protocol_show(args: argparse.Namespace) -> int:
     return 0
 
 
-def command_queue_list(args: argparse.Namespace) -> int:
+def command_queue_list(args: argparse.Namespace, context: FleetContext) -> int:
     """List the queue presets for one target, pool, or protocol."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
     selector = context.normalize_selector(args.selector)
     if selector in context.protocols:
         protocol = context.protocols[selector]
@@ -3256,13 +3320,8 @@ def command_queue_list(args: argparse.Namespace) -> int:
     return 0
 
 
-def command_resolve(args: argparse.Namespace) -> int:
+def command_resolve(args: argparse.Namespace, context: FleetContext) -> int:
     """Resolve one pool or project binding to a concrete target name."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
     target, _binding = context.resolve_target(args.selector, cwd=Path.cwd())
     if args.json:
         print(json.dumps({"target": target.name}, indent=2))
@@ -3271,13 +3330,8 @@ def command_resolve(args: argparse.Namespace) -> int:
     return 0
 
 
-def command_import_ssh(args: argparse.Namespace) -> int:
+def command_import_ssh(args: argparse.Namespace, context: FleetContext) -> int:
     """Import one existing local SSH alias into private fleet config."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
     ensure_private_dir(context.paths.config_home, mode=PRIVATE_DIR_MODE)
     ensure_private_dir(context.paths.targets_dir, mode=PRIVATE_DIR_MODE)
     ensure_private_dir(context.paths.secrets_dir, mode=PRIVATE_DIR_MODE)
@@ -3323,13 +3377,8 @@ def command_import_ssh(args: argparse.Namespace) -> int:
     return 0
 
 
-def command_migrate_env(args: argparse.Namespace) -> int:
+def command_migrate_env(args: argparse.Namespace, context: FleetContext) -> int:
     """Import env-based remote config into private fleet state."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
     ensure_private_dir(context.paths.config_home, mode=PRIVATE_DIR_MODE)
     ensure_private_dir(context.paths.targets_dir, mode=PRIVATE_DIR_MODE)
     ensure_private_dir(context.paths.secrets_dir, mode=PRIVATE_DIR_MODE)
@@ -3433,13 +3482,8 @@ def required_env_field(env: dict[str, str], prefix: str, machine: str, field: st
     return value
 
 
-def command_seed_pass(args: argparse.Namespace) -> int:
+def command_seed_pass(args: argparse.Namespace, context: FleetContext) -> int:
     """Seed pass entries from the current live fleet config."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
     prefix = args.pass_prefix.strip("/")
     if not prefix:
         raise FleetError("`--pass-prefix` must not be empty")
@@ -4001,40 +4045,26 @@ def command_deploy_config(args: argparse.Namespace) -> int:
         print(live.config_home)
     return 0
 
-def command_ssh(args: argparse.Namespace) -> int:
+def command_ssh(args: argparse.Namespace, context: FleetContext) -> int:
     """Open one interactive SSH session."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
-    target, _binding = context.resolve_target(args.selector, cwd=Path.cwd())
-    authorize("ssh", target, context.resolve_protocol(target), admin=bool(args.admin))
-    secret = context.resolve_secret(target)
+    plan = build_plan(context, args, "ssh")
     completed = run_ssh_command(
-        secret,
+        plan.secret,
         allocate_tty=True,
         remote_command=None,
-        **ssh_runtime_kwargs(context),
+        **plan.ssh_runtime(),
     )
     return completed.returncode
 
 
-def command_smoke(args: argparse.Namespace) -> int:
+def command_smoke(args: argparse.Namespace, context: FleetContext) -> int:
     """Run a lightweight connectivity check."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
-    target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
-    protocol = context.resolve_protocol(target)
     # `smoke` only reports on the host, so it rides the same rule as `ssh`.
-    authorize("ssh", target, protocol, admin=bool(args.admin))
-    secret = context.resolve_secret(target)
-    profile = context.resolve_profile(target, binding, args.profile)
+    plan = build_plan(context, args, "ssh")
+    target = plan.target
+    protocol = plan.protocol
     workdir = target.workdir
-    project_root = resolve_remote_root(target, binding, args.cwd)
+    project_root = plan.cwd
     prelude = ""
     if workdir:
         quoted_workdir = shlex.quote(workdir)
@@ -4104,12 +4134,12 @@ def command_smoke(args: argparse.Namespace) -> int:
         smoke_body,
     ]
     completed = run_ssh_command(
-        secret,
+        plan.secret,
         allocate_tty=False,
         remote_command=remote_shell_command(smoke_argv),
         capture_output=True,
         timeout=CONTROL_COMMAND_TIMEOUT,
-        **ssh_runtime_kwargs(context),
+        **plan.ssh_runtime(),
     )
     if completed.stdout:
         print(completed.stdout, end="")
@@ -4123,13 +4153,8 @@ def command_smoke(args: argparse.Namespace) -> int:
     return 0
 
 
-def command_exec(args: argparse.Namespace) -> int:
+def command_exec(args: argparse.Namespace, context: FleetContext) -> int:
     """Run one argv vector remotely without shell interpretation of the user payload."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
     # The positional is always a selector and the command always follows `--`.
     # Guessing between the two meant `fleetctl exec htop` silently ran htop on
     # whatever the current directory happened to be bound to.
@@ -4139,19 +4164,14 @@ def command_exec(args: argparse.Namespace) -> int:
             f"two targets named: {args.selector!r} positionally and "
             f"{args.selector_override!r} via --target; the command goes after `--`"
         )
-    selector = args.selector_override or args.selector
+    args.selector = args.selector_override or args.selector
     if not argv:
         raise FleetError(
             "`fleetctl exec` requires a command after `--`, as in "
             "`fleetctl exec rtx1 -- nvidia-smi`"
         )
-    target, binding = context.resolve_target(selector, cwd=Path.cwd())
-    protocol = context.resolve_protocol(target)
-    authorize("exec", target, protocol, admin=bool(args.admin))
-    secret = context.resolve_secret(target)
-    profile = context.resolve_profile(target, binding, args.profile)
-    cwd = resolve_remote_root(target, binding, args.cwd)
-    environment = dict(profile.environment)
+    plan = build_plan(context, args, "exec")
+    environment = dict(plan.profile.environment)
     encoded_stub = base64.b64encode(EXEC_REMOTE_STUB.encode("utf-8")).decode("ascii")
     payload = base64.b64encode(
         json.dumps(
@@ -4163,68 +4183,75 @@ def command_exec(args: argparse.Namespace) -> int:
     ).decode("ascii")
     remote = remote_shell_command(
         ["python3", "-c", EXEC_REMOTE_BOOTSTRAP, encoded_stub, payload],
-        cwd=cwd,
+        cwd=plan.cwd,
     )
     completed = run_ssh_command(
-        secret,
+        plan.secret,
         allocate_tty=bool(args.tty),
         remote_command=remote,
-        **ssh_runtime_kwargs(context),
+        **plan.ssh_runtime(),
     )
     return completed.returncode
 
 
-def command_script(args: argparse.Namespace) -> int:
-    """Upload and run one local script on a target."""
-    local_script = Path(args.local_script).expanduser().resolve()
-    if not local_script.is_file():
-        raise FleetError(f"missing local script: {local_script}")
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
-    target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
-    protocol = context.resolve_protocol(target)
-    authorize("script", target, protocol, admin=bool(args.admin))
-    secret = context.resolve_secret(target)
-    profile = context.resolve_profile(target, binding, args.profile)
-    ssh_runtime = ssh_runtime_kwargs(context)
+def run_script_plan(
+    plan: Plan,
+    local_script: Path,
+    *,
+    interpreter: str | None,
+    script_args: list[str],
+    tty: bool,
+) -> int:
+    """Stage LOCAL_SCRIPT on PLAN's target and run it there."""
+    secret = plan.secret
+    ssh_runtime = plan.ssh_runtime()
     remote_script = stage_remote_script(
         secret,
-        profile,
+        plan.profile,
         local_script,
         ssh_runtime=ssh_runtime,
     )
-    cwd = resolve_remote_root(target, binding, args.cwd)
-    interpreter = args.interpreter or profile.interpreter
-    argv = []
-    if interpreter:
-        argv.extend(shlex.split(interpreter))
+    argv: list[str] = []
+    chosen = interpreter or plan.profile.interpreter
+    if chosen:
+        argv.extend(shlex.split(chosen))
     argv.append(remote_script)
-    argv.extend(args.script_args)
-    argv = prefixed_env_command(argv, profile.environment)
+    argv.extend(script_args)
+    argv = prefixed_env_command(argv, plan.profile.environment)
     completed = run_ssh_command(
         secret,
-        allocate_tty=bool(args.tty),
-        remote_command=remote_shell_command(argv, cwd=cwd),
+        allocate_tty=tty,
+        remote_command=remote_shell_command(argv, cwd=plan.cwd),
         **ssh_runtime,
     )
     return completed.returncode
 
 
-def command_sync(args: argparse.Namespace) -> int:
-    """Push or pull files with rsync."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
+def command_script(args: argparse.Namespace, context: FleetContext) -> int:
+    """Upload and run one local script on a target."""
+    local_script = Path(args.local_script).expanduser().resolve()
+    if not local_script.is_file():
+        raise FleetError(f"missing local script: {local_script}")
+    return run_script_plan(
+        build_plan(context, args, "script"),
+        local_script,
+        interpreter=args.interpreter,
+        script_args=args.script_args,
+        tty=bool(args.tty),
     )
-    target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
-    authorize("sync", target, context.resolve_protocol(target), admin=bool(args.admin))
-    secret = context.resolve_secret(target)
-    ssh_runtime = ssh_runtime_kwargs(context)
-    default_remote = args.remote_path or resolve_remote_root(target, binding)
+
+
+def command_sync(args: argparse.Namespace, context: FleetContext) -> int:
+    """Push or pull files with rsync."""
+    plan = build_plan(context, args, "sync")
+    target = plan.target
+    secret = plan.secret
+    ssh_runtime = plan.ssh_runtime()
+    default_remote = (
+        resolve_remote_path(args.remote_path, base=plan.cwd)
+        if args.remote_path
+        else plan.cwd
+    )
     if not default_remote:
         raise FleetError(
             f"no remote path for {target.name!r}: the target defines no `workdir` and "
@@ -4240,8 +4267,8 @@ def command_sync(args: argparse.Namespace) -> int:
         )
 
     excludes = list(DEFAULT_SYNC_EXCLUDES)
-    if binding is not None:
-        excludes.extend(binding.sync_excludes)
+    if plan.binding is not None:
+        excludes.extend(plan.binding.sync_excludes)
 
     command = ["rsync", "-az"]
     if args.delete:
@@ -4282,23 +4309,18 @@ def command_sync(args: argparse.Namespace) -> int:
     return completed.returncode
 
 
-def command_submit(args: argparse.Namespace) -> int:
+def command_submit(args: argparse.Namespace, context: FleetContext) -> int:
     """Submit or launch a script according to its profile."""
     local_script = Path(args.local_script).expanduser().resolve()
     if not local_script.is_file():
         raise FleetError(f"missing local script: {local_script}")
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
-    target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
-    protocol = context.resolve_protocol(target)
-    authorize("submit", target, protocol, admin=bool(args.admin))
-    secret = context.resolve_secret(target)
-    profile = context.resolve_profile(target, binding, args.profile)
-    ssh_runtime = ssh_runtime_kwargs(context)
-    cwd = resolve_remote_root(target, binding, args.cwd)
+    plan = build_plan(context, args, "submit")
+    target = plan.target
+    protocol = plan.protocol
+    profile = plan.profile
+    secret = plan.secret
+    ssh_runtime = plan.ssh_runtime()
+    cwd = plan.cwd
 
     # Two paths, and the profile itself says which: a profile submits if and only
     # if it defines `submit_command`.  Dispatching on a separate `profile.kind`
@@ -4316,20 +4338,13 @@ def command_submit(args: argparse.Namespace) -> int:
                 f"{target.name!r}; there is no scheduler to allocate resources"
             ),
         )
-        namespace = argparse.Namespace(
-            config_home=args.config_home,
-            state_home=args.state_home,
-            cache_home=args.cache_home,
-            selector=target.name,
-            profile=profile.name,
-            cwd=cwd,
-            local_script=str(local_script),
+        return run_script_plan(
+            plan,
+            local_script,
             interpreter=args.interpreter,
             script_args=args.script_args,
-            admin=bool(args.admin),
             tty=False,
         )
-        return command_script(namespace)
 
     if args.native_batch:
         if args.script_args:
@@ -4371,7 +4386,7 @@ def command_submit(args: argparse.Namespace) -> int:
         local_script,
         ssh_runtime=ssh_runtime,
     )
-    job_base_root = protocol_base_root(target, binding, args.cwd)
+    job_base_root = protocol_base_root(target, plan.binding, args.cwd)
     output_dir, output_path, error_path = resolve_job_output_paths(
         protocol,
         base_root=job_base_root,
@@ -4421,32 +4436,24 @@ def command_submit(args: argparse.Namespace) -> int:
 
 
 def run_job_command(
-    args: argparse.Namespace,
+    plan: Plan,
     template: tuple[str, ...],
+    *,
+    job_id: str,
 ) -> int:
-    """Run one scheduler command from the current profile."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
-    target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
-    authorize("job", target, context.resolve_protocol(target), admin=bool(args.admin))
-    secret = context.resolve_secret(target)
-    profile = context.resolve_profile(target, binding, args.profile)
-    cwd = resolve_remote_root(target, binding, args.cwd)
+    """Run one scheduler command from PLAN's profile."""
     if not template:
         raise FleetError(
-            f"profile {profile.name!r} does not support this job operation"
+            f"profile {plan.profile.name!r} does not support this job operation"
         )
-    argv = render_template_values(template, job_id=args.job_id, workdir=cwd)
+    argv = render_template_values(template, job_id=job_id, workdir=plan.cwd)
     completed = run_ssh_command(
-        secret,
+        plan.secret,
         allocate_tty=False,
-        remote_command=remote_shell_command(argv, cwd=cwd),
+        remote_command=remote_shell_command(argv, cwd=plan.cwd),
         capture_output=True,
         timeout=CONTROL_COMMAND_TIMEOUT,
-        **ssh_runtime_kwargs(context),
+        **plan.ssh_runtime(),
     )
     if completed.stdout:
         print(completed.stdout, end="")
@@ -4455,40 +4462,22 @@ def run_job_command(
     return completed.returncode
 
 
-def command_job_status(args: argparse.Namespace) -> int:
+def command_job_status(args: argparse.Namespace, context: FleetContext) -> int:
     """Check remote scheduler status."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
-    target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
-    profile = context.resolve_profile(target, binding, args.profile)
-    return run_job_command(args, profile.status_command)
+    plan = build_plan(context, args, "job")
+    return run_job_command(plan, plan.profile.status_command, job_id=args.job_id)
 
 
-def command_job_logs(args: argparse.Namespace) -> int:
+def command_job_logs(args: argparse.Namespace, context: FleetContext) -> int:
     """Fetch remote scheduler logs."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
-    target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
-    profile = context.resolve_profile(target, binding, args.profile)
-    return run_job_command(args, profile.logs_command)
+    plan = build_plan(context, args, "job")
+    return run_job_command(plan, plan.profile.logs_command, job_id=args.job_id)
 
 
-def command_job_cancel(args: argparse.Namespace) -> int:
+def command_job_cancel(args: argparse.Namespace, context: FleetContext) -> int:
     """Cancel one remote scheduler job."""
-    context = FleetContext.load(
-        config_home=args.config_home,
-        state_home=args.state_home,
-        cache_home=args.cache_home,
-    )
-    target, binding = context.resolve_target(args.selector, cwd=Path.cwd())
-    profile = context.resolve_profile(target, binding, args.profile)
-    return run_job_command(args, profile.cancel_command)
+    plan = build_plan(context, args, "job")
+    return run_job_command(plan, plan.profile.cancel_command, job_id=args.job_id)
 
 
 def toml_syntax_problems(paths: FleetPaths) -> list[str]:
@@ -4769,7 +4758,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Populate example target, pool, and secret templates",
     )
-    init_parser.set_defaults(handler=command_init)
+    init_parser.set_defaults(handler=command_init, loads_own_config=True)
 
     list_parser = subparsers.add_parser("list", help="List configured targets")
     list_parser.add_argument("--json", action="store_true", help="Emit JSON")
@@ -4925,7 +4914,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print a short post-deploy summary after validation",
     )
-    deploy_config_parser.set_defaults(handler=command_deploy_config)
+    deploy_config_parser.set_defaults(handler=command_deploy_config, loads_own_config=True)
 
     migrate_config_parser = subparsers.add_parser(
         "migrate-config",
@@ -4954,7 +4943,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Print the migration and validate it, but leave the live config alone",
     )
-    migrate_config_parser.set_defaults(handler=command_migrate_config)
+    migrate_config_parser.set_defaults(handler=command_migrate_config, loads_own_config=True)
 
     import_ssh_parser = subparsers.add_parser(
         "import-ssh",
@@ -5241,7 +5230,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Also connect to every enabled target and check remote prerequisites",
     )
-    doctor_parser.set_defaults(handler=command_doctor)
+    doctor_parser.set_defaults(handler=command_doctor, loads_own_config=True)
 
     return parser
 
@@ -5272,7 +5261,18 @@ def main() -> int:
                 setattr(args, attribute, payload)
 
     try:
-        return int(args.handler(args))
+        # One load, one place.  There were twenty-four independent loads, which is
+        # how `job status` came to resolve its target twice in one invocation.
+        # The repair and diagnostic verbs opt out with `loads_own_config`: for
+        # those a broken config is the input, not a precondition.
+        if getattr(args, "loads_own_config", False):
+            return int(args.handler(args))
+        context = FleetContext.load(
+            config_home=args.config_home,
+            state_home=args.state_home,
+            cache_home=args.cache_home,
+        )
+        return int(args.handler(args, context))
     except FleetError as exc:
         parser.exit(exc.exit_code, f"error: {exc}\n")
     except KeyboardInterrupt:

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -498,6 +498,13 @@ class FleetContext:
     protocols: dict[str, ProtocolRecord]
     profiles: dict[str, ProfileRecord]
     projects: list[ProjectBinding]
+    # The route each target's control master actually came up over, this run only.
+    # Written where routes are chosen and read where a hop is rendered, so a
+    # bridge reached over its own fallback carries traffic on the socket that came
+    # up rather than the one declared first.  In memory and deliberately not in
+    # routes.json: a remembered route that outlived the process would pin later
+    # commands to the bridge, which is the opposite of preferring direct.
+    route_established: dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def load(
@@ -1302,8 +1309,12 @@ class Plan:
         """Bring up a route and return the SSH settings that use it.
 
         The one boundary between describing a plan and acting on one: `explain`
-        and `--dry-run` call `ssh_runtime` and never touch a network, while every
-        host-touching verb calls this and gets the route that came up.
+        and every `--dry-run` but one call `ssh_runtime` and never touch a
+        network, while every host-touching verb calls this and gets the route that
+        came up.  The exception is `sync --dry-run`, which connects here like any
+        other sync and hands the dry run to rsync -- the one honestly remote dry
+        run in the file, and the reason this cannot be written as "`--dry-run`
+        never connects".
         """
         ensure_route(self)
         return self.ssh_runtime()
@@ -2477,10 +2488,30 @@ CONTROL_CHECK_TIMEOUT = 10.0
 
 # A unix domain socket path cannot exceed 104 bytes on macOS or 108 on Linux, and
 # ssh reports the overflow as a bare "ControlPath too long" from wherever in a
-# ProxyCommand chain it happened -- which is not where anyone looks. `%C` expands
-# to a 40-character hash, so the length is predictable enough to refuse up front.
+# ProxyCommand chain it happened -- which is not where anyone looks, so the
+# length is worth refusing before anything connects.
+#
+# `%C` is the only token whose expansion has a fixed width, and budgeting it
+# alone was the bug: `%h`, `%r`, `%p`, `%l`, `%n` and `%u` were each charged the
+# two literal bytes they occupy, so a control_path of `mux/%h-%r` measured 9 and
+# expanded to whatever the hostname and account happened to be.  Every token is
+# now budgeted at the widest it can plausibly get.  The asymmetry is deliberate:
+# an over-estimate costs one config edit that the message names, while an
+# under-estimate costs exactly the failure this guard exists to prevent.
 CONTROL_PATH_LIMIT = 100
 CONTROL_PATH_HASH_WIDTH = 40
+CONTROL_PATH_TOKEN_WIDTHS = {
+    "%C": CONTROL_PATH_HASH_WIDTH,
+    "%h": 64,  # remote host, as connected to
+    "%n": 64,  # remote host, as it was written on the command line
+    "%l": 64,  # local host, fully qualified
+    "%d": 64,  # local home directory
+    "%L": 32,  # local host, first label only
+    "%r": 32,  # remote user
+    "%u": 32,  # local user
+    "%i": 10,  # local uid
+    "%p": 5,  # port
+}
 SUBMIT_COMMAND_TIMEOUT = 120.0
 PASS_COMMAND_TIMEOUT = 120.0
 
@@ -2862,6 +2893,27 @@ def route_connect_timeout(route: str) -> int:
     return BRIDGE_CONNECT_TIMEOUT
 
 
+def control_path_width(path: str) -> int:
+    """Return the widest PATH can get once ssh expands its percent tokens.
+
+    Scanned rather than counted, because `%%` is a literal percent: counting
+    occurrences of `%h` would read the `h` in `%%h` as a hostname and inflate a
+    path that is already safe.  An unknown token is charged its two literal
+    bytes, since ssh rejects it by name long before its length matters.
+    """
+    width = 0
+    index = 0
+    while index < len(path):
+        if path[index] != "%" or index + 1 >= len(path):
+            width += 1
+            index += 1
+            continue
+        token = path[index : index + 2]
+        width += 1 if token == "%%" else CONTROL_PATH_TOKEN_WIDTHS.get(token, 2)
+        index += 2
+    return width
+
+
 def route_control_path(control_path: str, route: str) -> str:
     """Return the control socket that belongs to ROUTE.
 
@@ -2874,10 +2926,10 @@ def route_control_path(control_path: str, route: str) -> str:
     bridge = route_bridge(route)
     token = ROUTE_DIRECT if bridge is None else f"via-{bridge}"
     path = f"{control_path}-{token}"
-    expanded = len(path) + path.count("%C") * (CONTROL_PATH_HASH_WIDTH - 2)
+    expanded = control_path_width(path)
     if expanded > CONTROL_PATH_LIMIT:
         raise FleetError(
-            f"the control socket for route {route!r} would be {expanded} bytes, "
+            f"the control socket for route {route!r} can expand to {expanded} bytes, "
             f"over the {CONTROL_PATH_LIMIT} a unix socket allows: shorten "
             '`control_path` under [ssh] in config.toml, e.g. "~/.cache/fleet/m/%C"'
         )
@@ -2932,9 +2984,15 @@ def build_proxy_command(
             "Give the bridge a key -- it is the host every other host is reached "
             "through."
         )
-    # The bridge is reached over its own first route and gets that route's
-    # socket: a bridge behind a bridge is the same problem one level down.
-    bridge_route = bridge.reach[0] if bridge.reach else ROUTE_DIRECT
+    # Which route the bridge is reached over is not decided here.  This function
+    # renders a command and has to stay printable offline -- `explain` and every
+    # `--dry-run` call it -- so it reads the choice establish_route made and
+    # recorded, and falls back to the bridge's first declared route while no
+    # master exists yet.  A bridge behind a bridge is the same problem one level
+    # down, and gets the same answer.
+    bridge_route = context.route_established.get(bridge_name) or (
+        bridge.reach[0] if bridge.reach else ROUTE_DIRECT
+    )
     parts = ["ssh", "-W", "%h:%p", "-p", str(secret.port)]
     parts += [
         escape_ssh_percent(part)
@@ -3252,12 +3310,20 @@ def open_control_master(
     """Bring up a background control master over ROUTE; return None on success.
 
     `-N -f` backgrounds after authentication rather than before, so a key
-    passphrase or a 2FA prompt is still answerable -- BatchMode stays unset here
-    for the same reason it is unset everywhere else in this file, which is why
+    passphrase or a 2FA prompt is still answerable when there is a terminal to
+    answer on -- and when there is not, ssh_option_parts has already set
+    `BatchMode=yes`, which turns a silent hang into a fast failure.  Either way
     the subprocess deadline is generous while ConnectTimeout is not.
-    ControlMaster is left at `auto` rather than forced to `yes`, so two fleetctl
-    processes racing for one socket share the winner instead of the loser failing
-    with "ControlSocket already exists".
+
+    ControlMaster is forced to `yes` here, against the `auto` every other
+    invocation in this file shares, and that is the whole point of the option.
+    Under `auto` the loser of a race between two fleetctl processes is told the
+    socket already exists, drops multiplexing and carries on as a plain
+    connection -- which, with `-N -f` and no socket to persist into, is a
+    background ssh that nothing will ever reap and that exits 0.  So the loser
+    leaked a connection per race and reported success.  `yes` fails it instead,
+    and the caller re-checks the socket: what it lost to is a live master over
+    this same route, so losing the race is not failing.
     """
     command = build_ssh_command(
         secret,
@@ -3266,7 +3332,9 @@ def open_control_master(
         **runtime,
     )
     # Inserted ahead of the secret's own ConnectTimeout, because OpenSSH keeps the
-    # first value it is given for an option.
+    # first value it is given for an option.  ControlMaster rides the same rule to
+    # get ahead of the shared `auto`, and only when there is a socket to own: with
+    # multiplexing off, `yes` would be a claim about a socket that never exists.
     insert_at = len(ssh_transport_prefix(secret)) + 1
     command[insert_at:insert_at] = [
         "-N",
@@ -3274,6 +3342,8 @@ def open_control_master(
         "-o",
         f"ConnectTimeout={route_connect_timeout(route)}",
     ]
+    if runtime.get("control_path"):
+        command[insert_at:insert_at] = ["-o", "ControlMaster=yes"]
     completed = run_command(
         command,
         env=ssh_env(secret),
@@ -3283,7 +3353,16 @@ def open_control_master(
     if completed.returncode == 0:
         return None
     detail = (completed.stderr or "").strip().splitlines()
-    return detail[-1] if detail else f"ssh exited {completed.returncode}"
+    reason = detail[-1] if detail else f"ssh exited {completed.returncode}"
+    bridge = route_bridge(route)
+    if bridge is not None:
+        # A hop fails from the outer ssh's point of view, and that point of view
+        # has no names in it: the ProxyCommand is a pipe, so a dead bridge and a
+        # destination that the bridge cannot see both read "Connection to UNKNOWN
+        # port 65535 timed out".  Name the two ends of the link that did not come
+        # up, which is the least a reader needs to know where to look.
+        reason = f"{reason} [{secret.host} through bridge {bridge!r}]"
+    return reason
 
 
 def utc_timestamp() -> str:
@@ -3574,8 +3653,71 @@ def record_invocation(
         pass
 
 
-def ensure_route(plan: Plan) -> str:
-    """Bring up a control master for the first of PLAN's routes that works.
+def bring_up_control_master(
+    secret: FleetSecret, runtime: dict[str, Any], route: str
+) -> str | None:
+    """Make sure RUNTIME's master over ROUTE is live; return why not, or None.
+
+    One definition of failure, shared by the selector and by `doctor --probe`, so
+    the two cannot disagree about which routes carry.  The second check is the
+    race: two fleetctl processes reaching one host over one route both try to
+    open it, `ControlMaster=yes` fails the loser, and the socket the loser lost to
+    is the master it wanted.  Reading that as a failure moved the command onto the
+    bridge while a perfectly good direct master sat there serving the winner.
+    """
+    if control_master_alive(secret, runtime):
+        return None
+    failure = open_control_master(secret, runtime, route)
+    if failure is None:
+        return None
+    return None if control_master_alive(secret, runtime) else failure
+
+
+def establish_hop(
+    context: FleetContext, bridge_name: str, *, chain: tuple[str, ...] = ()
+) -> str | None:
+    """Bring up the master a hop through BRIDGE_NAME will ride on.
+
+    A bridge is reached the way anything else is -- its own `reach`, in declared
+    order, through the one function that owns route selection.  It used not to be:
+    the hop was rendered against the bridge's `reach[0]` and the ProxyCommand's
+    own ssh brought that master up as a side effect, so a bridge's fallback was
+    unreachable in the one situation it was declared for, and a bridge whose
+    direct path was down took every host behind it down with it.
+
+    Returns None when the hop is ready, or why it is not.  The reasons are the
+    bridge's own, because "the bridge came up on no route" and "the destination
+    is not visible from the bridge" are different faults with different fixes.
+    """
+    if bridge_name in chain:
+        raise FleetError("reach cycle: " + " -> ".join((*chain, bridge_name)))
+    bridge = context.targets.get(bridge_name)
+    if bridge is None:
+        raise FleetError(
+            f"route names unknown target {bridge_name!r}; run `fleetctl list`"
+        )
+    ensure_target_enabled(bridge)
+    route, failures = establish_route(
+        context,
+        bridge,
+        context.resolve_secret(bridge),
+        bridge.reach or DEFAULT_REACH,
+        chain=chain,
+    )
+    if route is not None:
+        return None
+    return f"bridge {bridge_name!r} came up on no route: " + ", ".join(failures)
+
+
+def establish_route(
+    context: FleetContext,
+    target: TargetRecord,
+    secret: FleetSecret,
+    routes: tuple[str, ...],
+    *,
+    chain: tuple[str, ...] = (),
+) -> tuple[str | None, list[str]]:
+    """Bring up a master for the first of ROUTES that works, and report the rest.
 
     Selection happens once per socket, not once per command.  A warm master means
     the route was chosen already and is still carrying traffic, so nothing is
@@ -3583,11 +3725,78 @@ def ensure_route(plan: Plan) -> str:
     cold each declared route is tried in order and the first master to come up
     wins, which is what makes `reach` a fallback list rather than a wish.
 
+    Every step of an attempt is inside the same `try`, and that is the repair
+    this function exists for.  `ssh -O check` against a hung master times out and
+    raises, an over-long ControlPath raises, a bridge that is disabled or
+    password-authenticated raises -- and a raise out of this loop skipped every
+    remaining route, so fallback was lost in precisely the state it exists for: a
+    direct master wedged rather than absent.  A route that cannot be attempted is
+    a route that did not come up, reported by name like any other.
+
     Fallback lives here and nowhere else, deliberately.  Once a master exists a
     failing command is a failing command -- never retried, never re-routed --
     because `exec` and `submit` are at-most-once and a re-routed `sbatch` queues
     the job twice.  A retry added anywhere outside this function takes that
     guarantee away.
+    """
+    failures: list[str] = []
+    for route in routes or DEFAULT_REACH:
+        try:
+            bridge_name = route_bridge(route)
+            if bridge_name is not None:
+                # Before the destination, so the hop rides a master this code path
+                # owns rather than one the ProxyCommand opens behind its back.
+                hop_failure = establish_hop(
+                    context, bridge_name, chain=(*chain, target.name)
+                )
+                if hop_failure is not None:
+                    failures.append(f"{route} ({hop_failure})")
+                    continue
+            runtime = ssh_runtime_kwargs(context, target=target, route=route)
+            failure = bring_up_control_master(secret, runtime, route)
+        except FleetError as exc:
+            failures.append(f"{route} ({exc})")
+            continue
+        if failure is None:
+            context.route_established[target.name] = route
+            record_route_state(
+                context.paths, target.name, route, str(runtime["control_path"])
+            )
+            return route, failures
+        failures.append(f"{route} ({failure})")
+    return None, failures
+
+
+def route_fallback_hint(plan: Plan) -> str:
+    """Say what else there was to try, which is two different answers.
+
+    A suppressed fallback and a missing one produce the same failure and want
+    opposite fixes, and the hint was gated on the declared list alone -- so
+    `--no-fallback` against a host with a perfectly good bridge was told to go
+    declare the bridge it already had.
+    """
+    declared = plan.target.reach or DEFAULT_REACH
+    untried = tuple(route for route in declared if route not in plan.routes)
+    if untried:
+        return (
+            f" `--route`/`--no-fallback` narrowed this run to "
+            f"[{format_reach(plan.routes)}], so the declared "
+            f"[{format_reach(untried)}] was not tried."
+        )
+    if len(declared) < 2:
+        return (
+            " Declare a `via:<bridge>` fallback in that target's `reach` if a "
+            "bridge can carry it."
+        )
+    return ""
+
+
+def ensure_route(plan: Plan) -> str:
+    """Bring up a control master for the first of PLAN's routes that works.
+
+    The Plan-shaped door onto establish_route, which is where the ordering and
+    the at-most-once argument live.  Memoised on the plan as well as in the
+    context, so one command asks once.
     """
     if plan._route is not None:
         return plan._route
@@ -3595,35 +3804,17 @@ def ensure_route(plan: Plan) -> str:
         # Multiplexing is off, so there is no master to establish and no socket to
         # check.  Fallback is a property of the master, not of the command.
         return plan.route
-    secret = plan.secret
-    failures: list[str] = []
-    for route in plan.routes or DEFAULT_REACH:
-        runtime = ssh_runtime_kwargs(plan.context, target=plan.target, route=route)
-        failure = (
-            None
-            if control_master_alive(secret, runtime)
-            else open_control_master(secret, runtime, route)
-        )
-        if failure is None:
-            object.__setattr__(plan, "_route", route)
-            record_route_state(
-                plan.context.paths,
-                plan.target.name,
-                route,
-                str(runtime["control_path"]),
-            )
-            return route
-        failures.append(f"{route} ({failure})")
+    route, failures = establish_route(
+        plan.context, plan.target, plan.secret, plan.routes
+    )
+    if route is not None:
+        object.__setattr__(plan, "_route", route)
+        return route
     raise FleetError(
         f"no route to {plan.target.name!r} came up; tried "
         + ", ".join(failures)
         + "."
-        + (
-            " Declare a `via:<bridge>` fallback in that target's `reach` if a "
-            "bridge can carry it."
-            if len(plan.target.reach) < 2
-            else ""
-        )
+        + route_fallback_hint(plan)
     )
 
 
@@ -6610,7 +6801,9 @@ def toml_syntax_problems(paths: FleetPaths) -> list[str]:
     return problems
 
 
-def probe_remote_prerequisites(context: FleetContext) -> list[str]:
+def probe_remote_prerequisites(
+    context: FleetContext,
+) -> tuple[list[str], list[str]]:
     """Check the one remote prerequisite fleetctl silently assumes: python3.
 
     `exec` ships its payload through a remote Python stub, while `ssh`, `script`
@@ -6618,8 +6811,16 @@ def probe_remote_prerequisites(context: FleetContext) -> list[str]:
     right up to the first `fleetctl exec`.  This needs the network, so it is
     opt-in: an unreachable host is not a configuration fault, and plain `doctor`
     stays offline and instant.
+
+    Returns problems and warnings separately, and being out of reach is a
+    warning.  It used to be a problem reached over `reach[0]` alone, which made
+    `doctor` exit 1 saying a host could not be reached while its own route matrix,
+    printed a few lines below, showed the bridge carrying it.  A missing python3
+    is still a problem: that one is a fact about the host, and it is exactly what
+    the flag was asked to find out.
     """
     problems: list[str] = []
+    warnings: list[str] = []
     for target in sorted(context.targets.values(), key=lambda item: item.name):
         if not target.enabled:
             continue
@@ -6627,36 +6828,49 @@ def probe_remote_prerequisites(context: FleetContext) -> list[str]:
             secret = context.resolve_secret(target)
         except FleetError:
             continue  # already reported by the offline pass
-        try:
-            # Per target, not hoisted out of the loop: the ProxyCommand is part
-            # of the runtime now, and a hoisted one would send every probe down
-            # the first target's route.
-            runtime = ssh_runtime_kwargs(context, target=target)
-            completed = run_ssh_command(
-                secret,
-                allocate_tty=False,
-                remote_command="command -v python3",
-                capture_output=True,
-                timeout=CONTROL_COMMAND_TIMEOUT,
-                **runtime,
+        answered = None
+        refusals: list[str] = []
+        for route in target.reach or DEFAULT_REACH:
+            try:
+                # Per target and per route, not hoisted out of either loop: the
+                # ProxyCommand is part of the runtime now, and a hoisted one would
+                # send every probe down the first target's route.
+                runtime = ssh_runtime_kwargs(context, target=target, route=route)
+                completed = run_ssh_command(
+                    secret,
+                    allocate_tty=False,
+                    remote_command="command -v python3",
+                    capture_output=True,
+                    timeout=CONTROL_COMMAND_TIMEOUT,
+                    **runtime,
+                )
+            except FleetError as exc:
+                refusals.append(f"{route} ({exc})")
+                continue
+            if completed.returncode == SSH_TRANSPORT_FAILURE:
+                # ssh reserves 255 for its own failures, so this is a transport
+                # problem, not a missing interpreter -- do not blame python3 for
+                # it, and do not stop before the fallback has had its turn.
+                detail = (completed.stderr or "").strip().splitlines()
+                refusals.append(
+                    f"{route} ("
+                    + (detail[-1] if detail else "ssh failed with no diagnostic")
+                    + ")"
+                )
+                continue
+            answered = completed
+            break
+        if answered is None:
+            warnings.append(
+                f"target {target.name!r} answered on no declared route: "
+                + ", ".join(refusals)
             )
-        except FleetError as exc:
-            problems.append(f"target {target.name!r} is not reachable: {exc}")
-            continue
-        if completed.returncode == SSH_TRANSPORT_FAILURE:
-            # ssh reserves 255 for its own failures, so this is a transport
-            # problem, not a missing interpreter -- do not blame python3 for it.
-            detail = (completed.stderr or "").strip().splitlines()
-            problems.append(
-                f"target {target.name!r} is not reachable: "
-                + (detail[-1] if detail else "ssh failed with no diagnostic")
-            )
-        elif completed.returncode != 0:
+        elif answered.returncode != 0:
             problems.append(
                 f"target {target.name!r} has no `python3` on PATH; `fleetctl exec` "
                 "runs its payload through a remote Python stub and will fail there"
             )
-    return problems
+    return problems, warnings
 
 
 def probe_route_matrix(
@@ -6668,6 +6882,13 @@ def probe_route_matrix(
     rather than a slowdown you eventually notice -- and a fallback that has
     quietly become the only path is worth knowing before the bridge reboots.
     Sockets this opens are left warm, which is most of the point of opening them.
+
+    Each route is tried on its own terms and no hop is established first, unlike
+    selection: this reports which links carry, and rolling a broken bridge into
+    the cell for every host behind it would hide the one fact worth reading.
+    Nothing a cell does can end the matrix, either -- a wedged socket or a
+    missing ssh raises, and losing every remaining cell to it costs exactly the
+    report `--probe` was run to produce.
     """
     matrix: dict[str, dict[str, str]] = {}
     warnings: list[str] = []
@@ -6685,10 +6906,14 @@ def probe_route_matrix(
             except FleetError as exc:
                 results[route] = f"unusable: {exc}"
                 continue
-            if control_master_alive(secret, runtime):
-                results[route] = "live"
+            try:
+                if control_master_alive(secret, runtime):
+                    results[route] = "live"
+                    continue
+                failure = bring_up_control_master(secret, runtime, route)
+            except FleetError as exc:
+                results[route] = f"down: {exc}"
                 continue
-            failure = open_control_master(secret, runtime, route)
             results[route] = "up" if failure is None else f"down: {failure}"
         matrix[target.name] = results
         working = [route for route, state in results.items() if state in ("live", "up")]
@@ -6967,7 +7192,9 @@ def command_doctor(args: argparse.Namespace) -> int:
                     )
 
         if getattr(args, "probe", False):
-            problems.extend(probe_remote_prerequisites(context))
+            prerequisites, unreachable = probe_remote_prerequisites(context)
+            problems.extend(prerequisites)
+            warnings.extend(unreachable)
             route_matrix, route_warnings = probe_route_matrix(context)
             warnings.extend(route_warnings)
 
@@ -7201,14 +7428,32 @@ FALLBACK
     wins. Direct gets a 5 second deadline and a bridge 10, so the whole
     cost of preferring direct is one timeout per ControlPersist window,
     paid only when direct is really down. `--no-fallback` refuses to
-    degrade.
+    degrade, and the failure then says that is what happened rather
+    than telling you to declare the fallback you already have.
+
+    A route that cannot be attempted is a route that did not come up: a
+    wedged master that will not answer `ssh -O check`, a control socket
+    over the length limit, a bridge that is disabled or
+    password-authenticated. Each is reported against its own route and
+    the next route is tried, because a wedged direct master is the
+    exact state fallback exists for.
+
+    A `via:` route brings the bridge's own master up first, over the
+    bridge's own `reach` in declared order, so a bridge that has a
+    fallback can use it and the hop rides the socket that came up
+    rather than the one declared first. A bridge that comes up on no
+    route is that route's failure, reported with the bridge's own
+    reasons.
 
     Every route gets its own socket. OpenSSH's %C hash covers the host,
     port and user but not the ProxyCommand, so without a suffix a warm
     direct master would go on serving a `--route via:` command until it
-    expired. Setting an empty `control_path` turns multiplexing off,
-    and then there is no master to establish and the first route is the
-    only one.
+    expired. A `control_path` whose expansion could pass what a unix
+    socket allows is refused before anything connects, budgeting every
+    %-token at its widest, since ssh reports the overflow from whatever
+    link of the chain hit it. Setting an empty `control_path` turns
+    multiplexing off, and then there is no master to establish and the
+    first route is the only one.
 
     Fallback lives in that one step and nowhere else. Once a master
     exists a failing command is a failing command -- never retried,
@@ -7217,8 +7462,11 @@ FALLBACK
 
     `explain` names the route chain, the socket and the route last
     used; `doctor --probe` tries every route of every target and prints
-    the matrix. `list --format topology` prints the graph: each
-    target's routes, and what each bridge carries.
+    the matrix, one cell per route -- a route it cannot even probe is
+    one cell reading `down:`, and a host that answers on none of its
+    routes is a warning there rather than a problem, since being out of
+    reach is not a fault in the config. `list --format topology` prints
+    the graph: each target's routes, and what each bridge carries.
 
 DEPRECATED
     The secret key `proxy_jump` is accepted and ignored. Declare

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -22,10 +22,13 @@ import stat
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 import tomllib
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field, replace
-from pathlib import Path, PurePosixPath
-from typing import Any, Iterable
+from pathlib import Path
+from typing import Any, Callable, Iterable
 
 VERSION = "0.1.0"
 PRIVATE_DIR_MODE = 0o700
@@ -355,7 +358,6 @@ class TargetRecord:
 
     name: str
     enabled: bool = True
-    transport: str = "ssh"
     role: str | None = None
     protocol: str | None = None
     reach: tuple[str, ...] = DEFAULT_REACH
@@ -365,9 +367,8 @@ class TargetRecord:
     secret_ref: str | None = None
     secret_inline: dict[str, Any] = field(default_factory=dict)
     capabilities: dict[str, Any] = field(default_factory=dict)
-    ssh_host_alias: str | None = None
+    # Read by resolve_profile, between the project binding and the protocol.
     default_profile: str | None = None
-    metadata: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -428,7 +429,6 @@ class ProtocolRecord:
     description: str | None = None
     default_profile: str | None = None
     gpu_request_mode: str = "gres"
-    job_runtime: str = "host"
     native_batch_required: bool = False
     job_output_dir: str = ".fleet/jobs"
     docs: tuple[str, ...] = ()
@@ -977,6 +977,18 @@ class FleetContext:
             return load_toml_file(path), path
         if target.secret_backend == "pass":
             return parse_secret_blob(run_pass_show(target.secret_ref)), None
+        if target.secret_backend == "command":
+            # Merged over the inline table rather than replacing it, because the
+            # point is to supply *a field*.  Everything stable about the host
+            # stays written down in the target's `[secret]`, and the upcall
+            # answers only the question that has a different answer today.
+            values = dict(target.secret_inline)
+            values.update(
+                run_secret_command(
+                    target.secret_ref, what=f"target {target.name!r}"
+                )
+            )
+            return values, None
         raise FleetError(
             f"target {target.name!r} uses unsupported secret backend "
             f"{target.secret_backend!r}"
@@ -1240,6 +1252,199 @@ def parse_capabilities(
     return capabilities
 
 
+# ---- SECTION: probed facts (advisory, never authoritative) ------------------
+#
+# `probe` measures a host and writes down what it found.  Nothing in resolution
+# reads it, and that is the whole design rather than an omission: this is Salt's
+# grains-versus-pillars split, where minion-supplied grains are documented as
+# "less secure than other identifiers" precisely because the machine being
+# described is the one supplying the description.  A declared capability is a
+# commitment its owner made; a probed one is a reading taken over the connection
+# whose trustworthiness is the thing in question.  So admission and selection
+# read declarations only, and a fact file that says a box has eight GPUs cannot
+# route a job to it.
+#
+# What the facts are for is the other half of the idea, and Slurm has the shape
+# worth copying: a node found short of its configured GRES is DRAINed, not
+# logged.  A machine with less than it promised will accept a job sized for the
+# promise and then fail it, so `doctor` reports a shortfall as a fault.  Drift
+# the other way -- more than declared -- is a stale declaration, which is a
+# warning: nothing breaks, but `--fit` is choosing on old numbers.
+
+PROBE_FACT_KEYS = ("arch", "gpu_model", *FIT_ORDER)
+
+# How far a measurement may fall short of a declaration before it counts.  `free`
+# never reports the nominal size (the kernel, reserved regions and the
+# framebuffer come off the top) and `nvidia-smi` reports usable VRAM rather than
+# the number on the box.  With no slack every honestly-declared machine in the
+# fleet would be permanently faulty, which is how a check gets ignored.
+PROBE_DRIFT_TOLERANCE: dict[str, float] = {"mem_gb": 0.10, "vram_gb": 0.05}
+
+
+def probe_facts_file(paths: FleetPaths, target: str) -> Path:
+    """Where one target's measured facts are cached."""
+    return paths.state_home / "facts" / f"{target}.json"
+
+
+def read_probed_facts(paths: FleetPaths, target: str) -> dict[str, Any]:
+    """Read TARGET's last probe, for reporting only.
+
+    An unreadable or absent file is "not probed yet", never an error: the facts
+    are advisory, so `doctor` must not start failing because a state directory
+    went away.
+    """
+    try:
+        loaded = json.loads(probe_facts_file(paths, target).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def write_probed_facts(
+    paths: FleetPaths, target: str, facts: dict[str, Any]
+) -> Path:
+    """Record TARGET's measured facts, 0600 under the state home.
+
+    Measured facts name hardware and, through `queues`, a site's partitions, so
+    they get the same handling as the rest of the state directory rather than
+    landing world-readable in a cache.
+    """
+    path = probe_facts_file(paths, target)
+    ensure_private_dir(path.parent, mode=STATE_DIR_MODE)
+    write_text_file(
+        path, json.dumps(facts, indent=2, sort_keys=True) + "\n", mode=PRIVATE_FILE_MODE
+    )
+    return path
+
+
+def parse_probe_output(text: str) -> dict[str, Any]:
+    """Turn the probe script's `key=value` lines into facts.
+
+    The numeric keys are coerced exactly as `[capabilities]` coerces them, so a
+    measured `mem_gb` and a declared one are comparable without inventing a
+    second vocabulary.  A line whose value will not parse as a number where a
+    number belongs is dropped rather than stored as text: a fact that cannot be
+    compared is not a fact, and storing it would put `mem_gb = "unknown"` in a
+    file `doctor` reads.
+    """
+    facts: dict[str, Any] = {}
+    for line in text.splitlines():
+        key, separator, value = line.strip().partition("=")
+        key, value = key.strip(), value.strip()
+        if not separator or not key or not value:
+            continue
+        if key in CAPABILITY_NUMBER_KEYS:
+            number = capability_number(value)
+            if number is None:
+                continue
+            facts[key] = int(number) if number.is_integer() else number
+        else:
+            facts[key] = value
+    return facts
+
+
+def capability_drift(
+    declared: dict[str, Any], measured: dict[str, Any]
+) -> list[tuple[str, str]]:
+    """Compare a declaration against a measurement, key by key.
+
+    Only the intersection is compared, in both directions deliberately.  A key
+    measured but not declared is not drift -- the declaration is the contract,
+    and a fleet is not obliged to declare everything a tool can report.  A key
+    declared but not measured is not drift either: `nvidia-smi` missing means the
+    probe could not see, which is different from seeing zero.
+    """
+    drift: list[tuple[str, str]] = []
+    for key in sorted(set(declared) & set(measured)):
+        want, have = declared[key], measured[key]
+        want_number = capability_number(want)
+        have_number = capability_number(have)
+        if want_number is not None and have_number is not None:
+            slack = PROBE_DRIFT_TOLERANCE.get(key, 0.0) * abs(want_number)
+            if have_number < want_number - slack:
+                drift.append(
+                    (
+                        "short",
+                        f"declares {key} = {capability_text(want)} but measured "
+                        f"{capability_text(have)}, so a job sized for the "
+                        "declaration will be accepted and then fail",
+                    )
+                )
+            elif have_number > want_number + slack:
+                drift.append(
+                    (
+                        "stale",
+                        f"declares {key} = {capability_text(want)} but measured "
+                        f"{capability_text(have)}; `--fit` is choosing on the "
+                        "smaller number",
+                    )
+                )
+            continue
+        if capability_text(want) != capability_text(have):
+            drift.append(
+                (
+                    "stale",
+                    f"declares {key} = {capability_text(want)!r} but measured "
+                    f"{capability_text(have)!r}",
+                )
+            )
+    return drift
+
+
+def probe_remote_argv(plan: Plan) -> list[str]:
+    """The one remote script `probe` runs.
+
+    Read-only by construction, and every tool behind `command -v`, so a host with
+    no `nvidia-smi` reports no GPU instead of failing the probe.  `set -u` without
+    `-e` for the same reason: one absent tool must not end the measurement.
+
+    The numbers are normalised on the remote side into the keys `[capabilities]`
+    already uses, because drift is only computable where the two vocabularies
+    meet -- a probe reporting `MemTotal` in kB would produce a fact nothing could
+    compare against a declared `mem_gb`.
+    """
+    body = (
+        "set -u;"
+        " printf 'arch=%s\\n' \"$(uname -m)\";"
+        " printf 'kernel=%s\\n' \"$(uname -sr)\";"
+        " if command -v python3 >/dev/null 2>&1; then"
+        " printf 'python3=%s\\n' \"$(python3 --version 2>&1)\";"
+        " fi;"
+        " if command -v nproc >/dev/null 2>&1; then"
+        " printf 'cpus=%s\\n' \"$(nproc)\";"
+        " elif command -v getconf >/dev/null 2>&1; then"
+        " printf 'cpus=%s\\n' \"$(getconf _NPROCESSORS_ONLN)\";"
+        " fi;"
+        " if command -v free >/dev/null 2>&1; then"
+        " printf 'mem_gb=%s\\n'"
+        " \"$(free -m | awk '/^Mem:/ {printf \"%d\", ($2 + 512) / 1024}')\";"
+        " fi;"
+        " if command -v nvidia-smi >/dev/null 2>&1; then"
+        " cards=\"$(nvidia-smi --query-gpu=name,memory.total"
+        " --format=csv,noheader,nounits)\";"
+        " printf 'gpu_count=%s\\n' \"$(printf '%s\\n' \"$cards\" | grep -c .)\";"
+        " printf 'gpu_model=%s\\n'"
+        " \"$(printf '%s\\n' \"$cards\" | head -n1 | cut -d, -f1)\";"
+        # The smallest card, not the first: a mixed box can only really run a job
+        # that fits on whichever GPU it lands on.
+        " printf 'vram_gb=%s\\n' \"$(printf '%s\\n' \"$cards\" | cut -d, -f2"
+        " | sort -n | head -n1 | awk '{printf \"%d\", ($1 + 512) / 1024}')\";"
+        " fi;"
+    )
+    if plan.protocol.kind == "slurm":
+        # The partitions are the selectable surface at a scheduler site, so they
+        # are the fact worth measuring there.  The login node's own CPUs are not
+        # what anything runs on, and reporting them as the target's would be a
+        # measurement that contradicts the whole queue model.
+        body += (
+            " if command -v sinfo >/dev/null 2>&1; then"
+            " printf 'queues=%s\\n' \"$(sinfo -h -o '%P' | tr -d ' *' | sort -u"
+            " | paste -sd, -)\";"
+            " fi;"
+        )
+    return ["/usr/bin/env", "bash", "-lc", body]
+
+
 # ---- SECTION: resolution (config + args -> Plan, no remote I/O) ------------
 
 
@@ -1444,8 +1649,11 @@ def build_plan(context: FleetContext, args: argparse.Namespace, verb: str) -> Pl
 
     The role matrix is consulted here rather than in each handler, so a new verb
     cannot forget it: there is no way to obtain a Plan without passing admission
-    first, and no way to act on a host without a Plan.
+    first, and no way to act on a host without a Plan.  Fan-out is refused in the
+    same place and for the same reason -- a verb that writes must not acquire N
+    plans, and the check cannot be forgotten if there is nowhere else to put it.
     """
+    ensure_fanout_supported(args)
     selector = context.normalize_selector(getattr(args, "selector", None))
     requirements = parse_requirements(getattr(args, "require", None) or ())
     fit = bool(getattr(args, "fit", False))
@@ -1589,6 +1797,330 @@ def load_repo_template(path: str, fallback: str) -> str:
     return template_path.read_text(encoding="utf-8")
 
 
+# ---- SECTION: fan-out ------------------------------------------------------
+#
+# One command over many hosts, with two bounds that are not optional.
+#
+# The first is concurrency, and it is per reach-hop rather than global.
+# ClusterShell defaults to a fanout of 64, which is the right number for what it
+# was built for: a homogeneous LAN cluster where every node is one hop away.
+# This fleet is the other shape.  Every clustered connection can be multiplexed
+# through a Raspberry Pi, and 64 simultaneous ssh masters through a Pi is not a
+# fan-out, it is an outage -- while a fleet-wide cap of 4 would throttle the
+# directly-reachable boxes for a bottleneck they do not share.  So the limit
+# belongs to the hop, not to the run.
+#
+# The second is which verbs may do it at all, and the answer is: the ones where
+# half-finishing is recoverable.  `smoke`, `exec` and `job status` read and
+# report, so a fan-out that dies four hosts in has cost four reports.  `sync` and
+# `submit` write, and partial failure across a fleet is how fleets get hurt --
+# some hosts on the new code and some on the old, with nothing afterwards able to
+# say which; a fanned-out `sbatch` is a fanned-out double submission.  There is
+# no flag for it, because the flag would be used.
+#
+# Whatever narrows the set gets said out loud.  A silent truncation reads as
+# "covered everything" when it did not, which is worse than a refusal: the
+# operator moves on believing the fleet is consistent.
+
+FANOUT_COMMANDS = ("smoke", "exec", "job status")
+
+# Per hop, and roughly rather than exactly 4: the number that matters is "a
+# handful", set by what a Pi's CPU can do with four concurrent AES streams, and
+# any precision here would be false.
+FANOUT_HOP_LIMIT = 4
+
+FANOUT_REFUSALS: dict[str, str] = {
+    "sync": (
+        "a partial transfer leaves some hosts on the new code and some on the "
+        "old, and nothing afterwards can tell you which is which. Sync one "
+        "target at a time and let the first failure stop you"
+    ),
+    "submit": (
+        "a fanned-out `sbatch` is a fanned-out double submission -- N "
+        "allocations for one job, and a rerun that looks exactly like the first "
+        "attempt. Submit per target, and let each job id come back"
+    ),
+    "script": (
+        "staging a script is a write, and a stage that succeeded on four hosts "
+        "and failed on the fifth is not a state anything reports later"
+    ),
+    "ssh": "an interactive session is one terminal, and this would want N",
+    "probe": (
+        "the facts it writes are per host and per connection, so they are worth "
+        "having only when you can attribute them. `doctor` already reads every "
+        "fact file the fleet has"
+    ),
+    "job logs": (
+        "a scheduler job id means nothing off the site that issued it, so this "
+        "would fetch a different job's logs from each host -- interleaved"
+    ),
+    "job cancel": (
+        "the same id names a different job at every site, so a fanned-out "
+        "cancel cancels other people's work. Name the target that ran it"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class FanoutResult:
+    """What one target did, kept whole until every target is done."""
+
+    name: str
+    status: str
+    detail: str
+    code: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+def command_label(args: argparse.Namespace) -> str:
+    """The subcommand as a human writes it: `job status`, not `status`."""
+    parts = [str(getattr(args, "command", "") or "")]
+    nested = getattr(args, "job_command", None)
+    if nested:
+        parts.append(str(nested))
+    return " ".join(part for part in parts if part)
+
+
+def fanout_requested(args: argparse.Namespace) -> bool:
+    """True when `--all` or `--tag` asked for more than one target."""
+    return bool(getattr(args, "all_targets", False)) or bool(
+        optional_str(getattr(args, "tag", None))
+    )
+
+
+def ensure_fanout_supported(args: argparse.Namespace) -> None:
+    """Refuse a fan-out the verb cannot survive half-finishing.
+
+    Called from build_plan rather than from the handlers, for the same reason
+    admission is: there is exactly one way to reach a host, so a verb cannot
+    forget to check, and a verb added later inherits the refusal by default.
+    """
+    if not fanout_requested(args):
+        return
+    label = command_label(args)
+    if label in FANOUT_COMMANDS:
+        return
+    reason = FANOUT_REFUSALS.get(
+        label, "only read-only, idempotent verbs may run against many hosts"
+    )
+    raise FleetError(
+        f"`fleetctl {label}` does not fan out: {reason}. Fan-out is limited to "
+        + ", ".join(f"`{item}`" for item in FANOUT_COMMANDS)
+        + " -- read-only, idempotent, and safe to have half-finish."
+    )
+
+
+def fanout_targets(
+    context: FleetContext, args: argparse.Namespace
+) -> tuple[list[str], list[str]]:
+    """Which targets a fan-out covers, and every way the set got smaller."""
+    selector = optional_str(getattr(args, "selector", None)) or optional_str(
+        getattr(args, "selector_override", None)
+    )
+    if selector:
+        raise FleetError(
+            f"{selector!r} names one target and --all/--tag name many; pick one. "
+            "A pool already selects, so it resolves to a single host rather than "
+            "fanning out -- use `--tag` for the set a pool would collapse."
+        )
+    tag = optional_str(getattr(args, "tag", None))
+    notes: list[str] = []
+    names: list[str] = []
+    skipped: list[str] = []
+    for target in sorted(context.targets.values(), key=lambda item: item.name):
+        if tag and tag not in target.tags:
+            continue
+        if not target.enabled:
+            skipped.append(target.name)
+            continue
+        names.append(target.name)
+    if skipped:
+        notes.append(
+            "not covered, disabled in the inventory: " + ", ".join(skipped)
+        )
+    if not names:
+        raise FleetError(
+            f"no enabled target carries the tag {tag!r}"
+            if tag
+            else "the fleet has no enabled targets"
+        )
+    return names, notes
+
+
+def fanout_hop(routes: Iterable[str]) -> str:
+    """The hop that bounds concurrency for a target with these routes.
+
+    The first declared bridge, if there is one -- not the route the connection
+    will probably take.  A `reach` of `["direct", "via:numpi"]` is a statement
+    that the Pi may end up carrying this connection, and direct is down for all
+    of them about as often as it is down for one, so a cap that only holds while
+    nothing falls back is not a cap.  `--route direct --no-fallback` narrows the
+    route list to one entry and gets the full `--jobs` back, which is the honest
+    way to ask for it: it says out loud that a bridged host is now out of scope.
+    """
+    for route in routes:
+        if route.startswith(ROUTE_VIA_PREFIX):
+            return route
+    return ROUTE_DIRECT
+
+
+def fanout_hop_limit(hop: str, jobs: int) -> int:
+    """How many connections HOP carries at once, given `--jobs`."""
+    if hop == ROUTE_DIRECT:
+        return max(1, jobs)
+    return max(1, min(jobs, FANOUT_HOP_LIMIT))
+
+
+def fanout_execute(
+    items: list[tuple[str, str]],
+    *,
+    jobs: int,
+    work: Callable[[str], tuple[int, str, str]],
+) -> list[tuple[str, tuple[int, str, str]]]:
+    """Run WORK over ITEMS -- `(hop, key)` pairs -- and return one result each.
+
+    Two bounds, composed: `jobs` workers in total, and a semaphore per hop
+    holding that hop to fanout_hop_limit.  Each task takes exactly one semaphore,
+    so there is no lock order to get wrong.  Results come back in ITEMS order
+    however the threads finished, because a report whose line order depends on
+    which host answered first is a report you cannot diff against yesterday's.
+    """
+    limits: dict[str, threading.Semaphore] = {}
+    for hop, _ in items:
+        if hop not in limits:
+            limits[hop] = threading.Semaphore(fanout_hop_limit(hop, jobs))
+    ordered = [key for _, key in items]
+    if jobs <= 1 or len(items) <= 1:
+        # Sequential by default, and genuinely sequential: no pool, so a
+        # single-target run has the same stack as it did before this existed.
+        return [(key, work(key)) for key in ordered]
+
+    def guarded(hop: str, key: str) -> tuple[int, str, str]:
+        with limits[hop]:
+            return work(key)
+
+    with ThreadPoolExecutor(max_workers=jobs) as pool:
+        futures = {key: pool.submit(guarded, hop, key) for hop, key in items}
+    return [(key, futures[key].result()) for key in ordered]
+
+
+def fanout_detail(text: str) -> str:
+    """Collapse a message to one line, for a report that is one line per host."""
+    return " ".join(str(text).split())
+
+
+def fanout_exit_code(results: Iterable["FanoutResult"]) -> int:
+    """The one status a fan-out reports.
+
+    A refusal outranks a remote failure: exit 2 means the policy layer stopped
+    something, and that stays true when nine of ten hosts also happened to fail.
+    Otherwise the first non-zero remote code in name order, so the status is
+    reproducible rather than a race between hosts.
+    """
+    ordered = sorted(results, key=lambda item: item.name)
+    if any(result.status == "refused" for result in ordered):
+        return 2
+    for result in ordered:
+        if result.code:
+            return result.code
+    return 0
+
+
+def report_fanout(results: list["FanoutResult"], notes: Iterable[str]) -> int:
+    """Print one fan-out: remote output first, then one line per target.
+
+    Every remote line is prefixed with the host it came from.  Unprefixed output
+    from four machines interleaved is not a report -- there is no way to tell
+    which of them has no GPU.  Notes go to stderr so that piping the summary
+    somewhere does not silently drop the part that says what was left out.
+    """
+    ordered = sorted(results, key=lambda item: item.name)
+    for result in ordered:
+        for line in result.stdout.splitlines():
+            print(f"{result.name}: {line}")
+        for line in result.stderr.splitlines():
+            print(f"{result.name}: {line}", file=sys.stderr)
+    width = max((len(result.name) for result in ordered), default=0)
+    for result in ordered:
+        row = f"{result.name.ljust(width)}  {result.status.ljust(8)}{result.detail}"
+        print(row.rstrip())
+    for note in notes:
+        print(f"note: {note}", file=sys.stderr)
+    return fanout_exit_code(ordered)
+
+
+def fanout_run(
+    context: FleetContext,
+    args: argparse.Namespace,
+    *,
+    verb: str,
+    work: Callable[[Plan], tuple[int, str, str]],
+) -> int:
+    """Resolve every target in the fan-out, then run WORK against each.
+
+    Resolution happens for all of them before any of them runs, so an admission
+    refusal or an unresolvable target is reported next to the successes instead
+    of aborting the fleet -- and so the report does not depend on the alphabet.
+    """
+    names, notes = fanout_targets(context, args)
+    jobs = max(1, int(getattr(args, "jobs", 1) or 1))
+    results: list[FanoutResult] = []
+    plans: list[tuple[str, Plan]] = []
+    for name in names:
+        one = argparse.Namespace(**vars(args))
+        one.selector = name
+        one.all_targets = False
+        one.tag = None
+        try:
+            plans.append((name, build_plan(context, one, verb)))
+        except FleetError as error:
+            results.append(
+                FanoutResult(name, "refused", fanout_detail(error), 2)
+            )
+    items = [(fanout_hop(plan.routes), name) for name, plan in plans]
+    # Reported before the dry-run branch, not after: a plan that does not mention
+    # the cap it will hit is the kind of dry-run that reads as a promise.
+    for hop in sorted({hop for hop, _ in items if hop != ROUTE_DIRECT}):
+        carried = sum(1 for existing, _ in items if existing == hop)
+        limit = fanout_hop_limit(hop, jobs)
+        if carried > limit:
+            notes.append(
+                f"{carried} targets may be reached over {hop}, so at most "
+                f"{limit} of them run at once"
+            )
+    if getattr(args, "dry_run", False):
+        # `plan.route` is the first candidate until something connects, which is
+        # exactly what makes it printable here: nothing has been reached yet.
+        results.extend(
+            FanoutResult(name, "plan", f"{verb} over {plan.route}", 0)
+            for name, plan in plans
+        )
+        return report_fanout(results, notes)
+    by_name = dict(plans)
+
+    def guarded(name: str) -> tuple[int, str, str]:
+        try:
+            return work(by_name[name])
+        except FleetError as error:
+            # One host's failure is one line of the report.  Letting it out here
+            # would abandon the results already collected from the others.
+            return error.exit_code, "", f"{error}\n"
+
+    for name, (code, out, err) in fanout_execute(items, jobs=jobs, work=guarded):
+        results.append(
+            FanoutResult(
+                name,
+                "ok" if code == 0 else "failed",
+                "" if code == 0 else f"exit {code}",
+                code,
+                out,
+                err,
+            )
+        )
+    return report_fanout(results, notes)
+
+
 # ---- SECTION: config schema ------------------------------------------------
 #
 # Every key fleetctl understands is listed here, and anything else in a config
@@ -1617,7 +2149,6 @@ TARGET_KEYS = frozenset(
         "version",
         "name",
         "enabled",
-        "transport",
         "role",
         "protocol",
         "reach",
@@ -1627,12 +2158,10 @@ TARGET_KEYS = frozenset(
         "secret_ref",
         "secret",
         "capabilities",
-        "ssh_host_alias",
         "default_profile",
-        "metadata",
     }
 )
-POOL_KEYS = frozenset({"version", "name", "targets", "match_tags", "strategy"})
+POOL_KEYS = frozenset({"version", "name", "targets", "match_tags"})
 PROTOCOL_KEYS = frozenset(
     {
         "version",
@@ -1641,7 +2170,6 @@ PROTOCOL_KEYS = frozenset(
         "description",
         "default_profile",
         "gpu_request_mode",
-        "job_runtime",
         "native_batch_required",
         "job_output_dir",
         "docs",
@@ -1715,9 +2243,11 @@ SECRET_KEYS = frozenset(
     }
 )
 
-TRANSPORTS = ("ssh",)
-SECRET_BACKENDS = ("file", "pass", "inline")
-POOL_STRATEGIES = ("ordered",)
+# `command` runs `secret_ref` and reads TOML off its stdout.  It exists for the
+# field that will not hold still -- a cloud box whose address changes on every
+# start -- and it keeps that knowledge in a script the operator already has
+# rather than making fleetctl learn one provider's API and then the next one's.
+SECRET_BACKENDS = ("file", "pass", "inline", "command")
 PROTOCOL_KINDS = ("direct", "slurm")
 GPU_REQUEST_MODES = ("none", "gpus", "gres")
 AUTH_MODES = ("key", "password")
@@ -1731,6 +2261,22 @@ STRICT_HOST_KEY_MODES = ("yes", "no", "off", "ask", "accept-new")
 # so it is written down here rather than hidden as a stray entry in a key set.
 DEPRECATED_TARGET_KEYS: dict[str, str] = {
     "scheduler": "what may run here is decided by `role`; `protocol` is required",
+    "transport": (
+        "there was one value, `ssh`, and nothing ever branched on it. A second "
+        "transport would have to change how commands, copies and control sockets "
+        "are built, none of which a key in a target file could reach"
+    ),
+    "ssh_host_alias": (
+        "it never reached an ssh invocation, and could not: a fleet connection is "
+        "built from the secret and deliberately ignores `~/.ssh/config`, which is "
+        "what `IdentitiesOnly` and a private `known_hosts` are for. A real `Host` "
+        "alias is expressible as `[ssh_option]` in the secret"
+    ),
+    "metadata": (
+        "a free-form table nothing read. The two things people put in it are "
+        "already modelled by something that acts on them: `tags` to group hosts, "
+        "`[capabilities]` to describe the hardware"
+    ),
 }
 DEPRECATED_PROTOCOL_KEYS: dict[str, str] = {
     "scheduler_required": "the role matrix decides this for every verb",
@@ -1740,8 +2286,21 @@ DEPRECATED_PROTOCOL_KEYS: dict[str, str] = {
         'protocol shared by all of them; declare `gpu_count` under the target\'s '
         "`[capabilities]` and `smoke` follows it"
     ),
+    "job_runtime": (
+        "nothing ever read it, and a second runtime dimension is the wrong shape "
+        "anyway: how work is invoked belongs to the profile that invokes it, so a "
+        'container is an `interpreter` or a `submit_command` beginning '
+        '["apptainer", "exec", ...] -- one place, and one that `--dry-run` prints'
+    ),
 }
 DEPRECATED_POOL_KEYS: dict[str, str] = {
+    "strategy": (
+        "`ordered` was the only value left. The one it replaced, `random`, was "
+        "re-rolled on every call, so `sync push` landed the code on one member "
+        "and the `submit` after it queued the job on another. Selection takes the "
+        "first enabled member, and `--require`/`--fit` are how you ask for a "
+        "different one -- repeatably, and for a stated reason"
+    ),
     "default_profile": (
         "profile resolution never saw the pool, so this was unreachable; set it "
         "on the target, the protocol, or the project binding"
@@ -1958,13 +2517,6 @@ def load_targets(path: Path) -> dict[str, TargetRecord]:
         target = TargetRecord(
             name=name,
             enabled=bool(raw.get("enabled", True)),
-            transport=check_vocabulary(
-                str(raw.get("transport", "ssh")),
-                TRANSPORTS,
-                what=what,
-                key="transport",
-                source=source,
-            ),
             role=(
                 check_vocabulary(
                     str(raw["role"]), ROLES, what=what, key="role", source=source
@@ -1994,11 +2546,7 @@ def load_targets(path: Path) -> dict[str, TargetRecord]:
                 what=f"`[capabilities]` for {what}",
                 source=source,
             ),
-            ssh_host_alias=optional_str(raw.get("ssh_host_alias")),
             default_profile=optional_str(raw.get("default_profile")),
-            metadata=check_table(
-                raw.get("metadata", {}), what=f"`metadata` for {what}", source=source
-            ),
         )
         targets[target.name] = target
     return targets
@@ -2021,13 +2569,6 @@ def load_pools(path: Path) -> dict[str, PoolRecord]:
             name=name,
             targets=tuple(str(item) for item in raw.get("targets", [])),
             match_tags=tuple(str(item) for item in raw.get("match_tags", [])),
-            strategy=check_vocabulary(
-                str(raw.get("strategy", "ordered")),
-                POOL_STRATEGIES,
-                what=what,
-                key="strategy",
-                source=source,
-            ),
         )
         if not pool.targets and not pool.match_tags:
             # `select_pool` treats "no members declared" as "every target",
@@ -2051,7 +2592,6 @@ def built_in_protocols() -> dict[str, ProtocolRecord]:
         description="Direct SSH execution on a host-level workdir.",
         default_profile="plain-ssh",
         gpu_request_mode="gres",
-        job_runtime="host",
         native_batch_required=False,
     )
     slurm = ProtocolRecord(
@@ -2060,7 +2600,6 @@ def built_in_protocols() -> dict[str, ProtocolRecord]:
         description="Scheduler-backed login surface that submits compute via Slurm.",
         default_profile="slurm-batch",
         gpu_request_mode="gres",
-        job_runtime="host",
         native_batch_required=False,
     )
     return {
@@ -2161,7 +2700,6 @@ def load_protocols(path: Path) -> dict[str, ProtocolRecord]:
                 key="gpu_request_mode",
                 source=source,
             ),
-            job_runtime=str(raw.get("job_runtime", "host")),
             native_batch_required=bool(raw.get("native_batch_required", False)),
             job_output_dir=str(raw.get("job_output_dir", ".fleet/jobs")),
             docs=doc_values,
@@ -2411,7 +2949,10 @@ def parse_secret_dict(raw: dict[str, Any], *, source: Path | None = None) -> Fle
 
 
 def parse_secret_blob(text: str) -> dict[str, Any]:
-    """Parse multi-line secret material from `pass show`."""
+    """Parse multi-line secret material from an upcall.
+
+    Shared by the `pass` and `command` backends, so the error names neither.
+    """
     stripped = text.lstrip()
     if "=" in stripped:
         try:
@@ -2419,7 +2960,7 @@ def parse_secret_blob(text: str) -> dict[str, Any]:
         except tomllib.TOMLDecodeError as exc:
             raise FleetError(f"invalid TOML secret material: {exc}") from exc
     raise FleetError(
-        "pass secret material must be TOML with keys like `host`, `user`, and `port`"
+        "secret material must be TOML with keys like `host`, `user`, and `port`"
     )
 
 
@@ -2754,6 +3295,80 @@ def swap_config_tree(staging: Path, live: Path) -> Path | None:
             os.replace(previous, live)
         raise
     return previous if rotated else None
+
+SECRET_COMMAND_TIMEOUT = 30.0
+
+# How long one resolved upcall is reused.  ClusterShell caches its external group
+# sources too, but for an hour by default; this is far shorter because what is
+# cached is the address of a machine that moves, and a stale address is a
+# connection to whoever holds that address now.  It only has to cover the window
+# where two resolutions of one target must agree -- `sync push` and the `submit`
+# after it -- and it is deliberately not long enough to survive a coffee break.
+SECRET_COMMAND_TTL = 30.0
+
+# In-process only, and deliberately not a file under the state home.  A disk
+# cache of resolved secret material would be a second secret store with none of
+# the handling the first one gets, and the window that needs covering is one
+# command, not one week.  Locked because a fan-out resolves several targets at
+# once and they may share an upcall.
+_SECRET_COMMAND_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
+_SECRET_COMMAND_LOCK = threading.Lock()
+
+
+def run_secret_command(command: str, *, what: str) -> dict[str, Any]:
+    """Run one secret upcall and parse its output, cached for the TTL.
+
+    The whole point is to resolve a churning cloud address at connect time
+    without teaching fleetctl a cloud API: the command knows, fleetctl asks.
+
+    Its stdout is a secret, which is why the failure path reports stderr and
+    never stdout.  `run_pass_show` can fall back to printing stdout because
+    `pass` writes diagnostics there when it fails; an upcall that exits non-zero
+    has already put the first half of a credential there instead.  A failure is a
+    FleetError naming the command that failed -- never a partial secret handed on
+    to the connection layer, which would resolve to a target nobody chose.
+    """
+    argv = shlex.split(command)
+    if not argv:
+        raise FleetError(
+            f"`secret_ref` for {what} is empty, but the `command` backend reads "
+            "it as the command to run"
+        )
+    with _SECRET_COMMAND_LOCK:
+        cached = _SECRET_COMMAND_CACHE.get(command)
+        if cached is not None and cached[0] > time.monotonic():
+            return dict(cached[1])
+    try:
+        completed = subprocess.run(
+            argv,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=SECRET_COMMAND_TIMEOUT,
+        )
+    except FileNotFoundError as exc:
+        raise FleetError(
+            f"secret command for {what} cannot be run: {argv[0]!r} not found"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise FleetError(
+            f"secret command for {what} timed out after "
+            f"{SECRET_COMMAND_TIMEOUT:g}s: {shlex.join(argv)}"
+        ) from exc
+    if completed.returncode != 0:
+        detail = (completed.stderr or "").strip().splitlines()
+        raise FleetError(
+            f"secret command for {what} exited {completed.returncode}: "
+            + (detail[-1] if detail else "nothing on stderr to explain it")
+        )
+    values = parse_secret_blob(completed.stdout)
+    with _SECRET_COMMAND_LOCK:
+        _SECRET_COMMAND_CACHE[command] = (
+            time.monotonic() + SECRET_COMMAND_TTL,
+            dict(values),
+        )
+    return values
+
 
 def run_pass_show(secret_ref: str) -> str:
     """Fetch one pass entry."""
@@ -4320,7 +4935,6 @@ def target_display(
     """Render one target for table or JSON output."""
     return {
         "name": target.name,
-        "transport": target.transport,
         "protocol": protocol_name,
         "reach": list(target.reach),
         "workdir": target.workdir or "",
@@ -4343,7 +4957,6 @@ def protocol_display(protocol: ProtocolRecord) -> dict[str, Any]:
         "default_profile": protocol.default_profile or "",
         "default_queue": default_queue.name if default_queue is not None else "",
         "gpu_request_mode": protocol.gpu_request_mode,
-        "job_runtime": protocol.job_runtime,
         "native_batch_required": protocol.native_batch_required,
         "job_output_dir": protocol.job_output_dir,
         "docs": list(protocol.docs),
@@ -4650,7 +5263,6 @@ def local_target_template(name: str) -> str:
 version = 1
 name = "{name}"
 enabled = true
-transport = "ssh"
 protocol = "direct"
 # Ordered, and tried in order: direct first, a bridge as the fallback.
 # `["direct", "via:<bridge>"]` suits a host that is only sometimes dialable.
@@ -4691,7 +5303,6 @@ def pool_template(name: str) -> str:
     return f"""\
 version = 1
 name = "{name}"
-strategy = "ordered"
 targets = ["target-name"]
 """
 
@@ -4760,51 +5371,6 @@ def infer_secret_from_ssh_alias(alias: str) -> tuple[FleetSecret, str | None]:
         strict_host_key_checking=optional_str(raw.get("stricthostkeychecking")),
     )
     return secret, proxy_jump
-
-
-def parse_env_file(path: Path) -> dict[str, str]:
-    """Parse simple KEY=VALUE env files with shell quoting."""
-    values: dict[str, str] = {}
-    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
-        line = raw_line.strip()
-        if not line or line.startswith("#"):
-            continue
-        if line.startswith("export "):
-            line = line[len("export ") :].lstrip()
-        key, separator, value = line.partition("=")
-        if not separator:
-            raise FleetError(f"invalid env line {line_number} in {path}: {raw_line!r}")
-        parsed = shlex.split(value, posix=True)
-        if len(parsed) > 1:
-            raise FleetError(
-                f"env value for {key.strip()} on line {line_number} must parse to one token"
-            )
-        values[key.strip()] = parsed[0] if parsed else ""
-    return values
-
-
-def normalize_machine_name(name: str) -> str:
-    """Normalize a machine name for env-style prefixes."""
-    return name.upper().replace("-", "_").replace(".", "_")
-
-
-def machine_field(env: dict[str, str], prefix: str, machine: str, field: str) -> str | None:
-    """Return one imported env field."""
-    return env.get(f"{prefix}_{normalize_machine_name(machine)}_{field}")
-
-
-def configured_machine_names(env: dict[str, str], prefix: str) -> list[str]:
-    """Enumerate machine names from one env-based remote schema."""
-    configured = env.get(f"{prefix}_MACHINES", "")
-    if configured:
-        return [item.strip() for item in configured.split(",") if item.strip()]
-    suffix = "_HOST"
-    stem = f"{prefix}_"
-    names = []
-    for key in sorted(env):
-        if key.startswith(stem) and key.endswith(suffix):
-            names.append(key[len(stem) : -len(suffix)].lower())
-    return names
 
 
 TOML_ESCAPES = {
@@ -4883,7 +5449,6 @@ def target_to_toml(target: TargetRecord) -> str:
         "version = 1",
         f"name = {toml_string(target.name)}",
         f"enabled = {'true' if target.enabled else 'false'}",
-        f"transport = {toml_string(target.transport)}",
     ]
     if target.role:
         lines.append(f"role = {toml_string(target.role)}")
@@ -4900,8 +5465,6 @@ def target_to_toml(target: TargetRecord) -> str:
     lines.append(f"secret_backend = {toml_string(target.secret_backend)}")
     if target.secret_ref:
         lines.append(f"secret_ref = {toml_string(target.secret_ref)}")
-    if target.ssh_host_alias:
-        lines.append(f"ssh_host_alias = {toml_string(target.ssh_host_alias)}")
     if target.default_profile:
         lines.append(f"default_profile = {toml_string(target.default_profile)}")
     if target.capabilities:
@@ -5272,7 +5835,6 @@ def command_list(args: argparse.Namespace, context: FleetContext) -> int:
         [
             "name",
             "enabled",
-            "transport",
             "role",
             "protocol",
             "default_profile",
@@ -5320,7 +5882,6 @@ def command_show(args: argparse.Namespace, context: FleetContext) -> int:
             "name": pool.name,
             "targets": list(pool.targets),
             "match_tags": list(pool.match_tags),
-            "strategy": pool.strategy,
             "members": [member.name for member in context.pool_members(pool)],
             "resolved_target": resolved.name,
             "resolved_protocol": context.resolve_protocol(resolved).name,
@@ -5461,111 +6022,6 @@ def command_import_ssh(args: argparse.Namespace, context: FleetContext) -> int:
     return 0
 
 
-def command_migrate_env(args: argparse.Namespace, context: FleetContext) -> int:
-    """Import env-based remote config into private fleet state."""
-    ensure_private_dir(context.paths.config_home, mode=PRIVATE_DIR_MODE)
-    ensure_private_dir(context.paths.targets_dir, mode=PRIVATE_DIR_MODE)
-    ensure_private_dir(context.paths.secrets_dir, mode=PRIVATE_DIR_MODE)
-    ensure_private_dir(context.paths.profiles_dir, mode=PRIVATE_DIR_MODE)
-    write_text_if_missing(
-        context.paths.profiles_dir / "plain-ssh.toml",
-        default_plain_profile_template(),
-        mode=PRIVATE_FILE_MODE,
-    )
-
-    env = parse_env_file(args.env_file)
-    prefix = args.prefix
-    names = configured_machine_names(env, prefix)
-    if not names:
-        raise FleetError(
-            f"no machines found in {args.env_file}; expected keys like "
-            f"{prefix}_MACHINES or {prefix}_<MACHINE>_HOST"
-        )
-
-    imported: list[str] = []
-    target_roots: dict[str, str] = {}
-    project_path = (
-        expand_local_path(args.project_path)
-        if args.project_path
-        else args.env_file.resolve().parent
-    )
-    project_name = project_path.name
-    for machine in names:
-        secret_path = context.paths.secrets_dir / f"{machine}.toml"
-        target_path = context.paths.targets_dir / f"{machine}.toml"
-        if not args.force and (secret_path.exists() or target_path.exists()):
-            raise FleetError(
-                f"target {machine!r} already exists; rerun with --force to overwrite"
-            )
-        secret = FleetSecret(
-            host=required_env_field(env, prefix, machine, "HOST"),
-            user=required_env_field(env, prefix, machine, "USER"),
-            port=int(machine_field(env, prefix, machine, "PORT") or "22"),
-            auth=(machine_field(env, prefix, machine, "AUTH") or "key").lower(),
-            identity_file=optional_str(machine_field(env, prefix, machine, "SSH_KEY")),
-            password=optional_str(machine_field(env, prefix, machine, "PASSWORD")),
-            connect_timeout=int(args.connect_timeout),
-            server_alive_interval=int(args.server_alive_interval),
-            server_alive_count_max=int(args.server_alive_count_max),
-        )
-        remote_root = optional_str(machine_field(env, prefix, machine, "WORKDIR"))
-        inferred_workdir = None
-        if remote_root:
-            remote_root_path = PurePosixPath(remote_root)
-            if remote_root_path.name == project_name:
-                inferred_workdir = str(remote_root_path.parent)
-        target = TargetRecord(
-            name=machine,
-            role=args.role,
-            protocol=args.protocol or "direct",
-            workdir=inferred_workdir,
-            tags=tuple(args.tag),
-            secret_backend="file",
-            secret_ref=str(secret_path),
-            default_profile=args.profile or "plain-ssh",
-        )
-        write_text_file(target_path, target_to_toml(target), mode=PRIVATE_FILE_MODE)
-        write_text_file(secret_path, secret_to_toml(secret), mode=PRIVATE_FILE_MODE)
-        if remote_root and not inferred_workdir:
-            target_roots[machine] = remote_root
-        imported.append(machine)
-
-    default_machine = optional_str(env.get(f"{prefix}_DEFAULT_MACHINE"))
-    existing = next(
-        (item for item in context.projects if item.path == project_path),
-        None,
-    )
-    update_project_binding(
-        context.paths.projects_file,
-        project_path=project_path,
-        target=default_machine or (existing.default_target if existing else None),
-        pool=existing.default_pool if existing else None,
-        profile=args.profile or (
-            existing.default_profile if existing else "plain-ssh"
-        ),
-        remote_root=existing.remote_root if existing else None,
-        remote_roots_by_target={
-            **(existing.remote_roots_by_target if existing else {}),
-            **target_roots,
-        },
-        sync_excludes=existing.sync_excludes if existing else (),
-    )
-
-    for machine in imported:
-        print(machine)
-    return 0
-
-
-def required_env_field(env: dict[str, str], prefix: str, machine: str, field: str) -> str:
-    """Require one imported env field."""
-    value = machine_field(env, prefix, machine, field)
-    if value is None or value == "":
-        raise FleetError(
-            f"missing required field {prefix}_{normalize_machine_name(machine)}_{field}"
-        )
-    return value
-
-
 def command_seed_pass(args: argparse.Namespace, context: FleetContext) -> int:
     """Seed pass entries from the current live fleet config."""
     prefix = args.pass_prefix.strip("/")
@@ -5618,20 +6074,11 @@ def command_seed_pass(args: argparse.Namespace, context: FleetContext) -> int:
         secret_entry = pass_entry_name(prefix, "secrets", target.name)
         run_pass_insert(secret_entry, secret_to_toml(secret), force=args.force)
         written.append(secret_entry)
-        rendered_target = TargetRecord(
-            name=target.name,
-            enabled=target.enabled,
-            transport=target.transport,
-            role=target.role,
-            protocol=target.protocol,
-            workdir=target.workdir,
-            tags=target.tags,
+        rendered_target = replace(
+            target,
             secret_backend="pass",
             secret_ref=secret_entry,
             secret_inline={},
-            ssh_host_alias=target.ssh_host_alias,
-            default_profile=target.default_profile,
-            metadata=target.metadata,
         )
         target_entry = pass_entry_name(prefix, "targets", target.name)
         run_pass_insert(target_entry, target_to_toml(rendered_target), force=args.force)
@@ -5654,7 +6101,6 @@ def pool_to_toml(pool: PoolRecord) -> str:
     if pool.match_tags:
         tags = ", ".join(toml_string(tag) for tag in pool.match_tags)
         lines.append(f"match_tags = [{tags}]")
-    lines.append(f"strategy = {toml_string(pool.strategy)}")
     return "\n".join(lines) + "\n"
 
 
@@ -5828,12 +6274,7 @@ def command_migrate_config(args: argparse.Namespace) -> int:
                 if role == "login"
                 else f"protocol {protocol.name!r} runs work directly"
             )
-        # target_to_toml() cannot express these, so a rewrite would drop them.
-        if target.metadata:
-            blockers.append(
-                f"{name}: defines `metadata`, which fleetctl does not read and this "
-                "rewrite would silently drop; delete it by hand first"
-            )
+        # target_to_toml() cannot express this, so a rewrite would drop it.
         if target.secret_inline:
             blockers.append(
                 f"{name}: keeps its connection details in an inline `[secret]` table, "
@@ -5898,6 +6339,8 @@ def command_migrate_config(args: argparse.Namespace) -> int:
             # change list, which is what decides whether the swap happens at all.
             original = source.read_text(encoding="utf-8") if source else ""
             _, dead = strip_top_level_keys(original, DEPRECATED_TARGET_KEYS)
+            if strip_toml_table(original, "metadata")[1]:
+                dead = [*dead, "metadata"]
             for key in dead:
                 changes.append(f"targets.d/{new_name}.toml: dropped `{key}`")
             comments = sum(1 for line in original.splitlines() if line.strip().startswith("#"))
@@ -6197,9 +6640,32 @@ def command_ssh(args: argparse.Namespace, context: FleetContext) -> int:
 
 
 def command_smoke(args: argparse.Namespace, context: FleetContext) -> int:
-    """Run a lightweight connectivity check."""
+    """Run a lightweight connectivity check, on one host or across a fan-out."""
+    if fanout_requested(args):
+        return fanout_run(context, args, verb="ssh", work=smoke_one)
     # `smoke` only reports on the host, so it rides the same rule as `ssh`.
     plan = build_plan(context, args, "ssh")
+    code, out, err = smoke_one(plan)
+    if out:
+        print(out, end="")
+    if err:
+        print(err, end="", file=sys.stderr)
+    if code != 0:
+        raise FleetError(
+            f"smoke check failed for {plan.target.name!r} with exit code {code}",
+            exit_code=code,
+        )
+    return 0
+
+
+def smoke_one(plan: Plan) -> tuple[int, str, str]:
+    """Run the smoke script against PLAN and hand back what it printed.
+
+    Split out of the handler so a fan-out can hold N of these until every host
+    has answered.  Returning the output instead of printing it is the whole
+    difference: four hosts writing to one terminal at once is not a report.
+    """
+    # `smoke` only reports on the host, so it rides the same rule as `ssh`.
     target = plan.target
     protocol = plan.protocol
     workdir = target.workdir
@@ -6280,16 +6746,7 @@ def command_smoke(args: argparse.Namespace, context: FleetContext) -> int:
         timeout=CONTROL_COMMAND_TIMEOUT,
         **plan.connect(),
     )
-    if completed.stdout:
-        print(completed.stdout, end="")
-    if completed.stderr:
-        print(completed.stderr, end="", file=sys.stderr)
-    if completed.returncode != 0:
-        raise FleetError(
-            f"smoke check failed for {target.name!r} with exit code {completed.returncode}",
-            exit_code=completed.returncode,
-        )
-    return 0
+    return completed.returncode, completed.stdout or "", completed.stderr or ""
 
 
 def command_exec(args: argparse.Namespace, context: FleetContext) -> int:
@@ -6309,6 +6766,15 @@ def command_exec(args: argparse.Namespace, context: FleetContext) -> int:
             "`fleetctl exec` requires a command after `--`, as in "
             "`fleetctl exec rtx1 -- nvidia-smi`"
         )
+    if fanout_requested(args):
+        # No TTY across a fan-out, and none is offered: N pseudo-terminals
+        # sharing one keyboard is not something to allocate by accident.
+        return fanout_run(
+            context,
+            args,
+            verb="exec",
+            work=lambda plan: exec_one(plan, argv),
+        )
     plan = build_plan(context, args, "exec")
     environment = dict(plan.profile.environment)
     if args.dry_run:
@@ -6317,26 +6783,42 @@ def command_exec(args: argparse.Namespace, context: FleetContext) -> int:
             args,
             {"remote_command": shlex.join(argv), "environment": environment or None},
         )
+    completed = run_ssh_command(
+        plan.secret,
+        allocate_tty=bool(args.tty),
+        remote_command=exec_remote_command(plan, argv),
+        **plan.connect(),
+    )
+    return completed.returncode
+
+
+def exec_remote_command(plan: Plan, argv: list[str]) -> str:
+    """Build the remote invocation `exec` sends: ARGV, uninterpreted."""
     encoded_stub = base64.b64encode(EXEC_REMOTE_STUB.encode("utf-8")).decode("ascii")
     payload = base64.b64encode(
         json.dumps(
             {
                 "argv": argv,
-                "env": environment,
+                "env": dict(plan.profile.environment),
             }
         ).encode("utf-8")
     ).decode("ascii")
-    remote = remote_shell_command(
+    return remote_shell_command(
         ["python3", "-c", EXEC_REMOTE_BOOTSTRAP, encoded_stub, payload],
         cwd=plan.cwd,
     )
+
+
+def exec_one(plan: Plan, argv: list[str]) -> tuple[int, str, str]:
+    """Run ARGV against PLAN and hand back what it printed, for a fan-out."""
     completed = run_ssh_command(
         plan.secret,
-        allocate_tty=bool(args.tty),
-        remote_command=remote,
+        allocate_tty=False,
+        remote_command=exec_remote_command(plan, argv),
+        capture_output=True,
         **plan.connect(),
     )
-    return completed.returncode
+    return completed.returncode, completed.stdout or "", completed.stderr or ""
 
 
 def run_script_plan(
@@ -6717,6 +7199,22 @@ def run_job_command(
         raise FleetError(
             f"profile {plan.profile.name!r} does not support this job operation"
         )
+    code, out, err = job_command_output(plan, template, job_id=job_id)
+    if out:
+        print(out, end="")
+    if err:
+        print(err, end="", file=sys.stderr)
+    return code
+
+
+def job_command_output(
+    plan: Plan, template: tuple[str, ...], *, job_id: str
+) -> tuple[int, str, str]:
+    """Run one scheduler command and hand back what it printed."""
+    if not template:
+        raise FleetError(
+            f"profile {plan.profile.name!r} does not support this job operation"
+        )
     argv = render_template_values(template, job_id=job_id, workdir=plan.cwd)
     completed = run_ssh_command(
         plan.secret,
@@ -6726,15 +7224,29 @@ def run_job_command(
         timeout=CONTROL_COMMAND_TIMEOUT,
         **plan.connect(),
     )
-    if completed.stdout:
-        print(completed.stdout, end="")
-    if completed.stderr:
-        print(completed.stderr, end="", file=sys.stderr)
-    return completed.returncode
+    return completed.returncode, completed.stdout or "", completed.stderr or ""
 
 
 def command_job_status(args: argparse.Namespace, context: FleetContext) -> int:
-    """Check remote scheduler status."""
+    """Check remote scheduler status, on one host or across a fan-out.
+
+    The one `job` operation that fans out: it reads, and asking six sites where
+    a job is is a question with six independent answers.  `logs` and `cancel`
+    refuse, because a scheduler id means nothing off the site that issued it.
+
+    A fan-out does not consult the ledger.  `--all` and `--tag` name the set
+    outright, and filling a target in from a past submission would quietly
+    shrink that set to one.
+    """
+    if fanout_requested(args):
+        return fanout_run(
+            context,
+            args,
+            verb="job",
+            work=lambda plan: job_command_output(
+                plan, plan.profile.status_command, job_id=args.job_id
+            ),
+        )
     apply_job_ledger_defaults(args, context)
     plan = build_plan(context, args, "job")
     return run_job_command(plan, plan.profile.status_command, job_id=args.job_id)
@@ -6799,6 +7311,55 @@ def toml_syntax_problems(paths: FleetPaths) -> list[str]:
         except OSError as exc:
             problems.append(f"cannot read {candidate}: {exc}")
     return problems
+
+
+def command_probe(args: argparse.Namespace, context: FleetContext) -> int:
+    """Measure one target and record what it reported.
+
+    Admitted as `ssh`, deliberately not as a verb of its own: it reads and
+    reports, exactly like `smoke`, and a seventh column in the role matrix would
+    be a seventh thing every role needs an opinion about when the opinion here is
+    already "may I look at this host".
+    """
+    plan = build_plan(context, args, "ssh")
+    completed = run_ssh_command(
+        plan.secret,
+        allocate_tty=False,
+        remote_command=remote_shell_command(probe_remote_argv(plan)),
+        capture_output=True,
+        timeout=CONTROL_COMMAND_TIMEOUT,
+        **plan.connect(),
+    )
+    if completed.returncode != 0:
+        detail = (completed.stderr or "").strip().splitlines()
+        raise FleetError(
+            f"probe of {plan.target.name!r} failed with exit code "
+            f"{completed.returncode}: "
+            + (detail[-1] if detail else "no diagnostic on stderr"),
+            exit_code=completed.returncode,
+        )
+    observed = parse_probe_output(completed.stdout)
+    measured = {key: observed[key] for key in PROBE_FACT_KEYS if key in observed}
+    facts = {
+        "target": plan.target.name,
+        "probed_at": utc_timestamp(),
+        "route": plan.route,
+        "capabilities": measured,
+        "observed": {
+            key: value for key, value in observed.items() if key not in measured
+        },
+    }
+    path = write_probed_facts(context.paths, plan.target.name, facts)
+    payload = dict(facts)
+    payload["facts_file"] = str(path)
+    payload["drift"] = [detail for _, detail in capability_drift(
+        plan.target.capabilities, measured
+    )]
+    emit(payload, as_json=bool(args.json))
+    # Zero even when the measurement contradicts the declaration.  `probe`
+    # records; `doctor` decides whether a contradiction is a fault, because
+    # `doctor` is the command whose exit status people already gate on.
+    return 0
 
 
 def probe_remote_prerequisites(
@@ -7126,6 +7687,26 @@ def command_doctor(args: argparse.Namespace) -> int:
                     f"target {target.name!r}", target.capabilities
                 )
             )
+            # Drift between what a target declares and what `probe` last
+            # measured.  Reported here rather than acted on anywhere: the
+            # declaration stays authoritative, and this is the only thing the
+            # measurement is for.
+            facts = read_probed_facts(paths, target.name)
+            measured = facts.get("capabilities")
+            if isinstance(measured, dict):
+                for severity, detail in capability_drift(
+                    target.capabilities, measured
+                ):
+                    line = (
+                        f"target {target.name!r} {detail} "
+                        f"[probed {facts.get('probed_at') or 'at an unknown time'}]"
+                    )
+                    if severity == "short":
+                        # Slurm DRAINs a node found short of its configured GRES
+                        # instead of logging it and carrying on scheduling.
+                        problems.append(line)
+                    else:
+                        warnings.append(line)
             for queue in protocol.queues:
                 warnings.extend(
                     capability_key_warnings(
@@ -7276,6 +7857,7 @@ NAME
 
 SYNOPSIS
     fleetctl <verb> [<target>|<pool>] [--admin] [--route <route>]
+    fleetctl <verb> --all|--tag <tag> [--jobs <n>]
     fleetctl exec <target> [--tty] [--dry-run] -- <argv>...
     fleetctl script <file> --target <target> [--interpreter <cmd>]
     fleetctl sync push|pull <local> [<remote>] [--delete] [--force]
@@ -7286,12 +7868,37 @@ ADMISSION VERBS
 
 {VERB_TABLE}
 
-    `smoke` is not one of them: it only reports on the host, so it is
-    admitted as `ssh`. Nine subcommands open a connection and so carry
-    --admin and --route together -- ssh, smoke, exec, script, sync,
-    submit, and the three `job` operations. `explain` takes both too,
-    so you can ask what an --admin run or a chosen route would do
-    without doing it.
+    `smoke` and `probe` are not among them: both only report on the
+    host, so both are admitted as `ssh`. Ten subcommands open a
+    connection and so carry --admin and --route together -- ssh, smoke,
+    probe, exec, script, sync, submit, and the three `job` operations.
+    `explain` takes both too, so you can ask what an --admin run or a
+    chosen route would do without doing it.
+
+FAN-OUT
+    --all covers every enabled target, --tag every enabled target
+    carrying one tag, and --jobs runs up to N at once. Sequential by
+    default. Each host's output is prefixed with its name and held until
+    every host has answered, then one line per target reports ok,
+    failed, refused or plan.
+
+    Only smoke, exec and job status fan out. sync, submit, script, ssh,
+    probe, job logs and job cancel refuse by name: they write, or they
+    mean something different at each site, and partial failure across a
+    fleet leaves a state nothing afterwards can report. A fanned-out
+    `sbatch` is a fanned-out double submission.
+
+    Concurrency is capped per reach-hop at {FANOUT_HOP_LIMIT}, not
+    globally: a bridge multiplexes every connection through one small
+    machine, while direct hosts share no such bottleneck. A target that
+    declares a `via:` fallback counts against that bridge even when
+    direct is up, because a cap that only holds while nothing falls back
+    is not a cap; `--route direct --no-fallback` narrows the route list
+    and gets the full --jobs back.
+
+    Anything left out is said out loud -- a disabled host, a cap, a
+    target that would not resolve. Exit status is 2 if anything was
+    refused, otherwise the first non-zero remote code by target name.
 
     Those same nine append one line to
     $FLEET_STATE_HOME/audit.jsonl: the time, the subcommand, the
@@ -7304,9 +7911,9 @@ ADMISSION VERBS
 EVERYTHING ELSE
     Inventory   jobs, list, show, explain, resolve, protocol show,
                 queue list, project bind|show|list
-    Setup       init, import-ssh, migrate-config, migrate-env
+    Setup       init, import-ssh, migrate-config
     Secrets     seed-pass, deploy-config
-    Diagnosis   doctor, help
+    Diagnosis   doctor, probe, help
 
     --json is on the inspection and diagnostic subcommands only. A verb
     that runs remote work prints what the remote printed.
@@ -7559,9 +8166,27 @@ PREFLIGHT
     units are scheduler-specific, and a wrong parse would refuse a
     valid job.
 
-    Declared values are authoritative and nothing is measured. What a
-    machine has is a fact its owner writes down, not something probed
-    at selection time and already stale.
+MEASUREMENT
+    Declared values are authoritative. What a machine has is a fact its
+    owner writes down, not something probed at selection time and
+    already stale, and nothing here ever reads a measurement.
+
+    `fleetctl probe <target>` measures one host -- nvidia-smi, lscpu,
+    free, python3, and sinfo for the queues at a scheduler site -- and
+    writes it to `<state-home>/facts/<target>.json`, 0600. Those facts
+    exist for exactly one purpose: `doctor` compares them against the
+    declaration and reports the difference. They cannot select a host,
+    admit a verb or satisfy a --require, and the split is deliberate:
+    the machine being described is the one supplying the description.
+
+    Measuring short of the declaration is a problem, not a warning. A
+    box with less than it promised accepts a job sized for the promise
+    and then fails it -- the same reason Slurm DRAINs a node found
+    short of its configured GRES. Measuring over it is a warning: the
+    declaration is stale and --fit is choosing on old numbers. Memory
+    and VRAM carry a tolerance, because `free` never reports the
+    nominal size and a check that flags every honest machine gets
+    ignored.
 
 SEE ALSO
     fleetctl help roles, fleetctl help jobs, fleetctl help config
@@ -7575,6 +8200,7 @@ SYNOPSIS
         config.toml  projects.toml
         targets.d/  pools.d/  protocols.d/  profiles.d/  secrets/
     $FLEET_STATE_HOME   known_hosts  routes.json  jobs.jsonl  audit.jsonl
+                        facts/
     $FLEET_CACHE_HOME   mux/  (ssh control sockets)
 
 DESCRIPTION
@@ -7619,7 +8245,7 @@ NAME
     fleetctl secrets - connection material, kept out of the inventory
 
 SYNOPSIS
-    secret_backend = "file" | "pass" | "inline"
+    secret_backend = "file" | "pass" | "inline" | "command"
     secret_ref = "<config-home>/secrets/<target>.toml"
     fleetctl show <target> --secret [--sensitive]
 
@@ -7635,9 +8261,28 @@ DESCRIPTION
     entry becomes one `-o key=value`, which is the escape hatch for
     everything fleetctl does not model.
 
-    Three backends: a private TOML file, a `pass` entry, or a
-    `secret = { ... }` table inline in the target. Resolution is lazy,
-    on first use, so only the code that opens a connection pays for it.
+    Four backends: a private TOML file, a `pass` entry, a
+    `secret = { ... }` table inline in the target, or a command.
+    Resolution is lazy, on first use, so only the code that opens a
+    connection pays for it.
+
+    `secret_backend = "command"` runs `secret_ref` and reads the same
+    TOML off its stdout, merged over the target's inline `[secret]`
+    table. It is for the field that will not hold still -- a cloud box
+    whose address changes on every start -- so the address is resolved
+    at connect time by a script that already knows, rather than by
+    teaching fleetctl one provider's API and then the next one's. The
+    result is cached for 30 seconds, which covers a `sync push` and the
+    `submit` after it and not much else; a stale address is a
+    connection to whoever holds that address now. The cache is in
+    memory only, because a resolved secret on disk would be a second
+    secret store with none of the handling the first one gets.
+
+    Its stdout is a secret and is treated as one: redacted by `show`
+    like any other, and never quoted in an error. A failing upcall is a
+    refusal naming the command and its stderr -- never a partial secret
+    passed on to the connection layer, which would resolve to a host
+    nobody chose.
 
     A `host`, `user`, `port`, `password` or `identity_file` key in a
     target file is refused with that explanation, not a spelling hint:
@@ -7769,6 +8414,15 @@ DESCRIPTION
         fleetctl doctor
         fleetctl doctor --probe
 
+    Ask the whole fleet one read-only question, four at a time:
+        fleetctl smoke --all --jobs 4
+        fleetctl exec --tag gpu --jobs 4 -- nvidia-smi -L
+
+    Measure a host, then have doctor report what disagrees with the
+    inventory:
+        fleetctl probe <target>
+        fleetctl doctor
+
     Pick a machine by what it has rather than by name, smallest
     sufficient one first:
         fleetctl list --format capabilities
@@ -7832,6 +8486,10 @@ def render_manual(topic: str) -> str:
         .replace("{VERB_TABLE}", render_verb_table())
         .replace("{TOPIC_LIST}", "  ".join(MANUAL_TOPICS))
         .replace("{FIT_KEYS}", ", ".join(FIT_ORDER))
+        # Substituted rather than written out, for the same reason the role table
+        # is: a manual that states the cap independently of the cap is a manual
+        # that will one day be wrong.
+        .replace("{FANOUT_HOP_LIMIT}", str(FANOUT_HOP_LIMIT))
         .rstrip()
     )
 
@@ -7902,6 +8560,36 @@ def add_connection_flags(parser: argparse.ArgumentParser) -> None:
     add_route_flag(parser)
     add_capability_flags(parser)
     parser.set_defaults(audited=True)
+    add_fanout_flags(parser)
+
+
+def add_fanout_flags(parser: argparse.ArgumentParser) -> None:
+    """Register `--all`, `--tag` and `--jobs` on a verb that opens a connection.
+
+    Including the verbs that refuse to fan out, which is the point: argparse's
+    "unrecognized arguments: --all" explains nothing, and every other refusal in
+    this tool names the reason and the alternative.
+    """
+    parser.add_argument(
+        "--all",
+        dest="all_targets",
+        action="store_true",
+        help="Run against every enabled target (read-only verbs only)",
+    )
+    parser.add_argument(
+        "--tag",
+        help="Run against every enabled target carrying one tag",
+    )
+    parser.add_argument(
+        "--jobs",
+        type=int,
+        default=1,
+        metavar="N",
+        help=(
+            "Run up to N targets at once; sequential by default, and never more "
+            f"than {FANOUT_HOP_LIMIT} through any one bridge"
+        ),
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -8195,67 +8883,6 @@ def build_parser() -> argparse.ArgumentParser:
     )
     import_ssh_parser.set_defaults(handler=command_import_ssh)
 
-    migrate_env_parser = subparsers.add_parser(
-        "migrate-env",
-        help="Import env-based remote config into private fleet state",
-    )
-    migrate_env_parser.add_argument(
-        "--env-file",
-        type=Path,
-        required=True,
-        help="Path to the env file that currently holds remote config",
-    )
-    migrate_env_parser.add_argument(
-        "--prefix",
-        required=True,
-        help="Env variable prefix, without trailing underscore",
-    )
-    migrate_env_parser.add_argument(
-        "--tag",
-        action="append",
-        default=[],
-        help="Tag to attach to imported targets",
-    )
-    migrate_env_parser.add_argument(
-        "--profile",
-        default="plain-ssh",
-        help="Default profile to assign to imported targets",
-    )
-    migrate_env_parser.add_argument(
-        "--protocol",
-        help="Protocol name to attach to imported targets",
-    )
-    migrate_env_parser.add_argument(
-        "--role",
-        choices=ROLES,
-        help="Role to assign to every imported machine",
-    )
-    migrate_env_parser.add_argument(
-        "--project-path",
-        help="Project path for the generated local project binding",
-    )
-    migrate_env_parser.add_argument(
-        "--connect-timeout",
-        default=30,
-        help="Default connect timeout to store in imported secrets",
-    )
-    migrate_env_parser.add_argument(
-        "--server-alive-interval",
-        default=30,
-        help="Default ServerAliveInterval to store in imported secrets",
-    )
-    migrate_env_parser.add_argument(
-        "--server-alive-count-max",
-        default=3,
-        help="Default ServerAliveCountMax to store in imported secrets",
-    )
-    migrate_env_parser.add_argument(
-        "--force",
-        action="store_true",
-        help="Overwrite existing targets and secrets",
-    )
-    migrate_env_parser.set_defaults(handler=command_migrate_env)
-
     ssh_parser = subparsers.add_parser("ssh", help="Open an interactive SSH session")
     ssh_parser.add_argument("selector", nargs="?", help="Target or pool name")
     add_connection_flags(ssh_parser)
@@ -8267,6 +8894,17 @@ def build_parser() -> argparse.ArgumentParser:
     smoke_parser.add_argument("--cwd", help="Remote working directory override")
     add_connection_flags(smoke_parser)
     smoke_parser.set_defaults(handler=command_smoke)
+
+    probe_parser = subparsers.add_parser(
+        "probe",
+        help="Measure one target and record the facts (advisory; decides nothing)",
+    )
+    probe_parser.add_argument("selector", nargs="?", help="Target or pool name")
+    probe_parser.add_argument("--profile", help="Execution profile override")
+    probe_parser.add_argument("--cwd", help="Remote working directory override")
+    probe_parser.add_argument("--json", action="store_true", help="Emit JSON")
+    add_connection_flags(probe_parser)
+    probe_parser.set_defaults(handler=command_probe)
 
     exec_parser = subparsers.add_parser(
         "exec",

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import difflib
 import json
 import os
 import posixpath
@@ -272,6 +273,7 @@ class FleetContext:
             cache_home=cache_home,
         )
         config = load_toml_file(paths.config_file, default={})
+        validate_config_file(config, source=paths.config_file)
         targets = load_targets(paths.targets_dir)
         pools = load_pools(paths.pools_dir)
         protocols = load_protocols(paths.protocols_dir)
@@ -419,7 +421,7 @@ class FleetContext:
                 raise FleetError(f"target {target.name!r} is missing `secret_ref`")
             path = expand_local_path(target.secret_ref)
             raw = load_toml_file(path)
-            return parse_secret_dict(raw)
+            return parse_secret_dict(raw, source=path)
         if target.secret_backend == "pass":
             if not target.secret_ref:
                 raise FleetError(f"target {target.name!r} is missing `secret_ref`")
@@ -497,6 +499,247 @@ def load_repo_template(path: str, fallback: str) -> str:
     return template_path.read_text(encoding="utf-8")
 
 
+# ---- SECTION: config schema ------------------------------------------------
+#
+# Every key fleetctl understands is listed here, and anything else in a config
+# file is a hard error.  This is deliberate: silently ignoring an unknown key is
+# the tool's worst failure mode, because the defaults that fill in for a
+# misspelled key are the permissive ones.  `protocal = "amd-slurm"` used to
+# leave the target on the built-in `direct` protocol, which allows unrestricted
+# login-node execution -- a typo quietly turned a scheduler site into a box you
+# could run training jobs on directly.  Failing at load time, naming the file
+# and the key, is worth more than any amount of downstream checking.
+
+CONFIG_VERSION = 1
+
+CONFIG_KEYS = frozenset({"version", "defaults", "ssh"})
+CONFIG_DEFAULTS_KEYS = frozenset({"redact_sensitive_output"})
+CONFIG_SSH_KEYS = frozenset(
+    {
+        "user_known_hosts_file",
+        "strict_host_key_checking",
+        "update_host_keys",
+        "control_path",
+    }
+)
+TARGET_KEYS = frozenset(
+    {
+        "version",
+        "name",
+        "enabled",
+        "transport",
+        "protocol",
+        "workdir",
+        "tags",
+        "secret_backend",
+        "secret_ref",
+        "secret",
+        "ssh_host_alias",
+        "default_profile",
+        "scheduler",
+        "metadata",
+    }
+)
+POOL_KEYS = frozenset(
+    {"version", "name", "targets", "match_tags", "strategy", "default_profile"}
+)
+PROTOCOL_KEYS = frozenset(
+    {
+        "version",
+        "name",
+        "kind",
+        "description",
+        "default_profile",
+        "scheduler_required",
+        "allow_login_exec",
+        "smoke_gpu_probe",
+        "gpu_request_mode",
+        "job_runtime",
+        "native_batch_required",
+        "job_output_dir",
+        "docs",
+        "notes",
+        "queue",
+    }
+)
+QUEUE_KEYS = frozenset(
+    {
+        "name",
+        "partition",
+        "default",
+        "time_limit",
+        "gpus",
+        "gres",
+        "cpus_per_task",
+        "mem",
+        "account",
+        "qos",
+        "constraint",
+        "directive",
+        "directives",
+        "notes",
+    }
+)
+PROFILE_KEYS = frozenset(
+    {
+        "version",
+        "name",
+        "kind",
+        "script",
+        "environment",
+        "submit_command",
+        "status_command",
+        "cancel_command",
+        "logs_command",
+        "job_id_pattern",
+    }
+)
+PROFILE_SCRIPT_KEYS = frozenset({"interpreter", "remote_script_root"})
+PROJECTS_FILE_KEYS = frozenset({"version", "project"})
+PROJECT_KEYS = frozenset(
+    {
+        "path",
+        "default_target",
+        "default_pool",
+        "default_profile",
+        "remote_root",
+        "target_root",
+        "sync_excludes",
+    }
+)
+PROJECT_TARGET_ROOT_KEYS = frozenset({"target", "remote_root"})
+SECRET_KEYS = frozenset(
+    {
+        "host",
+        "user",
+        "port",
+        "auth",
+        "identity_file",
+        "password",
+        "proxy_jump",
+        "identities_only",
+        "forward_agent",
+        "compression",
+        "connect_timeout",
+        "server_alive_interval",
+        "server_alive_count_max",
+        "strict_host_key_checking",
+        "batch_mode",
+        "ssh_option",
+    }
+)
+
+TRANSPORTS = ("ssh",)
+SECRET_BACKENDS = ("file", "pass", "inline")
+SCHEDULERS = ("none", "slurm")
+POOL_STRATEGIES = ("ordered", "random")
+PROTOCOL_KINDS = ("direct", "slurm")
+PROFILE_KINDS = ("direct", "scheduler")
+GPU_REQUEST_MODES = ("none", "gpus", "gres")
+AUTH_MODES = ("key", "password")
+STRICT_HOST_KEY_MODES = ("yes", "no", "off", "ask", "accept-new")
+
+
+def reject_unknown_keys(
+    raw: dict[str, Any],
+    known: Iterable[str],
+    *,
+    what: str,
+    source: Path | None = None,
+    guidance: dict[str, str] | None = None,
+) -> None:
+    """Fail on any key the loader would otherwise ignore."""
+    known_keys = sorted(known)
+    unknown = sorted(key for key in raw if key not in set(known_keys))
+    if not unknown:
+        return
+    hints: list[str] = []
+    for key in unknown:
+        if guidance and key in guidance:
+            hints.append(f"`{key}` ({guidance[key]})")
+            continue
+        close = difflib.get_close_matches(key, known_keys, n=1, cutoff=0.7)
+        suggestion = f" (did you mean `{close[0]}`?)" if close else ""
+        hints.append(f"`{key}`{suggestion}")
+    where = f" in {source}" if source is not None else ""
+    plural = "keys" if len(unknown) > 1 else "key"
+    raise FleetError(
+        f"unrecognised {plural} in {what}{where}: {'; '.join(hints)}. "
+        f"Known keys: {', '.join(known_keys)}."
+    )
+
+
+def check_vocabulary(
+    value: str,
+    allowed: tuple[str, ...],
+    *,
+    what: str,
+    key: str,
+    source: Path | None = None,
+) -> str:
+    """Return VALUE when it is a member of ALLOWED, else fail."""
+    if value in allowed:
+        return value
+    close = difflib.get_close_matches(value, list(allowed), n=1, cutoff=0.6)
+    suggestion = f" Did you mean {close[0]!r}?" if close else ""
+    where = f" in {source}" if source is not None else ""
+    raise FleetError(
+        f"invalid `{key}` for {what}{where}: {value!r} is not one of "
+        f"{', '.join(repr(item) for item in allowed)}.{suggestion}"
+    )
+
+
+def check_version(
+    raw: dict[str, Any],
+    *,
+    what: str,
+    source: Path | None = None,
+) -> None:
+    """Reject a config file written for a different schema generation."""
+    if "version" not in raw:
+        return
+    version = raw["version"]
+    if version != CONFIG_VERSION:
+        where = f" in {source}" if source is not None else ""
+        raise FleetError(
+            f"unsupported `version` for {what}{where}: {version!r}; this "
+            f"fleetctl understands version {CONFIG_VERSION}"
+        )
+
+
+def check_table(value: Any, *, what: str, source: Path | None = None) -> dict[str, Any]:
+    """Return VALUE as a TOML table or fail with a readable message."""
+    if not isinstance(value, dict):
+        where = f" in {source}" if source is not None else ""
+        raise FleetError(f"{what}{where} must be a table, not {type(value).__name__}")
+    return value
+
+
+def validate_config_file(raw: dict[str, Any], *, source: Path) -> None:
+    """Validate the top-level config.toml."""
+    check_version(raw, what="fleet config", source=source)
+    reject_unknown_keys(raw, CONFIG_KEYS, what="fleet config", source=source)
+    defaults = check_table(
+        raw.get("defaults", {}), what="`defaults`", source=source
+    )
+    reject_unknown_keys(
+        defaults, CONFIG_DEFAULTS_KEYS, what="fleet config `[defaults]`", source=source
+    )
+    ssh_section = check_table(raw.get("ssh", {}), what="`ssh`", source=source)
+    reject_unknown_keys(
+        ssh_section, CONFIG_SSH_KEYS, what="fleet config `[ssh]`", source=source
+    )
+    strict = optional_str(ssh_section.get("strict_host_key_checking"))
+    if strict is not None:
+        check_vocabulary(
+            strict,
+            STRICT_HOST_KEY_MODES,
+            what="fleet config `[ssh]`",
+            key="strict_host_key_checking",
+            source=source,
+        )
+
+
 def load_toml_file(path: Path, *, default: Any | None = None) -> dict[str, Any]:
     """Load PATH as TOML or return DEFAULT when missing."""
     if not path.exists():
@@ -536,21 +779,52 @@ TARGET_FILE_WARNINGS: dict[str, str] = {
 def load_targets(path: Path) -> dict[str, TargetRecord]:
     """Load target metadata files."""
     targets: dict[str, TargetRecord] = {}
-    for name, raw, _source in load_records_from_dir(path):
+    for name, raw, source in load_records_from_dir(path):
+        what = f"target {name!r}"
+        check_version(raw, what=what, source=source)
+        reject_unknown_keys(
+            raw,
+            TARGET_KEYS,
+            what=what,
+            source=source,
+            guidance=TARGET_FILE_WARNINGS,
+        )
         target = TargetRecord(
             name=name,
             enabled=bool(raw.get("enabled", True)),
-            transport=str(raw.get("transport", "ssh")),
+            transport=check_vocabulary(
+                str(raw.get("transport", "ssh")),
+                TRANSPORTS,
+                what=what,
+                key="transport",
+                source=source,
+            ),
             protocol=optional_str(raw.get("protocol")),
             workdir=optional_str(raw.get("workdir")),
             tags=tuple(str(item) for item in raw.get("tags", [])),
-            secret_backend=str(raw.get("secret_backend", "file")),
+            secret_backend=check_vocabulary(
+                str(raw.get("secret_backend", "file")),
+                SECRET_BACKENDS,
+                what=what,
+                key="secret_backend",
+                source=source,
+            ),
             secret_ref=optional_str(raw.get("secret_ref")),
-            secret_inline=dict(raw.get("secret", {})),
+            secret_inline=check_table(
+                raw.get("secret", {}), what=f"`secret` for {what}", source=source
+            ),
             ssh_host_alias=optional_str(raw.get("ssh_host_alias")),
             default_profile=optional_str(raw.get("default_profile")),
-            scheduler=str(raw.get("scheduler", "none")),
-            metadata=dict(raw.get("metadata", {})),
+            scheduler=check_vocabulary(
+                str(raw.get("scheduler", "none")),
+                SCHEDULERS,
+                what=what,
+                key="scheduler",
+                source=source,
+            ),
+            metadata=check_table(
+                raw.get("metadata", {}), what=f"`metadata` for {what}", source=source
+            ),
         )
         targets[target.name] = target
     return targets
@@ -559,14 +833,33 @@ def load_targets(path: Path) -> dict[str, TargetRecord]:
 def load_pools(path: Path) -> dict[str, PoolRecord]:
     """Load pool metadata files."""
     pools: dict[str, PoolRecord] = {}
-    for name, raw, _source in load_records_from_dir(path):
+    for name, raw, source in load_records_from_dir(path):
+        what = f"pool {name!r}"
+        check_version(raw, what=what, source=source)
+        reject_unknown_keys(raw, POOL_KEYS, what=what, source=source)
         pool = PoolRecord(
             name=name,
             targets=tuple(str(item) for item in raw.get("targets", [])),
             match_tags=tuple(str(item) for item in raw.get("match_tags", [])),
-            strategy=str(raw.get("strategy", "ordered")),
+            strategy=check_vocabulary(
+                str(raw.get("strategy", "ordered")),
+                POOL_STRATEGIES,
+                what=what,
+                key="strategy",
+                source=source,
+            ),
             default_profile=optional_str(raw.get("default_profile")),
         )
+        if not pool.targets and not pool.match_tags:
+            # `select_pool` treats "no members declared" as "every target",
+            # which resolves to the alphabetically first host in the fleet --
+            # today a Slurm controller.  A pool that names nobody is a config
+            # mistake, never a request to match everything.
+            raise FleetError(
+                f"{what} in {source} declares neither `targets` nor "
+                "`match_tags`, so it would match the entire fleet; list its "
+                "members explicitly"
+            )
         pools[pool.name] = pool
     return pools
 
@@ -606,13 +899,19 @@ def built_in_protocols() -> dict[str, ProtocolRecord]:
 def load_protocols(path: Path) -> dict[str, ProtocolRecord]:
     """Load protocol definitions and merge them over the built-ins."""
     protocols = built_in_protocols()
-    for name, raw, _source in load_records_from_dir(path):
+    for name, raw, source in load_records_from_dir(path):
+        what = f"protocol {name!r}"
+        check_version(raw, what=what, source=source)
+        reject_unknown_keys(raw, PROTOCOL_KEYS, what=what, source=source)
         queues: list[QueueRecord] = []
         for item in raw.get("queue", []):
             if not isinstance(item, dict):
                 raise FleetError(
                     f"invalid queue entry in protocol {name!r}; expected a table"
                 )
+            reject_unknown_keys(
+                item, QUEUE_KEYS, what=f"a queue entry in {what}", source=source
+            )
             partition = optional_str(item.get("partition")) or optional_str(
                 item.get("name")
             )
@@ -658,7 +957,13 @@ def load_protocols(path: Path) -> dict[str, ProtocolRecord]:
             note_values = (notes,)
         else:
             note_values = tuple(str(value) for value in notes)
-        kind = str(raw.get("kind", "direct"))
+        kind = check_vocabulary(
+            str(raw.get("kind", "direct")),
+            PROTOCOL_KINDS,
+            what=what,
+            key="kind",
+            source=source,
+        )
         protocols[name] = ProtocolRecord(
             name=name,
             kind=kind,
@@ -670,7 +975,13 @@ def load_protocols(path: Path) -> dict[str, ProtocolRecord]:
             ),
             allow_login_exec=bool(raw.get("allow_login_exec", kind != "slurm")),
             smoke_gpu_probe=bool(raw.get("smoke_gpu_probe", kind != "slurm")),
-            gpu_request_mode=str(raw.get("gpu_request_mode", "gres")),
+            gpu_request_mode=check_vocabulary(
+                str(raw.get("gpu_request_mode", "gres")),
+                GPU_REQUEST_MODES,
+                what=what,
+                key="gpu_request_mode",
+                source=source,
+            ),
             job_runtime=str(raw.get("job_runtime", "host")),
             native_batch_required=bool(raw.get("native_batch_required", False)),
             job_output_dir=str(raw.get("job_output_dir", ".fleet/jobs")),
@@ -684,13 +995,25 @@ def load_protocols(path: Path) -> dict[str, ProtocolRecord]:
 def load_profiles(path: Path) -> dict[str, ProfileRecord]:
     """Load execution profile files."""
     profiles: dict[str, ProfileRecord] = {}
-    for name, raw, _source in load_records_from_dir(path):
+    for name, raw, source in load_records_from_dir(path):
+        what = f"profile {name!r}"
+        check_version(raw, what=what, source=source)
+        reject_unknown_keys(raw, PROFILE_KEYS, what=what, source=source)
         submit = tuple(str(item) for item in raw.get("submit_command", []))
         status = tuple(str(item) for item in raw.get("status_command", []))
         cancel = tuple(str(item) for item in raw.get("cancel_command", []))
         logs = tuple(str(item) for item in raw.get("logs_command", []))
-        script = raw.get("script", {})
-        environment = raw.get("environment", {})
+        script = check_table(
+            raw.get("script", {}), what=f"`[script]` for {what}", source=source
+        )
+        reject_unknown_keys(
+            script, PROFILE_SCRIPT_KEYS, what=f"`[script]` for {what}", source=source
+        )
+        environment = check_table(
+            raw.get("environment", {}),
+            what=f"`[environment]` for {what}",
+            source=source,
+        )
         if isinstance(script, dict):
             interpreter = optional_str(script.get("interpreter"))
             remote_script_root = str(
@@ -701,7 +1024,13 @@ def load_profiles(path: Path) -> dict[str, ProfileRecord]:
             remote_script_root = DEFAULT_SCRIPT_REMOTE_ROOT
         profiles[name] = ProfileRecord(
             name=name,
-            kind=str(raw.get("kind", "direct")),
+            kind=check_vocabulary(
+                str(raw.get("kind", "direct")),
+                PROFILE_KINDS,
+                what=what,
+                key="kind",
+                source=source,
+            ),
             interpreter=interpreter,
             remote_script_root=remote_script_root,
             environment={str(key): str(value) for key, value in environment.items()},
@@ -721,14 +1050,37 @@ def load_projects(path: Path) -> list[ProjectBinding]:
     if not path.exists():
         return []
     raw = load_toml_file(path)
+    check_version(raw, what="project bindings", source=path)
+    reject_unknown_keys(raw, PROJECTS_FILE_KEYS, what="project bindings", source=path)
     bindings: list[ProjectBinding] = []
-    for item in raw.get("project", []):
+    for index, item in enumerate(raw.get("project", [])):
+        item = check_table(item, what=f"`[[project]]` #{index + 1}", source=path)
+        if "path" not in item:
+            raise FleetError(
+                f"`[[project]]` #{index + 1} in {path} has no `path`; a binding "
+                "must name the local project directory it applies to"
+            )
+        what = f"project binding {str(item['path'])!r}"
+        reject_unknown_keys(item, PROJECT_KEYS, what=what, source=path)
         target_roots = {}
         for entry in item.get("target_root", []):
+            entry = check_table(
+                entry, what=f"`[[project.target_root]]` for {what}", source=path
+            )
+            reject_unknown_keys(
+                entry,
+                PROJECT_TARGET_ROOT_KEYS,
+                what=f"`[[project.target_root]]` for {what}",
+                source=path,
+            )
             target_name = optional_str(entry.get("target"))
             remote_root = optional_str(entry.get("remote_root"))
-            if target_name and remote_root:
-                target_roots[target_name] = remote_root
+            if not target_name or not remote_root:
+                raise FleetError(
+                    f"`[[project.target_root]]` for {what} in {path} needs both "
+                    "`target` and `remote_root`"
+                )
+            target_roots[target_name] = remote_root
         bindings.append(
             ProjectBinding(
                 path=expand_local_path(str(item["path"])),
@@ -758,20 +1110,40 @@ def target_schema_warnings(path: Path) -> list[str]:
     return warnings
 
 
-def parse_secret_dict(raw: dict[str, Any]) -> FleetSecret:
+def parse_secret_dict(raw: dict[str, Any], *, source: Path | None = None) -> FleetSecret:
     """Parse one secret record from TOML-style data."""
+    # A typo here is quiet and dangerous in a different way to the other
+    # loaders: `proxyjump` instead of `proxy_jump` drops the bridge hop and
+    # sends the connection straight at a host that is not directly reachable.
+    reject_unknown_keys(raw, SECRET_KEYS, what="secret record", source=source)
     host = optional_str(raw.get("host"))
     user = optional_str(raw.get("user"))
     if not host or not user:
         raise FleetError("secret record must define both `host` and `user`")
     port = int(raw.get("port", 22))
-    auth = str(raw.get("auth", "key"))
+    auth = check_vocabulary(
+        str(raw.get("auth", "key")),
+        AUTH_MODES,
+        what="secret record",
+        key="auth",
+        source=source,
+    )
     identity_file = optional_str(raw.get("identity_file"))
     password = optional_str(raw.get("password"))
     proxy_jump = optional_str(raw.get("proxy_jump"))
     strict_host_key_checking = optional_str(raw.get("strict_host_key_checking"))
+    if strict_host_key_checking is not None:
+        check_vocabulary(
+            strict_host_key_checking,
+            STRICT_HOST_KEY_MODES,
+            what="secret record",
+            key="strict_host_key_checking",
+            source=source,
+        )
     batch_mode_raw = raw.get("batch_mode")
-    extra_options_raw = raw.get("ssh_option", {})
+    extra_options_raw = check_table(
+        raw.get("ssh_option", {}), what="`[ssh_option]` in secret record", source=source
+    )
     return FleetSecret(
         host=host,
         user=user,

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -3247,7 +3247,10 @@ def command_sync(args: argparse.Namespace) -> int:
         command += [local, remote]
     else:
         local = str(Path(args.local_path).expanduser().resolve())
-        remote = f"{secret.target}:{default_remote}"
+        # Mirror push: transfer the *contents* of the remote directory, so that
+        # `pull` is the inverse of `push` instead of nesting a copy one level
+        # deeper.  This also makes `--delete` mean the same thing both ways.
+        remote = f"{secret.target}:{default_remote.rstrip('/')}/"
         command += [remote, local]
 
     completed = run_command(command, env=ssh_env(secret))

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -3937,6 +3937,44 @@ def toml_syntax_problems(paths: FleetPaths) -> list[str]:
     return problems
 
 
+def probe_remote_prerequisites(context: FleetContext) -> list[str]:
+    """Check the one remote prerequisite fleetctl silently assumes: python3.
+
+    `exec` ships its payload through a remote Python stub, while `ssh`, `script`
+    and `smoke` all work without it -- so a host missing python3 looks healthy
+    right up to the first `fleetctl exec`.  This needs the network, so it is
+    opt-in: an unreachable host is not a configuration fault, and plain `doctor`
+    stays offline and instant.
+    """
+    problems: list[str] = []
+    runtime = ssh_runtime_kwargs(context)
+    for target in sorted(context.targets.values(), key=lambda item: item.name):
+        if not target.enabled:
+            continue
+        try:
+            secret = context.resolve_secret(target)
+        except FleetError:
+            continue  # already reported by the offline pass
+        try:
+            completed = run_ssh_command(
+                secret,
+                allocate_tty=False,
+                remote_command="command -v python3",
+                capture_output=True,
+                timeout=CONTROL_COMMAND_TIMEOUT,
+                **runtime,
+            )
+        except FleetError as exc:
+            problems.append(f"target {target.name!r} is not reachable: {exc}")
+            continue
+        if completed.returncode != 0:
+            problems.append(
+                f"target {target.name!r} has no `python3` on PATH; `fleetctl exec` "
+                "runs its payload through a remote Python stub and will fail there"
+            )
+    return problems
+
+
 def command_doctor(args: argparse.Namespace) -> int:
     """Validate local prerequisites and private file permissions.
 
@@ -4000,17 +4038,34 @@ def command_doctor(args: argparse.Namespace) -> int:
         context = None
 
     if context is not None:
+        referenced_secrets: set[Path] = set()
         for target in context.targets.values():
             try:
                 protocol = context.resolve_protocol(target)
             except FleetError as exc:
                 problems.append(str(exc))
                 continue
+            # Every name a target points at must resolve, not just its protocol.
+            # A target naming a profile that does not exist used to pass doctor
+            # and fail at the moment you tried to use it.
+            try:
+                profile = context.resolve_profile(target, None, None)
+            except FleetError as exc:
+                problems.append(f"target {target.name!r}: {exc}")
+                profile = None
+            if profile is not None and protocol.kind == "slurm" and not profile.submit_command:
+                problems.append(
+                    f"target {target.name!r} resolves to profile {profile.name!r}, "
+                    f"which has no `submit_command`, but protocol {protocol.name!r} "
+                    "is scheduler-backed: `fleetctl submit` cannot work here"
+                )
             try:
                 secret = context.resolve_secret(target)
             except FleetError as exc:
                 problems.append(str(exc))
                 continue
+            if target.secret_backend == "file" and target.secret_ref:
+                referenced_secrets.add(expand_local_path(target.secret_ref).resolve())
             if target.secret_backend == "file" and target.secret_ref:
                 secret_path = expand_local_path(target.secret_ref)
                 if secret_path.exists():
@@ -4030,13 +4085,61 @@ def command_doctor(args: argparse.Namespace) -> int:
                     "without any queue presets"
                 )
 
+        # A pool that cannot be selected from is a pool that aborts the first
+        # command aimed at it.  `select_pool` is the only definition of pool
+        # membership, so run the real thing rather than re-deriving it.
+        for pool in context.pools.values():
+            try:
+                context.select_pool(pool)
+            except FleetError as exc:
+                problems.append(str(exc))
+            for name in pool.targets:
+                target = context.targets.get(name)
+                if target is not None and not target.enabled:
+                    warnings.append(
+                        f"pool {pool.name!r} lists disabled target {name!r}"
+                    )
+
         for binding in context.projects:
+            # `default_target` and `default_pool` are exactly the fields that
+            # abort `resolve_target`, and were the two doctor did not check.
+            if binding.default_target and binding.default_target not in context.targets:
+                problems.append(
+                    f"project binding {binding.path} names unknown default target "
+                    f"{binding.default_target!r}"
+                )
+            if binding.default_pool and binding.default_pool not in context.pools:
+                problems.append(
+                    f"project binding {binding.path} names unknown default pool "
+                    f"{binding.default_pool!r}"
+                )
+            if binding.default_profile and binding.default_profile not in context.profiles:
+                problems.append(
+                    f"project binding {binding.path} names unknown default profile "
+                    f"{binding.default_profile!r}"
+                )
+            if not binding.path.exists():
+                warnings.append(
+                    f"project binding points at a missing directory: {binding.path}"
+                )
             for target_name in sorted(binding.remote_roots_by_target):
                 if target_name not in context.targets:
                     warnings.append(
                         f"project binding {binding.path} defines a landing strip for "
                         f"unknown target {target_name!r}"
                     )
+
+        # A secret file no target references is usually the leftover of a rename:
+        # live credentials for a host nothing in the fleet points at any more.
+        if paths.secrets_dir.is_dir():
+            for orphan in sorted(paths.secrets_dir.glob("*.toml")):
+                if orphan.resolve() not in referenced_secrets:
+                    warnings.append(
+                        f"secret file is not referenced by any target: {orphan}"
+                    )
+
+        if getattr(args, "probe", False):
+            problems.extend(probe_remote_prerequisites(context))
 
     payload = {
         "config_home": str(paths.config_home),
@@ -4470,6 +4573,11 @@ def build_parser() -> argparse.ArgumentParser:
 
     doctor_parser = subparsers.add_parser("doctor", help="Validate local fleet setup")
     doctor_parser.add_argument("--json", action="store_true", help="Emit JSON")
+    doctor_parser.add_argument(
+        "--probe",
+        action="store_true",
+        help="Also connect to every enabled target and check remote prerequisites",
+    )
     doctor_parser.set_defaults(handler=command_doctor)
 
     return parser

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -1370,11 +1370,35 @@ def render_template_values(
     return rendered
 
 
+def quote_remote_path(path: str) -> str:
+    """Quote a fleet-resolved remote path, keeping a leading `~/` expandable.
+
+    `shlex.quote("~/work")` yields `'~/work'`, and no shell expands a quoted
+    tilde, so every `~`-relative workdir failed with "remote cwd not found".
+    Emitting `$HOME` unquoted with the remainder quoted keeps the expansion while
+    staying safe for paths containing spaces or quotes.
+    """
+    if path in ("~", "$HOME"):
+        return "$HOME"
+    for prefix in ("~/", "$HOME/"):
+        if path.startswith(prefix):
+            remainder = path[len(prefix) :]
+            return f"$HOME/{shlex.quote(remainder)}" if remainder else "$HOME"
+    return shlex.quote(path)
+
+
+def remote_shell_path_command(argv: list[str], remote_path: str) -> str:
+    """Build a remote command whose final argument is a fleet-resolved path."""
+    return shlex.join(
+        ["/bin/sh", "-c", f"{shlex.join(argv)} {quote_remote_path(remote_path)}"]
+    )
+
+
 def remote_shell_command(command: list[str], *, cwd: str | None = None) -> str:
     """Build a remote shell command from argv."""
     inner = shlex.join(command)
     if cwd:
-        quoted_cwd = shlex.quote(cwd)
+        quoted_cwd = quote_remote_path(cwd)
         inner = (
             f"if [ -d {quoted_cwd} ]; then cd {quoted_cwd};"
             f" else printf 'error: remote cwd not found: %s\\n' {quoted_cwd} >&2;"
@@ -1442,7 +1466,7 @@ def stage_remote_script(
     mkdir = run_ssh_command(
         secret,
         allocate_tty=False,
-        remote_command=remote_shell_command(["mkdir", "-p", remote_dir]),
+        remote_command=remote_shell_path_command(["mkdir", "-p"], remote_dir),
         timeout=CONTROL_COMMAND_TIMEOUT,
         **ssh_runtime,
     )
@@ -1470,7 +1494,7 @@ def stage_remote_script(
     chmod = run_ssh_command(
         secret,
         allocate_tty=False,
-        remote_command=remote_shell_command(["chmod", "700", remote_path]),
+        remote_command=remote_shell_path_command(["chmod", "700"], remote_path),
         timeout=CONTROL_COMMAND_TIMEOUT,
         **ssh_runtime,
     )
@@ -1502,7 +1526,7 @@ def ensure_remote_directory(
     mkdir = run_ssh_command(
         secret,
         allocate_tty=False,
-        remote_command=remote_shell_command(["mkdir", "-p", remote_path]),
+        remote_command=remote_shell_path_command(["mkdir", "-p"], remote_path),
         timeout=CONTROL_COMMAND_TIMEOUT,
         **(ssh_runtime or {}),
     )
@@ -3133,7 +3157,7 @@ def command_sync(args: argparse.Namespace) -> int:
         mkdir = run_ssh_command(
             secret,
             allocate_tty=False,
-            remote_command=remote_shell_command(["mkdir", "-p", remote_parent]),
+            remote_command=remote_shell_path_command(["mkdir", "-p"], remote_parent),
             timeout=CONTROL_COMMAND_TIMEOUT,
             **ssh_runtime,
         )

--- a/bin/fleetctl
+++ b/bin/fleetctl
@@ -85,6 +85,14 @@ ROLE_MATRIX: dict[str, tuple[str, ...]] = {
     "storage":     (ALLOW, ADMIN, DENY,  ALLOW, DENY,  DENY),
 }
 
+# How each decision reads in `fleetctl explain`, where a refusal is information
+# rather than an error.
+DECISION_LABELS = {
+    ALLOW: "allowed",
+    ADMIN: "needs --admin",
+    DENY: "refused",
+}
+
 # Why a verb is refused outright, so the error names the alternative instead of
 # just restating the rule.
 DENY_REASON = {
@@ -654,6 +662,15 @@ class Plan:
     def ssh_runtime(self) -> dict[str, Any]:
         """Return the fleet-managed SSH settings for this plan."""
         return ssh_runtime_kwargs(self.context)
+
+    def ssh_connect_argv(self) -> list[str]:
+        """The ssh invocation this plan will use, without the remote command."""
+        return build_ssh_command(
+            self.secret,
+            allocate_tty=False,
+            remote_command=None,
+            **self.ssh_runtime(),
+        )
 
     def describe(self) -> dict[str, Any]:
         """Report the plan as data, for `--dry-run`, `explain` and `--json`."""
@@ -2597,6 +2614,130 @@ def redact_secret(secret: FleetSecret) -> dict[str, Any]:
     }
 
 
+def emit(payload: dict[str, Any], *, as_json: bool) -> None:
+    """Print one command result: JSON when asked, aligned key/value lines otherwise.
+
+    Every command used to carry its own printer, and two of them shipped an
+    `if args.json:` whose branches were character-identical -- so `doctor`
+    emitted JSON whether or not you asked for it.
+    """
+    if as_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    print(render_text_payload(payload))
+
+
+def render_text_payload(value: Any, *, indent: int = 0) -> str:
+    """Render nested plain data as readable indented lines."""
+    pad = "  " * indent
+    if isinstance(value, dict):
+        if not value:
+            return f"{pad}(none)"
+        width = max(len(str(key)) for key in value)
+        lines: list[str] = []
+        for key, item in value.items():
+            label = f"{pad}{str(key).ljust(width)}"
+            if isinstance(item, (dict, list, tuple)) and item:
+                lines.append(f"{label} :")
+                lines.append(render_text_payload(item, indent=indent + 1))
+            else:
+                lines.append(f"{label} : {render_scalar(item)}")
+        return "\n".join(lines)
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return f"{pad}(none)"
+        return "\n".join(
+            render_text_payload(item, indent=indent)
+            if isinstance(item, (dict, list, tuple))
+            else f"{pad}- {render_scalar(item)}"
+            for item in value
+        )
+    return f"{pad}{render_scalar(value)}"
+
+
+def render_scalar(value: Any) -> str:
+    """Render one leaf value for human output."""
+    if value is None:
+        return "-"
+    if isinstance(value, (dict, list, tuple)) and not value:
+        return "(none)"
+    if value is True:
+        return "yes"
+    if value is False:
+        return "no"
+    return str(value)
+
+
+def planned_script_path(profile: ProfileRecord, local_script: Path) -> str:
+    """Return the shape of the path a script would be staged to, without staging it.
+
+    The real token is drawn per run and a relative `remote_script_root` needs the
+    remote home resolved, so a dry run shows the shape rather than pretending to
+    know the exact path.  Nothing else about the command depends on it.
+    """
+    root = profile.remote_script_root
+    if not root.startswith(("/", "~/", "$HOME")):
+        # What the real staging does, minus the round trip that resolves $HOME.
+        root = f"$HOME/{root}"
+    return remote_posix_join(remote_posix_join(root, "<token>"), local_script.name)
+
+
+def report_plan(
+    plan: Plan,
+    args: argparse.Namespace,
+    extra: dict[str, Any] | None = None,
+    *,
+    block: tuple[str, str] | None = None,
+) -> int:
+    """Print the resolved plan and do nothing else.
+
+    Ansible's honesty rule: this simulates local resolution and claims nothing
+    about remote state.  `sync` is the one verb where a dry run can be
+    remote-accurate, and it runs `rsync --dry-run` itself to earn that.
+    """
+    payload = plan.describe()
+    payload["ssh"] = shlex.join(plan.ssh_connect_argv())
+    payload.update(extra or {})
+    as_json = bool(getattr(args, "json", False))
+    if block is not None and as_json:
+        payload[block[0]] = block[1]
+    emit(payload, as_json=as_json)
+    if block is not None and not as_json:
+        print(f"\n--- {block[0]} ---")
+        print(block[1].rstrip("\n"))
+    return 0
+
+
+def report_script_plan(
+    plan: Plan,
+    args: argparse.Namespace,
+    local_script: Path,
+    *,
+    interpreter: str | None,
+    script_args: list[str],
+) -> int:
+    """Describe the script run PLAN would perform."""
+    chosen = interpreter or plan.profile.interpreter
+    staged = planned_script_path(plan.profile, local_script)
+    argv: list[str] = []
+    if chosen:
+        argv.extend(shlex.split(chosen))
+    argv.append(staged)
+    argv.extend(script_args)
+    return report_plan(
+        plan,
+        args,
+        {
+            "local_script": str(local_script),
+            "staged_as": staged,
+            "interpreter": chosen,
+            "remote_command": shlex.join(
+                prefixed_env_command(argv, plan.profile.environment)
+            ),
+        },
+    )
+
+
 def format_table(rows: list[dict[str, Any]], columns: list[str]) -> str:
     """Render a tiny fixed-width table."""
     def cell(value: Any) -> str:
@@ -4172,6 +4313,12 @@ def command_exec(args: argparse.Namespace, context: FleetContext) -> int:
         )
     plan = build_plan(context, args, "exec")
     environment = dict(plan.profile.environment)
+    if args.dry_run:
+        return report_plan(
+            plan,
+            args,
+            {"remote_command": shlex.join(argv), "environment": environment or None},
+        )
     encoded_stub = base64.b64encode(EXEC_REMOTE_STUB.encode("utf-8")).decode("ascii")
     payload = base64.b64encode(
         json.dumps(
@@ -4232,8 +4379,17 @@ def command_script(args: argparse.Namespace, context: FleetContext) -> int:
     local_script = Path(args.local_script).expanduser().resolve()
     if not local_script.is_file():
         raise FleetError(f"missing local script: {local_script}")
+    plan = build_plan(context, args, "script")
+    if args.dry_run:
+        return report_script_plan(
+            plan,
+            args,
+            local_script,
+            interpreter=args.interpreter,
+            script_args=args.script_args,
+        )
     return run_script_plan(
-        build_plan(context, args, "script"),
+        plan,
         local_script,
         interpreter=args.interpreter,
         script_args=args.script_args,
@@ -4275,7 +4431,7 @@ def command_sync(args: argparse.Namespace, context: FleetContext) -> int:
         command.append("--delete")
     for pattern in excludes:
         command += ["--exclude", pattern]
-    if args.direction == "push":
+    if args.direction == "push" and not args.dry_run:
         remote_parent = posixpath.dirname(default_remote.rstrip("/")) or "."
         mkdir = run_ssh_command(
             secret,
@@ -4304,6 +4460,27 @@ def command_sync(args: argparse.Namespace, context: FleetContext) -> int:
         # deeper.  This also makes `--delete` mean the same thing both ways.
         remote = f"{secret.target}:{default_remote.rstrip('/')}/"
         command += [remote, local]
+
+    if args.dry_run:
+        # The one verb where a dry run is remote-accurate rather than a local
+        # simulation: rsync itself reports exactly what it would transfer.
+        command[1:1] = ["--dry-run", "--itemize-changes"]
+        report_plan(
+            plan,
+            args,
+            {
+                "direction": args.direction,
+                "local_path": local,
+                "remote_path": default_remote,
+                "delete": bool(args.delete),
+                "excludes": excludes,
+                "rsync": shlex.join(command),
+            },
+        )
+        print("\n--- rsync --itemize-changes ---")
+        # rsync writes straight to the terminal, so the plan above has to be on
+        # its way out before it starts, or a piped run interleaves them.
+        sys.stdout.flush()
 
     completed = run_command(command, env=ssh_env(secret))
     return completed.returncode
@@ -4338,6 +4515,14 @@ def command_submit(args: argparse.Namespace, context: FleetContext) -> int:
                 f"{target.name!r}; there is no scheduler to allocate resources"
             ),
         )
+        if args.dry_run:
+            return report_script_plan(
+                plan,
+                args,
+                local_script,
+                interpreter=args.interpreter,
+                script_args=args.script_args,
+            )
         return run_script_plan(
             plan,
             local_script,
@@ -4359,6 +4544,17 @@ def command_submit(args: argparse.Namespace, context: FleetContext) -> int:
             ),
         )
         ensure_job_id_pattern(profile)
+        if args.dry_run:
+            return report_plan(
+                plan,
+                args,
+                {
+                    "local_script": str(local_script),
+                    "staged_as": planned_script_path(profile, local_script),
+                    "native_batch": True,
+                    "submit_command": shlex.join(profile.submit_command),
+                },
+            )
         remote_script = stage_remote_script(
             secret,
             profile,
@@ -4380,11 +4576,15 @@ def command_submit(args: argparse.Namespace, context: FleetContext) -> int:
         )
     ensure_job_id_pattern(profile)
     queue = resolve_queue(protocol, args.queue)
-    remote_script = stage_remote_script(
-        secret,
-        profile,
-        local_script,
-        ssh_runtime=ssh_runtime,
+    remote_script = (
+        planned_script_path(profile, local_script)
+        if args.dry_run
+        else stage_remote_script(
+            secret,
+            profile,
+            local_script,
+            ssh_runtime=ssh_runtime,
+        )
     )
     job_base_root = protocol_base_root(target, plan.binding, args.cwd)
     output_dir, output_path, error_path = resolve_job_output_paths(
@@ -4393,7 +4593,7 @@ def command_submit(args: argparse.Namespace, context: FleetContext) -> int:
         output_override=args.output,
         error_override=args.error,
     )
-    if output_dir:
+    if output_dir and not args.dry_run:
         ensure_remote_directory(secret, output_dir, ssh_runtime=ssh_runtime)
     job_name = sanitize_job_name(args.job_name or local_script.stem)
     wrapper_text = render_slurm_wrapper(
@@ -4412,6 +4612,24 @@ def command_submit(args: argparse.Namespace, context: FleetContext) -> int:
         output_path=output_path,
         error_path=error_path,
     )
+    if args.dry_run:
+        # The whole point of a submit dry run: read the wrapper the scheduler
+        # would receive, before it receives it.
+        return report_plan(
+            plan,
+            args,
+            {
+                "local_script": str(local_script),
+                "staged_as": remote_script,
+                "queue": queue.name,
+                "partition": queue.partition,
+                "job_name": job_name,
+                "output_path": output_path,
+                "error_path": error_path,
+                "submit_command": shlex.join(profile.submit_command),
+            },
+            block=("rendered batch script", wrapper_text),
+        )
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
         handle.write(wrapper_text)
         wrapper_local = Path(handle.name)
@@ -4477,6 +4695,23 @@ def command_job_logs(args: argparse.Namespace, context: FleetContext) -> int:
 def command_job_cancel(args: argparse.Namespace, context: FleetContext) -> int:
     """Cancel one remote scheduler job."""
     plan = build_plan(context, args, "job")
+    if args.dry_run:
+        return report_plan(
+            plan,
+            args,
+            {
+                "job_id": args.job_id,
+                "remote_command": shlex.join(
+                    render_template_values(
+                        plan.profile.cancel_command,
+                        job_id=args.job_id,
+                        workdir=plan.cwd,
+                    )
+                )
+                if plan.profile.cancel_command
+                else None,
+            },
+        )
     return run_job_command(plan, plan.profile.cancel_command, job_id=args.job_id)
 
 
@@ -4554,6 +4789,41 @@ def probe_remote_prerequisites(context: FleetContext) -> list[str]:
                 "runs its payload through a remote Python stub and will fail there"
             )
     return problems
+
+
+def command_explain(args: argparse.Namespace, context: FleetContext) -> int:
+    """Explain what a selector resolves to, and what each verb may do there.
+
+    Deliberately does not call authorize(): here a refusal is the answer, not an
+    error, so `explain` can tell you that `exec` needs --admin without making you
+    pass --admin to find out.  Everything else is the same resolution the verbs
+    use, so this is also the debugging story for "why did it pick that?".
+    """
+    selector = context.normalize_selector(args.selector)
+    target, binding = context.resolve_target(selector, cwd=Path.cwd())
+    protocol = context.resolve_protocol(target)
+    plan = Plan(
+        verb=args.verb or "explain",
+        context=context,
+        target=target,
+        binding=binding,
+        protocol=protocol,
+        profile=context.resolve_profile(target, binding, args.profile),
+        cwd=resolve_remote_root(target, binding, args.cwd),
+        selector=selector,
+        pool=context.pools.get(selector) if selector else None,
+        admin=bool(args.admin),
+    )
+    role = resolve_role(target, protocol)
+    payload = plan.describe()
+    payload["ssh"] = shlex.join(plan.ssh_connect_argv())
+    payload["queues"] = [queue.name for queue in protocol.queues]
+    payload["admission"] = {
+        verb: DECISION_LABELS[ROLE_MATRIX[role][VERBS.index(verb)]]
+        for verb in (VERBS if args.verb is None else (args.verb,))
+    }
+    emit(payload, as_json=bool(args.json))
+    return 0
 
 
 def command_doctor(args: argparse.Namespace) -> int:
@@ -5086,6 +5356,11 @@ def build_parser() -> argparse.ArgumentParser:
         nargs="*",
         help="Command to run remotely, introduced by `--`",
     )
+    exec_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve and print the plan without touching the target",
+    )
     exec_parser.set_defaults(handler=command_exec)
 
     script_parser = subparsers.add_parser(
@@ -5107,6 +5382,11 @@ def build_parser() -> argparse.ArgumentParser:
         "script_args",
         nargs="*",
         help="Arguments passed to the uploaded script after `--`",
+    )
+    script_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve and print the plan without touching the target",
     )
     script_parser.set_defaults(handler=command_script)
 
@@ -5133,6 +5413,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--admin",
         action="store_true",
         help="Acknowledge a control-plane action on a role that repels this verb",
+    )
+    sync_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve and print the plan without touching the target",
     )
     sync_parser.set_defaults(handler=command_sync)
 
@@ -5182,6 +5467,11 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Acknowledge a control-plane action on a role that repels this verb",
     )
+    submit_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve and print the plan without touching the target",
+    )
     submit_parser.set_defaults(handler=command_submit)
 
     job_parser = subparsers.add_parser("job", help="Inspect or manage remote jobs")
@@ -5221,7 +5511,33 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Acknowledge a control-plane action on a role that repels this verb",
     )
+    cancel_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve and print the plan without touching the target",
+    )
     cancel_parser.set_defaults(handler=command_job_cancel)
+
+    explain_parser = subparsers.add_parser(
+        "explain",
+        help="Show what a selector resolves to and which verbs it admits",
+    )
+    explain_parser.add_argument("selector", nargs="?", help="Target or pool name")
+    explain_parser.add_argument(
+        "verb",
+        nargs="?",
+        choices=VERBS,
+        help="Report admission for one verb instead of all of them",
+    )
+    explain_parser.add_argument("--profile", help="Execution profile override")
+    explain_parser.add_argument("--cwd", help="Remote working directory override")
+    explain_parser.add_argument(
+        "--admin",
+        action="store_true",
+        help="Show the plan as it would resolve with --admin",
+    )
+    explain_parser.add_argument("--json", action="store_true", help="Emit JSON")
+    explain_parser.set_defaults(handler=command_explain)
 
     doctor_parser = subparsers.add_parser("doctor", help="Validate local fleet setup")
     doctor_parser.add_argument("--json", action="store_true", help="Emit JSON")

--- a/codex/instructions.md
+++ b/codex/instructions.md
@@ -7,10 +7,9 @@
 - Before using an unfamiliar target, inspect its rules with
   `fleetctl protocol show <target>` and, for scheduler-backed targets,
   `fleetctl queue list <target>`.
-- Respect the resolved protocol's runtime expectations. If `job_runtime` says
-  `docker`, prepare the submitted job script to launch the containerized
-  workload inside the scheduler allocation instead of running the payload on the
-  host directly.
+- Container invocation belongs in the profile's `interpreter` or
+  `submit_command`, for example `["apptainer", "exec", ...]`. There is no
+  runtime field to read.
 - If `fleetctl protocol show <target>` reports `native_batch_required = true`,
   use `fleetctl submit --native-batch` and keep the site-native scheduler
   directives in the submitted script instead of relying on the wrapper path.
@@ -21,10 +20,13 @@
   `fleetctl smoke <target>` unless the user explicitly asks to skip it.
 - When a project has a fleet binding, rely on that binding instead of inventing
   repo-local remote config.
-- Treat scheduler-backed protocols as login-node control surfaces:
-  `fleetctl exec --login <target> -- ...` is for administrative commands such as
-  `squeue`, `sinfo`, `sacct`, and `pwd`, while compute should go through
-  `fleetctl submit`.
+- A target's `role` decides what may be done to it, and `fleetctl explain
+  <target>` reports every verb for one host. On a `login` role,
+  `fleetctl exec --admin <target> -- ...` is for control-plane commands such as
+  `squeue`, `sinfo` and `sacct`; compute goes through `fleetctl submit`.
+- A refusal is the answer, not an obstacle. `fleetctl` exits 2 and names the
+  alternative; take it, or ask. Do not fall back to raw `ssh` to do the thing
+  that was just refused.
 - Keep site policy and queue defaults in private fleet protocol files under
   `~/.config/fleet/protocols.d/`, not in repo code or project-specific hacks.
 - Treat `~/.config/fleet/` as generated state when the user has enabled the

--- a/codex/instructions.md
+++ b/codex/instructions.md
@@ -9,7 +9,7 @@
   `fleetctl queue list <target>`.
 - Container invocation belongs in the profile's `interpreter` or
   `submit_command`, for example `["apptainer", "exec", ...]`. There is no
-  runtime field to read.
+  `job_runtime`: how work is invoked belongs to the profile that invokes it.
 - If `fleetctl protocol show <target>` reports `native_batch_required = true`,
   use `fleetctl submit --native-batch` and keep the site-native scheduler
   directives in the submitted script instead of relying on the wrapper path.
@@ -27,6 +27,19 @@
 - A refusal is the answer, not an obstacle. `fleetctl` exits 2 and names the
   alternative; take it, or ask. Do not fall back to raw `ssh` to do the thing
   that was just refused.
+- Routing is declared on the target, direct first with a `via:` bridge as the
+  fallback, and chosen once per control socket. Never wrap `exec` or `submit` in
+  a retry loop: a re-run of an accepted `sbatch` queues the job twice.
+- The manual is in the tool: `fleetctl help <topic>` covers verbs, roles, reach,
+  capabilities, config, secrets and jobs. Check yourself with `fleetctl explain`
+  and `--dry-run` before acting, and `fleetctl doctor --probe` for the live fleet.
+- Only read-only verbs fan out (`--all`, `--tag`, `--jobs`); `sync` and `submit`
+  refuse, and looping them over `fleetctl list` recreates exactly the
+  partial-failure state the refusal prevents. Read the `note:` lines: they name
+  what a run did not cover.
+- `fleetctl probe` measures a host; the declaration still decides. A probed fact
+  never selects a target, so fix drift in the inventory rather than expecting the
+  measurement to win.
 - Keep site policy and queue defaults in private fleet protocol files under
   `~/.config/fleet/protocols.d/`, not in repo code or project-specific hacks.
 - Treat `~/.config/fleet/` as generated state when the user has enabled the

--- a/codex/skills/remote-fleet-operator/SKILL.md
+++ b/codex/skills/remote-fleet-operator/SKILL.md
@@ -14,6 +14,8 @@ Use `fleetctl` as the control plane for remote work.
 - Avoid brittle shell quoting and repo-local SSH wrappers.
 - Make remote actions boring: inspect, smoke test, sync, execute, submit.
 - Keep sensitive connection material out of target metadata.
+- Treat each target's `role` as the boundary on what may be done to it,
+  and `--admin` as an acknowledgement rather than a convenience.
 - Put each host's base `workdir` on the target itself.
 - Use project bindings only for defaults and for project-specific absolute
   overrides when `workdir/<project-name>` is not correct.
@@ -31,6 +33,7 @@ Run these before changing anything substantial:
 fleetctl doctor
 fleetctl list
 fleetctl project show
+fleetctl explain <target-or-pool>
 ```
 
 If the current project is not bound, inspect the available targets or pools and
@@ -47,11 +50,11 @@ fleetctl queue list <target-or-pool>
 
 1. Resolve context.
    Use `fleetctl project show`, `fleetctl resolve`, or `fleetctl show`.
-2. Inspect protocol.
-   Use `fleetctl protocol show` to decide whether the target is direct or
-   scheduler-backed, whether the expected job runtime is host-side or Docker,
-   whether `native_batch_required` forces site-native batch scripts, and use
-   `fleetctl queue list` when queue choice matters.
+2. Inspect role and protocol.
+   Use `fleetctl explain <target>` for the admission answer, and
+   `fleetctl protocol show` to decide whether the target is direct or
+   scheduler-backed and whether `native_batch_required` forces site-native
+   batch scripts. Use `fleetctl queue list` when queue choice matters.
 3. Verify transport.
    Run `fleetctl smoke <target-or-pool>` unless the user explicitly wants a
    direct attempt first.
@@ -59,8 +62,8 @@ fleetctl queue list <target-or-pool>
    Use `fleetctl sync push ...`.
 5. Run the work through the narrowest interface that fits:
    - `fleetctl exec <target> -- ...` for direct-host argv execution
-   - `fleetctl exec --login <target> -- ...` for administrative commands on a
-     scheduler login surface
+   - `fleetctl exec --admin <target> -- ...` for control-plane commands such
+     as `squeue` or `sinfo` on a login surface, never for compute
    - `fleetctl script <local-script> --target <target> -- ...` for staged
      scripts on direct hosts
    - `fleetctl submit <local-script> --target <target>` for compute jobs,
@@ -75,11 +78,17 @@ fleetctl queue list <target-or-pool>
 
 When the user wants to bring hosts into the fleet:
 
-- Import an existing SSH alias with `fleetctl import-ssh <alias>`.
+- Import an existing SSH alias with `fleetctl import-ssh <alias> --role
+  <bridge|login|compute|workstation|storage>`. The role is the whole point
+  of the import; guessing it wrong is how a login node gets used as a
+  workstation.
 - Migrate env-based machine config with
   `fleetctl migrate-env --env-file <path> --prefix <PREFIX>`.
 - Define reusable protocols in `~/.config/fleet/protocols.d/*.toml` and point
   targets at them with `protocol = "name"`.
+- Declare how a host is reached on the target itself, direct first:
+  `reach = ["direct", "via:<bridge>"]`. Never hide a hop in a secret or in
+  `~/.ssh/config`.
 - Seed the current live fleet into pass with `fleetctl seed-pass`, then rebuild
   the generated tree with `fleetctl deploy-config`.
 - When the dotfiles repo is the source of the operator surface, prefer the
@@ -97,11 +106,14 @@ When the user wants to bring hosts into the fleet:
   fleet.
 - Prefer `fleetctl exec` over `ssh <host> 'bash -lc ...'` when the user payload
   is naturally an argv vector on direct hosts.
-- On scheduler-backed protocols, treat `fleetctl exec --login` as control-plane
-  access only. Use `fleetctl submit` for compute.
-- When a protocol reports `job_runtime = "docker"`, make the submitted script
-  launch the workload inside the allocated container runtime instead of assuming
-  host-side execution is the correct path.
+- On a `login` role, treat `fleetctl exec --admin` as control-plane access
+  only. Use `fleetctl submit` for compute.
+- A refusal is the answer, not an obstacle. When `fleetctl` exits 2 it names the
+  alternative; take that path, or ask. Do not reach for raw `ssh` to do the
+  thing that was just refused, and do not add `--admin` to make a refusal go
+  away -- it only lifts the cells the role marks as needing acknowledgement.
+- Container invocation belongs in a profile's `interpreter` or `submit_command`,
+  for example `["apptainer", "exec", ...]`. There is no runtime field to read.
 - When a protocol reports `native_batch_required = true`, use
   `fleetctl submit --native-batch` so the scheduler sees the site-native script
   unchanged.
@@ -109,6 +121,9 @@ When the user wants to bring hosts into the fleet:
   contain the runtime setup or policy-specific directives.
 - Prefer `fleetctl script` or `fleetctl submit` when the command is large enough
   that quoting would become fragile.
+- Use `--dry-run` before a first-time submit and before any `sync --delete`. It
+  resolves the plan locally and claims nothing about remote state, except for
+  `sync`, where it is a real `rsync --dry-run`.
 - Use raw `ssh` only for transport debugging or when `fleetctl` genuinely lacks
   the needed primitive.
 

--- a/codex/skills/remote-fleet-operator/SKILL.md
+++ b/codex/skills/remote-fleet-operator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: remote-fleet-operator
-description: Operate remote machines, pools, and project-bound compute environments through fleetctl. Use when the task involves running experiments on named machines, syncing repos to remote hosts, staging scripts, submitting jobs to schedulers, inspecting fleet config, importing SSH aliases, or migrating repo-local remote settings into the private home-local fleet inventory. Prefer this over ad hoc raw SSH whenever the host should come from the user's managed fleet.
+description: Operate remote machines, pools, and project-bound compute environments through fleetctl. Use when the task involves running experiments on named machines, syncing repos to remote hosts, staging scripts, submitting jobs to schedulers, inspecting fleet config, importing SSH aliases, fanning a read-only check across the fleet, or migrating an older private inventory to the schema fleetctl reads today. Prefer this over ad hoc raw SSH whenever the host should come from the user's managed fleet.
 ---
 
 # Remote Fleet Operator
@@ -38,6 +38,10 @@ fleetctl explain <target-or-pool>
 
 If the current project is not bound, inspect the available targets or pools and
 either use an explicit target or bind the project.
+
+The manual is in the tool: `fleetctl help <topic>` for overview, verbs, roles,
+reach, config, secrets, jobs and examples, and `fleetctl doctor --probe` when
+the live fleet itself is in question. Read the topic instead of guessing.
 
 When a target may be scheduler-backed or otherwise policy-constrained, inspect:
 
@@ -82,13 +86,14 @@ When the user wants to bring hosts into the fleet:
   <bridge|login|compute|workstation|storage>`. The role is the whole point
   of the import; guessing it wrong is how a login node gets used as a
   workstation.
-- Migrate env-based machine config with
-  `fleetctl migrate-env --env-file <path> --prefix <PREFIX>`.
 - Define reusable protocols in `~/.config/fleet/protocols.d/*.toml` and point
   targets at them with `protocol = "name"`.
 - Declare how a host is reached on the target itself, direct first:
   `reach = ["direct", "via:<bridge>"]`. Never hide a hop in a secret or in
   `~/.ssh/config`.
+- For a host whose address changes on every start, use
+  `secret_backend = "command"` with `secret_ref` naming a script that prints
+  `host = "..."`. Its output is a secret: never echo it back to the user.
 - Seed the current live fleet into pass with `fleetctl seed-pass`, then rebuild
   the generated tree with `fleetctl deploy-config`.
 - When the dotfiles repo is the source of the operator surface, prefer the
@@ -113,17 +118,37 @@ When the user wants to bring hosts into the fleet:
   thing that was just refused, and do not add `--admin` to make a refusal go
   away -- it only lifts the cells the role marks as needing acknowledgement.
 - Container invocation belongs in a profile's `interpreter` or `submit_command`,
-  for example `["apptainer", "exec", ...]`. There is no runtime field to read.
+  for example `["apptainer", "exec", ...]`. There is no second runtime dimension:
+  a protocol's `job_runtime` no longer exists, and a config still carrying it is
+  reported by `doctor` and stripped by `fleetctl migrate-config`.
+- Ask the whole fleet a read-only question with `--all` or `--tag <tag>`, and
+  `--jobs <n>` to overlap them: `fleetctl smoke --all --jobs 4`. Only `smoke`,
+  `exec` and `job status` fan out; `sync`, `submit`, `script` and `job
+  logs|cancel` refuse and say why. Never loop a refused verb over `fleetctl
+  list` to fake it -- that is the partial-failure state the refusal exists to
+  prevent, and for `submit` it is a double submission.
+- Read the `note:` lines a fan-out prints. They name what the run did not cover,
+  and a fan-out that covered eight of ten hosts otherwise reads as ten.
+- `fleetctl probe <target>` measures a host and caches the facts for `doctor` to
+  compare against the declaration. It is advisory by construction: a probed fact
+  never selects a target or admits a verb. Fix drift by correcting the
+  inventory, not by expecting the measurement to win.
 - When a protocol reports `native_batch_required = true`, use
   `fleetctl submit --native-batch` so the scheduler sees the site-native script
   unchanged.
-- Use `--native-batch` when the site expects the scheduler script itself to
-  contain the runtime setup or policy-specific directives.
 - Prefer `fleetctl script` or `fleetctl submit` when the command is large enough
   that quoting would become fragile.
+- Routing is declared, not guessed: `reach` tries direct first and falls back to
+  a `via:` bridge once per control socket. `--route` pins a declared route and
+  `--no-fallback` refuses to degrade. A failing command is never re-routed, so
+  never wrap `exec` or `submit` in a retry loop; `sbatch` would run twice.
+- Select on declared capabilities rather than probing: `--require 'vram_gb>=24'`
+  refuses a named target that does not match, and `--fit` picks the smallest
+  sufficient candidate instead. Neither moves work to a host you did not name.
 - Use `--dry-run` before a first-time submit and before any `sync --delete`. It
-  resolves the plan locally and claims nothing about remote state, except for
-  `sync`, where it is a real `rsync --dry-run`.
+  resolves the plan locally and claims nothing about remote state -- for
+  `submit` it prints the rendered batch script, and for `sync` it is a real
+  `rsync --dry-run`.
 - Use raw `ssh` only for transport debugging or when `fleetctl` genuinely lacks
   the needed primitive.
 

--- a/docs/bin/fleetctl.md
+++ b/docs/bin/fleetctl.md
@@ -1,235 +1,166 @@
-# fleetctl - Private Remote Fleet Control
+# fleetctl
 
-Run remote work through a private host inventory that lives under your home
-directory instead of scattering machine definitions across individual repos.
+Run work on machines you do not all administer, through a private inventory,
+under one admission policy. One file of Python 3 and the standard library
+driving `ssh`, `scp` and `rsync` — no daemon, nothing installed on the remote.
 
-## Overview
+`fleetctl help` is the manual: `overview verbs roles reach config secrets jobs
+examples`. This page is the tour.
 
-`fleetctl` keeps generated host metadata, profiles, project bindings, and SSH
-runtime state in XDG paths:
+## Why
 
-- `~/.config/fleet/` - targets, pools, profiles, protocols, and project bindings
-- `~/.local/state/fleet/` - `known_hosts` and runtime state
-- `~/.cache/fleet/` - SSH control sockets
+The fleet grows in variety faster than in size — a Raspberry Pi whose only job
+is to be jumped through, a bare-metal GPU box behind it, a Slurm site reached
+through a login node. So most of fleetctl's value is in what it refuses.
+Running `python train.py` on a login node is not a mistake it lets you make by
+accident.
 
-In the pass-backed model, the public templates live in the dotfiles repo under
-`fleet/templates/`, private fleet source data lives in `pass`, and
-`~/.config/fleet/` is rendered from those two inputs with `fleetctl deploy-config`.
+## The pieces
 
-The dotfiles repo owns the operator interface, documentation, and Codex
-instructions. Sensitive hostnames, IPs, usernames, passwords, and keys stay out
-of version control.
+- **Target** — one SSH-reachable surface. A Slurm compute node is *not* a
+  target; node types are queue presets on the site's protocol.
+- **Pool** — an ordered set of targets. Selection takes the first enabled one.
+- **Protocol** — a site: whether compute is scheduled there, and its queues.
+- **Profile** — how work runs: interpreter, and submit/status/logs/cancel.
+- **Project binding** — a local directory mapped to a target and a remote root,
+  so a bound directory needs no `--target`.
+- **Secret** — connection material, kept out of the inventory and out of git.
 
-## Core Ideas
+| path | holds |
+| --- | --- |
+| `~/.config/fleet/` | `targets.d/` `pools.d/` `protocols.d/` `profiles.d/` `secrets/` `config.toml` `projects.toml` |
+| `~/.local/state/fleet/` | private `known_hosts`, staged scripts |
+| `~/.cache/fleet/mux/` | SSH control sockets |
 
-- Targets are concrete machines.
-- Pools are logical groups that resolve to one target.
-- Protocols define site rules and host-class behavior such as direct execution
-  versus scheduler-backed submission and queue defaults.
-- Profiles define how remote commands run: direct SSH or scheduler-backed.
-- Targets may define a host-level `workdir`, which is the base directory where
-  projects land on that machine.
-- Project bindings attach a local repo path to a default target or pool plus
-  any exceptional project-specific absolute overrides.
-- By default, a bound project resolves to `workdir/<project-name>`. Record a
-  per-target root in the project binding only when that default path is wrong.
-- `fleetctl` owns SSH transport details directly, including a private
-  `known_hosts` file and multiplexed control sockets.
+`$FLEET_CONFIG_HOME`, `$FLEET_STATE_HOME` and `$FLEET_CACHE_HOME` move all
+three; `--config-home`, `--state-home` and `--cache-home` do it for one run.
 
-## Bootstrap
+An unknown key in any of those files is fatal, and the error names the file, the
+key and a likely correction — because the default that fills in for a
+misspelling is always the permissive one.
+
+## Roles decide what may be done
+
+Every target declares a `role`. A role is a taint, not a label: it repels work,
+and `--admin` is the toleration — permission, never a recommendation.
+
+```
+role         ssh   exec  script sync  submit job
+bridge       yes   admin no     admin no     no
+login        yes   admin admin  yes   yes    yes
+compute      yes   yes   yes    yes   yes    yes
+workstation  yes   yes   yes    yes   yes    no
+storage      yes   admin no     yes   no     no
+
+yes = allowed    admin = needs --admin    no = refused
+```
+
+`fleetctl help roles` prints that table, generated from the same constant the
+admission check reads, so the two cannot drift apart.
+
+There is deliberately no role meaning "scheduler node where direct execution is
+fine", so the state this tool exists to prevent cannot be spelled in the config
+at all. A refusal names the alternative — *run compute through `fleetctl
+submit`* — and no flag lifts it. `fleetctl explain <target>` reports every cell
+for one host, where a refusal is the answer rather than an error.
+
+Role and protocol must agree, checked at load: `role = "login"` on a protocol
+that runs work directly is refused, and so is any other role on a
+scheduler-backed one. A target with no `role` gets the conservative reading of
+its protocol, and `doctor` names it.
+
+## Reach: direct first, the bridge as fallback
+
+How a host is reached is inventory, not a credential.
+
+```toml
+# targets.d/rtx1.toml
+reach = ["direct", "via:numpi"]
+```
+
+Ordered, and the order is the point: direct is the route taken, the bridge is
+the declared fallback. Every `via:` must name an enabled target whose `role` is
+`bridge`; self-bridges and cycles are refused at load, once per fleet rather
+than once per dependent.
+
+A hop is a full fleetctl connection to the bridge — its own secret, and the same
+private `known_hosts`, `IdentitiesOnly`, timeouts and control socket the
+destination gets — so it inherits nothing from `~/.ssh/config`, and it chains.
+Using a bridge is transport, not execution, so it takes no admission check;
+`exec` on that same bridge is still refused. A password-authenticated bridge is
+refused as a hop, because sshpass hands one password to the whole process tree.
+
+`--route direct` or `--route via:<bridge>` pins a *declared* route; fleetctl
+will not invent one. `fleetctl list --format topology` prints the graph.
+
+Current limit: the first declared route is the one used — nothing degrades
+automatically yet — and both routes to one host share a control socket, because
+OpenSSH's `%C` does not hash the ProxyCommand.
+
+## Start
 
 ```bash
 fleetctl init
-fleetctl doctor
+fleetctl import-ssh <alias> --name <target> --role workstation
+fleetctl doctor            # must be clean before anything else
+fleetctl doctor --probe    # also checks remote python3, which exec needs
 ```
 
-That creates the base layout, a `protocols.d/` directory, a default
-`plain-ssh` profile, and a starter `slurm-batch` profile.
+`migrate-config` rewrites an older inventory in place: it fills in `role`, makes
+`protocol` explicit, and lifts a secret's `proxy_jump` into `reach` with
+`direct` in front of it.
 
-## Pass-Backed Deploy
-
-The recommended long-term model is:
-
-- public templates and behavior in the dotfiles repo
-- private fleet source data in `pass`
-- generated `~/.config/fleet/`
-
-Seed the current live fleet into `pass`:
+## Daily
 
 ```bash
+fleetctl smoke <target>                            # transport, then workdir
+fleetctl exec <target> -- python3 -c 'print(1)'    # after `--` is verbatim
+fleetctl script ./setup.sh --target <target> -- --flag value
+fleetctl sync push .                               # from a bound directory
+fleetctl submit train.sh --target <target> --queue <preset>
+fleetctl job status <id> --target <target>
+```
+
+`--dry-run` prints the fully resolved plan and exits 0, claiming nothing about
+remote state — except for `sync`, where it runs `rsync --dry-run
+--itemize-changes` and returns rsync's own code.
+
+`sync --delete` refuses a home or root directory outright, and refuses the
+target's own workdir, or any pull, without `--force`.
+
+`submit` wraps your script in a scheduler preamble built from the queue preset;
+`--native-batch` sends your file unchanged instead. Nothing is submitted unless
+a job id could be reported back.
+
+## Secrets
+
+`host`, `user`, `port`, `auth`, `identity_file`, `password` and the SSH tuning
+knobs live in a secret, never in a target file — putting one in a target is a
+refusal with that explanation. Three backends: a private TOML file, a `pass`
+entry, or an inline table. Resolution is lazy.
+
+```bash
+fleetctl show <target> --secret               # host and user both redacted
+fleetctl show <target> --secret --sensitive   # ask for the real values
 fleetctl seed-pass --pass-prefix infra/fleet
-```
-
-Rebuild the generated tree at any time:
-
-```bash
 fleetctl deploy-config --pass-prefix infra/fleet --doctor
 ```
 
-The usual dotfiles bootstrap now runs that deploy step automatically during
-`./setup.sh` whenever the `infra/fleet` pass prefix exists locally.
+`deploy-config` renders a fresh tree beside the live one, validates it, and only
+then swaps — keeping one previous generation, and never clearing `secrets/`
+unless every target is pass-backed and it can refill them. `./setup.sh` runs it
+when the `infra/fleet` pass prefix exists locally.
 
-When targets use `secret_backend = "pass"`, the generated fleet tree contains
-only references to pass entries such as `infra/fleet/secrets/ampere` rather than
-plaintext secret files.
+Files are written `0600` and directories `0700`; `doctor` treats a group- or
+world-readable secret as a problem, not a warning. Prefer keys — and above all
+on the bridge, which every other host is reached through.
 
-## Bringing Hosts In
+## Exit status
 
-### Import an existing SSH alias
+`0` success · `1` `doctor` found problems · `2` any refusal, and any usage error
+· `130` interrupted. Anything else is the remote command's own.
 
-```bash
-fleetctl import-ssh gpu-a --name gpu-a
-```
+## Shell integration
 
-This resolves the alias through `ssh -G`, writes a private target record under
-`~/.config/fleet/targets.d/`, and writes the sensitive connection material under
-`~/.config/fleet/secrets/`.
-
-### Migrate an env schema
-
-```bash
-fleetctl migrate-env --env-file ~/projects/repo-a/.env --prefix REPO_A_REMOTE
-```
-
-Use this when you need to move an existing env-based machine schema into the
-private fleet inventory. Host-level workdirs are stored on targets, and only
-non-standard project paths stay in the project binding.
-
-If legacy target files still carry project-specific `remote_root` entries or
-inline connection fields, `fleetctl doctor` warns so the stale shape does not
-quietly linger.
-
-## Project Binding
-
-Bind a project to a default machine or pool:
-
-```bash
-fleetctl project bind ~/projects/repo-a --pool gpu-pool --profile plain-ssh
-fleetctl project bind ~/projects/repo-a --pool gpu-pool \
-  --target-root ampere=/data/ayand/repo-a \
-  --target-root ada=/data/home/ayand/repo-a \
-  --target-root hopper=/raid/phyayan/repo-a
-fleetctl project show ~/projects/repo-a
-fleetctl project list
-```
-
-Once a binding exists, most commands can omit the target when run from inside
-that project.
-
-## Protocol Inspection
-
-Inspect a target before you assume it behaves like a plain SSH box:
-
-```bash
-fleetctl protocol show hopper
-fleetctl queue list hopper
-```
-
-Scheduler-backed protocols expose queue presets, runtime hints such as
-`job_runtime = "docker"`, and can require compute to flow through
-`fleetctl submit` instead of `fleetctl exec`. If a protocol reports
-`native_batch_required = true`, use `fleetctl submit --native-batch` so the
-site-native scheduler script is submitted unchanged.
-
-## Daily Workflow
-
-### Connectivity smoke test
-
-```bash
-fleetctl smoke gpu-a
-```
-
-When a target defines a `workdir`, `smoke` reports whether that host-level
-directory exists. When a bound project resolves to `workdir/<project-name>` or
-to an explicit per-target project root, `smoke` reports that project root
-separately instead of failing transport just because the repo has not been
-synced there yet.
-
-### Run a remote argv vector
-
-```bash
-fleetctl exec gpu-a -- python3 -m pytest tests/test_streaming.py
-fleetctl exec --target gpu-a -- python3 -m pytest tests/test_streaming.py
-```
-
-`exec` runs the payload through a remote Python stub and avoids shell
-interpolation of the user command itself. `--target` is available when you want
-to force an explicit target without using the positional selector.
-
-On scheduler-backed targets, direct login-surface execution requires an explicit
-acknowledgment:
-
-```bash
-fleetctl exec --login hopper -- squeue --me
-fleetctl exec --login volta -- sinfo -h -o '%P'
-```
-
-Use `--login` only for administrative commands on the submission surface. Do
-not use it as a substitute for proper job submission.
-
-### Upload and run a script
-
-```bash
-fleetctl script scripts/train.sh --target gpu-a -- --config configs/base.toml
-```
-
-### Sync a project
-
-```bash
-fleetctl sync push . --target gpu-a
-fleetctl sync pull remote-downloads/ --target gpu-a artifacts/
-```
-
-### Submit through a scheduler profile
-
-For direct targets, `submit` falls back to running the staged script directly.
-For scheduler-backed protocols, `submit` wraps a normal script in a Slurm job
-using the protocol's queue defaults:
-
-```bash
-fleetctl submit scripts/train.sh --target hopper
-fleetctl submit scripts/train.sh --target hopper --queue q_1day-2G
-fleetctl submit scripts/train.sh --target volta --time 00:10:00
-fleetctl job status 12345 --target hopper --profile slurm-batch
-fleetctl job logs 12345 --target hopper --profile slurm-batch
-fleetctl job cancel 12345 --target hopper --profile slurm-batch
-```
-
-When `submit` parses a Slurm job ID, it also reports the resolved stdout and
-stderr paths under the protocol's `job_output_dir`.
-
-When a site expects a fully native scheduler script, bypass the wrapper:
-
-```bash
-fleetctl submit scripts/site_native.slurm --target volta --native-batch
-```
-
-That stages the batch script and hands it to the scheduler unchanged.
-
-## Shell Integration
-
-`fssh` in Zsh now merges classic SSH host discovery with `fleetctl list --format
-ssh-hosts`. Selecting a `fleet:*` entry routes the session through `fleetctl ssh`
-instead of raw `ssh`.
-
-## Files You Will Actually Touch
-
-- `fleet/templates/` - public templates for generated fleet config
-- `~/.config/fleet/targets.d/*.toml` - generated target metadata
-- `~/.config/fleet/targets.d/*.toml` may include host-level `workdir`, but not
-  repo-specific absolute project paths or sensitive connection material
-- `~/.config/fleet/protocols.d/*.toml` - generated site rules and queue presets
-- `~/.config/fleet/profiles.d/*.toml` - generated execution profiles
-- `~/.config/fleet/projects.toml` - generated local path to remote defaults and any
-  exceptional per-target project-root overrides
-- `pass` entries under your chosen prefix - private fleet source data and
-  pass-backed connection secrets
-
-## Security Notes
-
-- Keep `~/.config/fleet/` private; `fleetctl doctor` checks file modes.
-- Prefer pass-backed secrets over plaintext `~/.config/fleet/secrets/*.toml`.
-- Prefer key auth. Keep password auth only as a temporary fallback.
-- Do not commit `~/.config/fleet/` into any repo.
-- Use `fleetctl show --secret <target>` for a redacted preview; add
-  `--sensitive` only when you explicitly need the real host details on screen.
+`fssh` in Zsh merges classic SSH host discovery with `fleetctl list --format
+ssh-hosts`; picking a `fleet:*` entry routes through `fleetctl ssh`.

--- a/docs/bin/fleetctl.md
+++ b/docs/bin/fleetctl.md
@@ -4,8 +4,8 @@ Run work on machines you do not all administer, through a private inventory,
 under one admission policy. One file of Python 3 and the standard library
 driving `ssh`, `scp` and `rsync` — no daemon, nothing installed on the remote.
 
-`fleetctl help` is the manual: `overview verbs roles reach config secrets jobs
-examples`. This page is the tour.
+`fleetctl help` is the manual: `overview verbs roles reach capabilities config
+secrets jobs examples`. This page is the tour.
 
 ## Why
 
@@ -29,7 +29,7 @@ accident.
 | path | holds |
 | --- | --- |
 | `~/.config/fleet/` | `targets.d/` `pools.d/` `protocols.d/` `profiles.d/` `secrets/` `config.toml` `projects.toml` |
-| `~/.local/state/fleet/` | private `known_hosts`, staged scripts |
+| `~/.local/state/fleet/` | private `known_hosts`, `routes.json`, `jobs.jsonl`, `audit.jsonl` |
 | `~/.cache/fleet/mux/` | SSH control sockets |
 
 `$FLEET_CONFIG_HOME`, `$FLEET_STATE_HOME` and `$FLEET_CACHE_HOME` move all
@@ -164,7 +164,8 @@ fleetctl exec <target> -- python3 -c 'print(1)'    # after `--` is verbatim
 fleetctl script ./setup.sh --target <target> -- --flag value
 fleetctl sync push .                               # from a bound directory
 fleetctl submit train.sh --target <target> --queue <preset>
-fleetctl job status <id> --target <target>
+fleetctl jobs                                      # what you have submitted
+fleetctl job status <id>                           # target from the ledger
 ```
 
 `--dry-run` prints the fully resolved plan and exits 0, claiming nothing about
@@ -181,6 +182,26 @@ multiplexed through a Raspberry Pi is bound by the compressor, not the link.
 `submit` wraps your script in a scheduler preamble built from the queue preset;
 `--native-batch` sends your file unchanged instead. Nothing is submitted unless
 a job id could be reported back.
+
+## What gets written down
+
+Every accepted submission appends one line to `$FLEET_STATE_HOME/jobs.jsonl`,
+after the job id has been printed — so recording a job can never be what loses
+one. `fleetctl jobs` lists them newest first, and `job status|logs|cancel` read
+them, so an id the ledger knows needs neither `--target` nor `--profile`. An
+explicit flag still wins; an id two targets both claim is refused rather than
+guessed.
+
+The nine subcommands that open a connection each append one line to
+`$FLEET_STATE_HOME/audit.jsonl`: time, subcommand, resolved target and role,
+route taken, the flag names you typed, and the exit code — refusals included,
+since a refused `exec` on a login node is the line most worth having. No flag
+value and nothing after `--` is recorded, because that is where a pasted token
+would be; you cannot replay a command from this file, and that is the point.
+
+Both are `0600` and keep their newest 2000 lines. Staged scripts under a
+profile's `remote_script_root` are collected after 14 days, by the same round
+trip that creates the next one.
 
 ## Secrets
 

--- a/docs/bin/fleetctl.md
+++ b/docs/bin/fleetctl.md
@@ -29,7 +29,7 @@ accident.
 | path | holds |
 | --- | --- |
 | `~/.config/fleet/` | `targets.d/` `pools.d/` `protocols.d/` `profiles.d/` `secrets/` `config.toml` `projects.toml` |
-| `~/.local/state/fleet/` | private `known_hosts`, `routes.json`, `jobs.jsonl`, `audit.jsonl` |
+| `~/.local/state/fleet/` | private `known_hosts`, `routes.json`, `jobs.jsonl`, `audit.jsonl`, probed `facts/` |
 | `~/.cache/fleet/mux/` | SSH control sockets |
 
 `$FLEET_CONFIG_HOME`, `$FLEET_STATE_HOME` and `$FLEET_CACHE_HOME` move all
@@ -144,6 +144,16 @@ takes the smallest sufficient candidate (fewest GPUs, then VRAM, CPUs, memory,
 then by name) and an ambiguous match without `--fit` is refused rather than
 guessed.
 
+Declared values are authoritative and nothing measured ever selects anything.
+`fleetctl probe <target>` records what a host reports — `nvidia-smi`, `lscpu`,
+`free`, `python3`, and `sinfo` for the queues at a scheduler site — into
+`<state-home>/facts/<target>.json` at `0600`, and the only thing that reads it
+is `doctor`, which reports the difference. Measuring short of a declaration is a
+problem, since a box with less than it promised accepts a job sized for the
+promise and then fails it; measuring over it is a warning that the declaration
+is stale. The machine being described is the one supplying the description, which
+is why it never gets a vote.
+
 On a Slurm site the hardware belongs to the partition, so a queue carries its
 own `[queue.capabilities]`. Those layer over the target's, `--require` filters
 the partitions, and `--fit` picks the smallest sufficient one. `--gpus` and
@@ -158,11 +168,15 @@ fleetctl import-ssh <alias> --name <target> --role workstation
 fleetctl doctor            # must be clean before anything else
 fleetctl doctor --probe    # also checks remote python3, which exec needs
                           # (a host out of reach is a warning, not a problem)
+fleetctl probe <target>    # measure one host; doctor then reports the drift
 ```
 
 `migrate-config` rewrites an older inventory in place: it fills in `role`, makes
-`protocol` explicit, and lifts a secret's `proxy_jump` into `reach` with
-`direct` in front of it.
+`protocol` explicit, lifts a secret's `proxy_jump` into `reach` with `direct` in
+front of it, and strips the keys nothing reads any more — `transport`,
+`ssh_host_alias`, `metadata`, `job_runtime` and a pool's `strategy`. Those stay
+*accepted* so an unmigrated inventory still loads, and `doctor` names every file
+still carrying one.
 
 ## Daily
 
@@ -175,6 +189,33 @@ fleetctl submit train.sh --target <target> --queue <preset>
 fleetctl jobs                                      # what you have submitted
 fleetctl job status <id>                           # target from the ledger
 ```
+
+One question, whole fleet:
+
+```bash
+fleetctl smoke --all --jobs 4
+fleetctl exec --tag gpu --jobs 4 -- nvidia-smi -L
+fleetctl job status <id> --all
+```
+
+Sequential without `--jobs`. Each host's output is prefixed with its name and
+held until every host has answered, then one line per target says `ok`,
+`failed`, `refused` or `plan`; exit is 2 if anything was refused, otherwise the
+first non-zero remote code by target name.
+
+Only `smoke`, `exec` and `job status` fan out. `sync`, `submit`, `script`,
+`ssh`, `probe` and `job logs|cancel` refuse by name and say why: they write, or
+they mean something different at each site, and partial failure across a fleet
+leaves a state nothing afterwards can report. A fanned-out `sbatch` is a
+fanned-out double submission.
+
+Concurrency is capped at four per reach-hop rather than globally — a bridge
+multiplexes every connection through one small machine, and ClusterShell's
+default fan-out of 64 is a number for a homogeneous LAN. A target that declares
+a `via:` fallback counts against that bridge even when direct is up; `--route
+direct --no-fallback` narrows the route list and gets the full `--jobs` back.
+Anything left out of the run — a disabled host, a cap, a target that would not
+resolve — is printed as a `note:` rather than passed over.
 
 `--dry-run` prints the fully resolved plan and exits 0, claiming nothing about
 remote state — except for `sync`, where it runs `rsync --dry-run
@@ -216,7 +257,14 @@ trip that creates the next one.
 `host`, `user`, `port`, `auth`, `identity_file`, `password` and the SSH tuning
 knobs live in a secret, never in a target file — putting one in a target is a
 refusal with that explanation. Three backends: a private TOML file, a `pass`
-entry, or an inline table. Resolution is lazy.
+entry, an inline table, or a command fleetctl runs. Resolution is lazy.
+
+`secret_backend = "command"` runs `secret_ref` and reads the same TOML off its
+stdout, merged over the target's inline `[secret]` table — for the field that
+will not hold still, such as a cloud box whose address changes on every start.
+Cached 30 seconds in memory only, never on disk. Its stdout is a secret: it is
+redacted like any other, and a failing upcall is a refusal naming the command
+and its stderr rather than a half-resolved connection.
 
 ```bash
 fleetctl show <target> --secret               # host and user both redacted

--- a/docs/bin/fleetctl.md
+++ b/docs/bin/fleetctl.md
@@ -136,6 +136,10 @@ remote state — except for `sync`, where it runs `rsync --dry-run
 `sync --delete` refuses a home or root directory outright, and refuses the
 target's own workdir, or any pull, without `--force`.
 
+`sync` compresses at level 1 rather than rsync's default 6, because a transfer
+multiplexed through a Raspberry Pi is bound by the compressor, not the link.
+`--compress-level 0` turns compression off for a fast local hop.
+
 `submit` wraps your script in a scheduler preamble built from the queue preset;
 `--native-batch` sends your file unchanged instead. Nothing is submitted unless
 a job id could be reported back.

--- a/docs/bin/fleetctl.md
+++ b/docs/bin/fleetctl.md
@@ -105,6 +105,44 @@ Once a master exists a failing command is a failing command — never retried,
 never re-routed. That is what keeps `exec` and `submit` at-most-once: a
 re-routed `sbatch` would queue the job twice.
 
+## Capabilities: ask for hardware, not for a hostname
+
+Declare what a machine has and let the tool choose:
+
+```toml
+# targets.d/rtx1.toml
+[capabilities]
+arch      = "x86_64"
+gpu_model = "RTX 3090"
+gpu_count = 1
+vram_gb   = 24
+cpus      = 16
+mem_gb    = 64
+```
+
+```
+fleetctl list --format capabilities                        # one row per surface
+fleetctl resolve --require 'vram_gb>=24' --fit             # smallest that fits
+fleetctl submit train.sh --require 'vram_gb>=40' --fit
+```
+
+Any key you like; `gpu_count`, `vram_gb`, `cpus` and `mem_gb` are compared as
+numbers. Operators: `>= <= > < = == !=`, comma-separated or repeated. An
+undeclared capability never satisfies a requirement.
+
+A requirement narrows a choice; it never moves work. Name a target — or let a
+project binding name one — and `--require` is a check that refuses with the
+mismatch. Give it a pool, or nothing at all, and it is a filter; `--fit` then
+takes the smallest sufficient candidate (fewest GPUs, then VRAM, CPUs, memory,
+then by name) and an ambiguous match without `--fit` is refused rather than
+guessed.
+
+On a Slurm site the hardware belongs to the partition, so a queue carries its
+own `[queue.capabilities]`. Those layer over the target's, `--require` filters
+the partitions, and `--fit` picks the smallest sufficient one. `--gpus` and
+`--cpus-per-task` are checked against the declared numbers before anything
+connects. `fleetctl help capabilities` has the rest.
+
 ## Start
 
 ```bash

--- a/docs/bin/fleetctl.md
+++ b/docs/bin/fleetctl.md
@@ -99,7 +99,14 @@ by trying each route in declared order until a master comes up. Direct gets 5
 seconds and a bridge 10, so preferring direct costs one timeout per
 `ControlPersist` window, and only when direct is down. Each route gets its own
 socket, since `%C` does not hash the ProxyCommand. `--no-fallback` refuses to
-degrade.
+degrade, and says so when it fails rather than telling you to declare the
+fallback you suppressed.
+
+A route that cannot be attempted counts as a route that did not come up — a
+wedged master that will not answer `ssh -O check`, a socket path over the length
+limit — so the next route still gets its turn. A `via:` route brings the
+bridge's own master up first, over the bridge's own `reach`, so a bridge with a
+fallback can use it.
 
 Once a master exists a failing command is a failing command — never retried,
 never re-routed. That is what keeps `exec` and `submit` at-most-once: a
@@ -150,6 +157,7 @@ fleetctl init
 fleetctl import-ssh <alias> --name <target> --role workstation
 fleetctl doctor            # must be clean before anything else
 fleetctl doctor --probe    # also checks remote python3, which exec needs
+                          # (a host out of reach is a warning, not a problem)
 ```
 
 `migrate-config` rewrites an older inventory in place: it fills in `role`, makes

--- a/docs/bin/fleetctl.md
+++ b/docs/bin/fleetctl.md
@@ -93,9 +93,17 @@ refused as a hop, because sshpass hands one password to the whole process tree.
 `--route direct` or `--route via:<bridge>` pins a *declared* route; fleetctl
 will not invent one. `fleetctl list --format topology` prints the graph.
 
-Current limit: the first declared route is the one used — nothing degrades
-automatically yet — and both routes to one host share a control socket, because
-OpenSSH's `%C` does not hash the ProxyCommand.
+Fallback is automatic, and happens once per control socket rather than once per
+command: a warm master means the route already works, and a cold one is filled
+by trying each route in declared order until a master comes up. Direct gets 5
+seconds and a bridge 10, so preferring direct costs one timeout per
+`ControlPersist` window, and only when direct is down. Each route gets its own
+socket, since `%C` does not hash the ProxyCommand. `--no-fallback` refuses to
+degrade.
+
+Once a master exists a failing command is a failing command — never retried,
+never re-routed. That is what keeps `exec` and `submit` at-most-once: a
+re-routed `sbatch` would queue the job twice.
 
 ## Start
 

--- a/emacs/lisp/bv-dired.el
+++ b/emacs/lisp/bv-dired.el
@@ -48,9 +48,28 @@
   (define-key dired-mode-map "q" 'kill-current-buffer)
   (add-hook 'dired-mode-hook 'dired-hide-details-mode))
 
+;;; Remote copy
+
+;; Deliberately not `-az --delete'.
+;;
+;; No `--delete': the destination is read with `dired-dwim-target-directory',
+;; which prefills the other dired window, and `dired-dwim-target' is t above.
+;; Accepting that prefill with `--delete' set erases everything in that
+;; directory that is not in the marked source, and `delete-by-moving-to-trash'
+;; is nil, so there is nothing to recover from. Mirror deliberately with
+;; `dired-rsync-transient' instead, which toggles flags per invocation.
+;;
+;; `-rlptD' rather than `-a': `-a' is `-rlptgoD', and `-o' silently does nothing
+;; unless the receiving rsync runs as root, which it does not here.
+;;
+;; `--compress-level=1' rather than bare `-z' (level 6): every clustered host is
+;; reachable through a Raspberry Pi bridge, where the compressor is the
+;; bottleneck and not the link. Matches what `fleetctl sync' uses.
 (with-eval-after-load 'dired-rsync
   (when (boundp 'dired-rsync-options)
-    (setq dired-rsync-options "-az --info=progress2 --delete")))
+    (setq dired-rsync-options
+          (concat "-rlptD -z --compress-level=1 --info=progress2"
+                  " -h --partial"))))
 
 (with-eval-after-load 'ls-lisp
   (when (boundp 'ls-lisp-use-insert-directory-program)

--- a/emacs/lisp/bv-tramp.el
+++ b/emacs/lisp/bv-tramp.el
@@ -254,8 +254,16 @@
 
 ;; Performance improvements
 (setq tramp-use-ssh-controlmaster-options t)
-(setq tramp-chunksize 500)
-(setq tramp-default-proxies-alist nil)
+
+;; `tramp-chunksize' is deliberately NOT set. It exists for ssh builds that
+;; lose data on large writes, and a non-nil value splits every inline transfer
+;; into chunks that small with a delay between them. It was 500 here, which
+;; throttled every remote save for a bug this fleet does not have. Set it again
+;; only if a transfer actually corrupts.
+
+;; Not `(setq tramp-default-proxies-alist nil)'. That was already the default,
+;; and writing it kept the one mechanism that reaches a bridge-only host from
+;; ever being set from elsewhere in this config.
 
 ;; Add TRAMP own remote path
 (add-to-list 'tramp-remote-path 'tramp-own-remote-path)

--- a/fleet/templates/config.toml
+++ b/fleet/templates/config.toml
@@ -1,8 +1,5 @@
 version = 1
 
-[defaults]
-redact_sensitive_output = true
-
 [ssh]
 user_known_hosts_file = "~/.local/state/fleet/known_hosts"
 strict_host_key_checking = "accept-new"

--- a/fleet/templates/profiles/plain-ssh.toml
+++ b/fleet/templates/profiles/plain-ssh.toml
@@ -1,6 +1,5 @@
 version = 1
 name = "plain-ssh"
-kind = "direct"
 
 [script]
 interpreter = "/usr/bin/env bash"

--- a/fleet/templates/profiles/slurm-batch.toml
+++ b/fleet/templates/profiles/slurm-batch.toml
@@ -1,6 +1,5 @@
 version = 1
 name = "slurm-batch"
-kind = "scheduler"
 job_id_pattern = "Submitted batch job (?P<job_id>\\d+)"
 submit_command = ["sbatch", "{script}"]
 status_command = ["squeue", "--jobs", "{job_id}"]


### PR DESCRIPTION
Summary:
- harden fleetctl sync, submit, configuration loading, routing, admission, and job tracking
- add dry runs, structured output, embedded help, capability selection, probing, fan-out, and safer route fallback
- refresh fleetctl documentation and operator guidance
- fix dired-rsync mirroring and compression behavior, and remove the global TRAMP chunk-size throttle

Validation:
- python3 -m py_compile bin/fleetctl
- ./bin/fleetctl --help
- ./bin/fleetctl help
- git diff --check upstream/master..HEAD

This PR contains the complete fleetctl hardening series plus the two Emacs remote-copy fixes.